### PR TITLE
Ch991 adapt code to use lucuma observe

### DIFF
--- a/modules/common-graphql/src/main/scala/observe/common/SequenceStepsGQL.scala
+++ b/modules/common-graphql/src/main/scala/observe/common/SequenceStepsGQL.scala
@@ -23,34 +23,32 @@ object SequenceStepsGQL {
   @GraphQL
   trait SequenceSteps extends GraphQLOperation[ObservationDB] {
     val document = """
-      query {
-        observations(programId: "p-2", first: 1) {
-          nodes {
-            id
-            name
-            config {
-              __typename
-              instrument
-              plannedTime {
-                total {
-                  microseconds
-                }
+      query($observationId: ObservationId!) {
+        observation(id: $observationId) {
+          id
+          name
+          config {
+            __typename
+            instrument
+            plannedTime {
+              total {
+                microseconds
               }
-              ... on GmosNorthConfig {
-                acquisitionN:acquisition {
-                  ...northSequenceFields
-                }
-                scienceN:science {
-                  ...northSequenceFields
-                }
+            }
+            ... on GmosNorthConfig {
+              acquisitionN:acquisition {
+                ...northSequenceFields
               }
-              ... on GmosSouthConfig {
-                acquisitionS: acquisition {
-                  ...southSequenceFields
-                }
-                scienceS:science {
-                  ...southSequenceFields
-                }
+              scienceN:science {
+                ...northSequenceFields
+              }
+            }
+            ... on GmosSouthConfig {
+              acquisitionS: acquisition {
+                ...southSequenceFields
+              }
+              scienceS:science {
+                ...southSequenceFields
               }
             }
           }
@@ -225,117 +223,115 @@ object SequenceStepsGQL {
     }
 
     object Data {
-      object Observations {
-        object Nodes {
-          object Config {
-            object GmosNorthConfig {
-              trait AcquisitionN extends Sequence[SeqSite.North]
-              object AcquisitionN {
-                trait Atoms extends SeqAtom[SeqSite.North]
-                object Atoms {
-                  trait Steps extends SeqStep[SeqSite.North]
-                  object Steps {
-                    // object StepType
-                    trait InstrumentConfig extends SeqInstrumentConfig[SeqSite.North]
-                    object InstrumentConfig {
-                      type Exposure = time.Duration
-                      trait Grating extends SeqGrating[SeqSite.North]
-                      object Grating {
-                        type Wavelength = math.Wavelength
-                      }
-                      trait Fpu extends SeqFpu[SeqSite.North]
-                      trait Readout extends SeqReadout
+      object Observation {
+        object Config {
+          object GmosNorthConfig {
+            trait AcquisitionN extends Sequence[SeqSite.North]
+            object AcquisitionN {
+              trait Atoms extends SeqAtom[SeqSite.North]
+              object Atoms {
+                trait Steps extends SeqStep[SeqSite.North]
+                object Steps {
+                  // object StepType
+                  trait InstrumentConfig extends SeqInstrumentConfig[SeqSite.North]
+                  object InstrumentConfig {
+                    type Exposure = time.Duration
+                    trait Grating extends SeqGrating[SeqSite.North]
+                    object Grating {
+                      type Wavelength = math.Wavelength
                     }
-                    trait StepConfig extends SeqStepConfig
-                    object StepConfig       {
-                      trait Science extends SeqStepConfig.SeqScienceStep
-                      object Science {
-                        type Offset = lucuma.core.math.Offset
-                      }
-                    }
+                    trait Fpu extends SeqFpu[SeqSite.North]
+                    trait Readout extends SeqReadout
                   }
-                }
-              }
-              trait ScienceN extends Sequence[SeqSite.North]
-              object ScienceN     {
-                trait Atoms extends SeqAtom[SeqSite.North]
-                object Atoms {
-                  trait Steps extends SeqStep[SeqSite.North]
-                  object Steps {
-                    // object StepType
-                    trait InstrumentConfig extends SeqInstrumentConfig[SeqSite.North]
-                    object InstrumentConfig {
-                      type Exposure = time.Duration
-                      trait Grating extends SeqGrating[SeqSite.North]
-                      object Grating {
-                        type Wavelength = math.Wavelength
-                      }
-                      trait Fpu extends SeqFpu[SeqSite.North]
-                      trait Readout extends SeqReadout
-                    }
-                    trait StepConfig extends SeqStepConfig
-                    object StepConfig       {
-                      trait Science extends SeqStepConfig.SeqScienceStep
-                      object Science {
-                        type Offset = lucuma.core.math.Offset
-                      }
+                  trait StepConfig extends SeqStepConfig
+                  object StepConfig       {
+                    trait Science extends SeqStepConfig.SeqScienceStep
+                    object Science {
+                      type Offset = lucuma.core.math.Offset
                     }
                   }
                 }
               }
             }
-
-            object GmosSouthConfig {
-              trait AcquisitionS extends Sequence[SeqSite.South]
-              object AcquisitionS {
-                trait Atoms extends SeqAtom[SeqSite.South]
-                object Atoms {
-                  trait Steps extends SeqStep[SeqSite.South]
-                  object Steps {
-                    // object StepType
-                    trait InstrumentConfig extends SeqInstrumentConfig[SeqSite.South]
-                    object InstrumentConfig {
-                      type Exposure = time.Duration
-                      trait Grating extends SeqGrating[SeqSite.South]
-                      object Grating {
-                        type Wavelength = math.Wavelength
-                      }
-                      trait Fpu extends SeqFpu[SeqSite.South]
-                      trait Readout extends SeqReadout
+            trait ScienceN extends Sequence[SeqSite.North]
+            object ScienceN     {
+              trait Atoms extends SeqAtom[SeqSite.North]
+              object Atoms {
+                trait Steps extends SeqStep[SeqSite.North]
+                object Steps {
+                  // object StepType
+                  trait InstrumentConfig extends SeqInstrumentConfig[SeqSite.North]
+                  object InstrumentConfig {
+                    type Exposure = time.Duration
+                    trait Grating extends SeqGrating[SeqSite.North]
+                    object Grating {
+                      type Wavelength = math.Wavelength
                     }
-                    trait StepConfig extends SeqStepConfig
-                    object StepConfig       {
-                      trait Science extends SeqStepConfig.SeqScienceStep
-                      object Science {
-                        type Offset = lucuma.core.math.Offset
-                      }
+                    trait Fpu extends SeqFpu[SeqSite.North]
+                    trait Readout extends SeqReadout
+                  }
+                  trait StepConfig extends SeqStepConfig
+                  object StepConfig       {
+                    trait Science extends SeqStepConfig.SeqScienceStep
+                    object Science {
+                      type Offset = lucuma.core.math.Offset
                     }
                   }
                 }
               }
-              trait ScienceS extends Sequence[SeqSite.South]
-              object ScienceS     {
-                trait Atoms extends SeqAtom[SeqSite.South]
-                object Atoms {
-                  trait Steps extends SeqStep[SeqSite.South]
-                  object Steps {
-                    // object StepType
-                    trait InstrumentConfig extends SeqInstrumentConfig[SeqSite.South]
-                    object InstrumentConfig {
-                      type Exposure = time.Duration
-                      trait Grating extends SeqGrating[SeqSite.South]
-                      object Grating {
-                        type Wavelength = math.Wavelength
-                      }
-                      trait Fpu extends SeqFpu[SeqSite.South]
-                      trait Readout extends SeqReadout
+            }
+          }
+
+          object GmosSouthConfig {
+            trait AcquisitionS extends Sequence[SeqSite.South]
+            object AcquisitionS {
+              trait Atoms extends SeqAtom[SeqSite.South]
+              object Atoms {
+                trait Steps extends SeqStep[SeqSite.South]
+                object Steps {
+                  // object StepType
+                  trait InstrumentConfig extends SeqInstrumentConfig[SeqSite.South]
+                  object InstrumentConfig {
+                    type Exposure = time.Duration
+                    trait Grating extends SeqGrating[SeqSite.South]
+                    object Grating {
+                      type Wavelength = math.Wavelength
                     }
-                    trait StepConfig extends SeqStepConfig
-                    object StepConfig       {
-                      trait Science extends SeqStepConfig.SeqScienceStep
-                      object Science {
-                        type Offset = lucuma.core.math.Offset
-                      }
+                    trait Fpu extends SeqFpu[SeqSite.South]
+                    trait Readout extends SeqReadout
+                  }
+                  trait StepConfig extends SeqStepConfig
+                  object StepConfig       {
+                    trait Science extends SeqStepConfig.SeqScienceStep
+                    object Science {
+                      type Offset = lucuma.core.math.Offset
+                    }
+                  }
+                }
+              }
+            }
+            trait ScienceS extends Sequence[SeqSite.South]
+            object ScienceS     {
+              trait Atoms extends SeqAtom[SeqSite.South]
+              object Atoms {
+                trait Steps extends SeqStep[SeqSite.South]
+                object Steps {
+                  // object StepType
+                  trait InstrumentConfig extends SeqInstrumentConfig[SeqSite.South]
+                  object InstrumentConfig {
+                    type Exposure = time.Duration
+                    trait Grating extends SeqGrating[SeqSite.South]
+                    object Grating {
+                      type Wavelength = math.Wavelength
+                    }
+                    trait Fpu extends SeqFpu[SeqSite.South]
+                    trait Readout extends SeqReadout
+                  }
+                  trait StepConfig extends SeqStepConfig
+                  object StepConfig       {
+                    trait Science extends SeqStepConfig.SeqScienceStep
+                    object Science {
+                      type Offset = lucuma.core.math.Offset
                     }
                   }
                 }

--- a/modules/engine/src/main/scala/observe/engine/Engine.scala
+++ b/modules/engine/src/main/scala/observe/engine/Engine.scala
@@ -344,22 +344,22 @@ class Engine[F[_]: MonadError[*[_], Throwable]: Logger, S, U](stateL: Engine.Sta
 
   private def handleUserEvent(ue: UserEventType): HandleType[ResultType] = ue match {
     case Start(id, _, _)            =>
-      debug(s"Engine: Start requested for sequence ${id.format}") *> start(id) *> pure(
+      debug(s"Engine: Start requested for sequence $id") *> start(id) *> pure(
         UserCommandResponse(ue, Outcome.Ok, None)
       )
     case Pause(id, _)               =>
-      debug(s"Engine: Pause requested for sequence ${id.format}") *> pause(id) *> pure(
+      debug(s"Engine: Pause requested for sequence $id") *> pause(id) *> pure(
         UserCommandResponse(ue, Outcome.Ok, None)
       )
     case CancelPause(id, _)         =>
-      debug(s"Engine: Pause canceled for sequence ${id.format}") *> cancelPause(id) *> pure(
+      debug(s"Engine: Pause canceled for sequence $id") *> cancelPause(id) *> pure(
         UserCommandResponse(ue, Outcome.Ok, None)
       )
     case Breakpoint(id, _, step, v) =>
-      debug(s"Engine: breakpoint changed for sequence ${id.format} and step $step to $v") *>
+      debug(s"Engine: breakpoint changed for sequence $id and step $step to $v") *>
         modifyS(id)(_.setBreakpoint(step, v)) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
     case SkipMark(id, _, step, v)   =>
-      debug(s"Engine: skip mark changed for sequence ${id.format} and step $step to $v") *>
+      debug(s"Engine: skip mark changed for sequence $id and step $step to $v") *>
         modifyS(id)(_.setSkipMark(step, v)) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
     case Poll(_)                    =>
       debug("Engine: Polling current state") *> pure(UserCommandResponse(ue, Outcome.Ok, None))
@@ -383,26 +383,20 @@ class Engine[F[_]: MonadError[*[_], Throwable]: Logger, S, U](stateL: Engine.Sta
     se:          SystemEvent[F]
   )(implicit ci: Concurrent[F]): HandleType[ResultType] = se match {
     case Completed(id, _, i, r)     =>
-      debug(s"Engine: From sequence ${id.format}: Action completed ($r)") *> complete(id, i, r) *>
+      debug(s"Engine: From sequence $id: Action completed ($r)") *> complete(id, i, r) *>
         pure(SystemUpdate(se, Outcome.Ok))
     case StopCompleted(id, _, i, r) =>
-      debug(s"Engine: From sequence ${id.format}: Action completed with stop ($r)") *> stopComplete(
+      debug(s"Engine: From sequence $id: Action completed with stop ($r)") *> stopComplete(
         id,
         i,
         r
       ) *>
         pure(SystemUpdate(se, Outcome.Ok))
     case Aborted(id, _, i, r)       =>
-      debug(s"Engine: From sequence ${id.format}: Action completed with abort ($r)") *> abort(id,
-                                                                                              i,
-                                                                                              r
-      ) *>
+      debug(s"Engine: From sequence $id: Action completed with abort ($r)") *> abort(id, i, r) *>
         pure(SystemUpdate(se, Outcome.Ok))
     case PartialResult(id, _, i, r) =>
-      debug(s"Engine: From sequence ${id.format}: Partial result ($r)") *> partialResult(id,
-                                                                                         i,
-                                                                                         r
-      ) *>
+      debug(s"Engine: From sequence $id: Partial result ($r)") *> partialResult(id, i, r) *>
         pure(SystemUpdate(se, Outcome.Ok))
     case Paused(id, i, r)           =>
       debug("Engine: Action paused") *>
@@ -412,7 +406,7 @@ class Engine[F[_]: MonadError[*[_], Throwable]: Logger, S, U](stateL: Engine.Sta
         pure(SystemUpdate(se, Outcome.Ok))
     case Busy(id, _)                =>
       warning(
-        s"Cannot run sequence ${id.format} " +
+        s"Cannot run sequence $id " +
           s"because " +
           s"required systems are in use."
       ) *> pure(SystemUpdate(se, Outcome.Ok))

--- a/modules/engine/src/main/scala/observe/engine/Sequence.scala
+++ b/modules/engine/src/main/scala/observe/engine/Sequence.scala
@@ -8,9 +8,9 @@ import monocle.Lens
 import monocle.macros.GenLens
 import observe.engine.Action.ActionState
 import observe.engine.Result.RetVal
-import observe.model.Observation
 import observe.model.SequenceState
-import observe.model.StepId
+import lucuma.core.model.Observation
+import lucuma.core.model.Step.{ Id => StepId }
 
 /**
  * A list of `Step`s grouped by target and instrument.
@@ -108,11 +108,7 @@ object Sequence {
      * completed `Step`s or pending `Step`s.
      */
     val toSequence: Sequence[F] =
-      Sequence(
-        id,
-        // TODO: Functor composition?
-        done ++ List(focus.toStep) ++ pending
-      )
+      Sequence(id, done ++ List(focus.toStep) ++ pending)
   }
 
   object Zipper {

--- a/modules/engine/src/main/scala/observe/engine/Step.scala
+++ b/modules/engine/src/main/scala/observe/engine/Step.scala
@@ -81,7 +81,7 @@ object Step {
    * Step Zipper. This structure is optimized for the actual `Step` execution.
    */
   final case class Zipper[F[_]](
-    id:         Int,
+    id:         StepId,
     breakpoint: BreakpointMark,
     skipMark:   SkipMark,
     pending:    List[ParallelActions[F]],

--- a/modules/engine/src/test/scala/observe/engine/EngineSpec.scala
+++ b/modules/engine/src/test/scala/observe/engine/EngineSpec.scala
@@ -6,22 +6,22 @@ package observe.engine
 import cats.Eq
 import cats.effect.IO
 import observe.model.Observation
-import observe.model.arb.ArbObservationId
 import monocle.law.discipline.OptionalTests
 import org.scalacheck.{ Arbitrary, Cogen }
 import org.scalacheck.Arbitrary._
 import observe.engine.TestUtil.TestState
 import observe.model.ObserveModelArbitraries._
 import observe.model.SequenceState
+import lucuma.core.util.arb.ArbGid._
 
 final class EngineSpec extends munit.DisciplineSuite {
-  import ArbObservationId._
+
   implicit val seqstateEq: Eq[Sequence.State[IO]] = Eq.fromUniversalEquals
   implicit val execstateEq: Eq[TestState]         = Eq.by(x => x.sequences)
 
   implicit val sequenceArb: Arbitrary[Sequence[IO]] = Arbitrary {
     for {
-      id <- arbitrary[Observation.Id](ArbObservationId.arbObservationId)
+      id <- arbitrary[Observation.Id]
     } yield Sequence(id, List())
   }
 

--- a/modules/engine/src/test/scala/observe/engine/StepSpec.scala
+++ b/modules/engine/src/test/scala/observe/engine/StepSpec.scala
@@ -9,7 +9,6 @@ import cats.implicits._
 import munit.CatsEffectSuite
 import cats.effect.std.Queue
 import fs2.Stream
-import observe.model.Observation
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import java.util.UUID
@@ -21,6 +20,7 @@ import observe.model.enum.Instrument.GmosS
 import observe.model.{ ClientId, SequenceState, StepState }
 import observe.model.enum.Resource
 import observe.model.{ ActionType, UserDetails }
+import observe.common.test._
 import scala.Function.const
 import scala.concurrent.duration._
 import cats.effect.Ref
@@ -29,7 +29,7 @@ class StepSpec extends CatsEffectSuite {
 
   private implicit def L: Logger[IO] = Slf4jLogger.getLoggerFromName[IO]("observe")
 
-  private val seqId = Observation.Id.unsafeFromString("GS-2017B-Q-1-1")
+  private val seqId = observationId(1)
   private val user  = UserDetails("telops", "Telops")
 
   private val executionEngine = new Engine[IO, TestState, Unit](TestState)
@@ -59,7 +59,7 @@ class StepSpec extends CatsEffectSuite {
     }
 
     Step.Zipper(
-      id = 1,
+      id = stepId(1),
       breakpoint = Step.BreakpointMark(false),
       skipMark = Step.SkipMark(false),
       pending = pending,
@@ -209,7 +209,7 @@ class StepSpec extends CatsEffectSuite {
                id = seqId,
                steps = List(
                  Step.init(
-                   id = 1,
+                   id = stepId(1),
                    executions = List(
                      NonEmptyList.of(configureTcs, configureInst, triggerPause(q)), // Execution
                      NonEmptyList.one(observe)                                      // Execution
@@ -259,10 +259,10 @@ class StepSpec extends CatsEffectSuite {
           (seqId,
            Sequence.State.Zipper(
              Sequence.Zipper(
-               id = Observation.Id.unsafeFromString("GS-2018A-Q-3-1"),
+               id = observationId(1),
                pending = Nil,
                focus = Step.Zipper(
-                 id = 2,
+                 id = stepId(2),
                  breakpoint = Step.BreakpointMark(false),
                  skipMark = Step.SkipMark(false),
                  pending = Nil,
@@ -307,10 +307,10 @@ class StepSpec extends CatsEffectSuite {
           (seqId,
            Sequence.State.Zipper(
              Sequence.Zipper(
-               id = Observation.Id.unsafeFromString("GN-2017A-Q-7-1"),
+               id = observationId(1),
                pending = Nil,
                focus = Step.Zipper(
-                 id = 2,
+                 id = stepId(2),
                  breakpoint = Step.BreakpointMark(false),
                  skipMark = Step.SkipMark(false),
                  pending = Nil,
@@ -355,7 +355,7 @@ class StepSpec extends CatsEffectSuite {
                id = seqId,
                steps = List(
                  Step.init(
-                   id = 1,
+                   id = stepId(1),
                    executions = List(
                      NonEmptyList.of(configureTcs, configureInst), // Execution
                      NonEmptyList.one(observe)                     // Execution
@@ -401,7 +401,7 @@ class StepSpec extends CatsEffectSuite {
                id = seqId,
                steps = List(
                  Step.init(
-                   id = 1,
+                   id = stepId(1),
                    executions = List(
                      NonEmptyList.of(configureTcs, configureInst), // Execution
                      NonEmptyList.one(triggerStart(q)),            // Execution
@@ -457,7 +457,7 @@ class StepSpec extends CatsEffectSuite {
                id = seqId,
                steps = List(
                  Step.init(
-                   id = 1,
+                   id = stepId(1),
                    executions = List(
                      NonEmptyList.of(configureTcs, configureInst), // Execution
                      NonEmptyList.one(error(errMsg)),
@@ -501,16 +501,15 @@ class StepSpec extends CatsEffectSuite {
         sequences = Map(
           (seqId,
            Sequence.State.init(
-             Sequence(
-               id = seqId,
-               steps = List(
-                 Step.init(
-                   id = 1,
-                   executions = List(
-                     NonEmptyList.one(action)
-                   )
-                 )
-               )
+             Sequence(id = seqId,
+                      steps = List(
+                        Step.init(
+                          id = stepId(1),
+                          executions = List(
+                            NonEmptyList.one(action)
+                          )
+                        )
+                      )
              )
            )
           )
@@ -534,16 +533,15 @@ class StepSpec extends CatsEffectSuite {
         sequences = Map(
           (seqId,
            Sequence.State.init(
-             Sequence(
-               id = seqId,
-               steps = List(
-                 Step.init(
-                   id = 1,
-                   executions = List(
-                     NonEmptyList.one(aborted)
-                   )
-                 )
-               )
+             Sequence(id = seqId,
+                      steps = List(
+                        Step.init(
+                          id = stepId(1),
+                          executions = List(
+                            NonEmptyList.one(aborted)
+                          )
+                        )
+                      )
              )
            )
           )
@@ -567,16 +565,15 @@ class StepSpec extends CatsEffectSuite {
         sequences = Map(
           (seqId,
            Sequence.State.init(
-             Sequence(
-               id = seqId,
-               steps = List(
-                 Step.init(
-                   id = 1,
-                   executions = List(
-                     NonEmptyList.one(errorSet2(errMsg))
-                   )
-                 )
-               )
+             Sequence(id = seqId,
+                      steps = List(
+                        Step.init(
+                          id = stepId(1),
+                          executions = List(
+                            NonEmptyList.one(errorSet2(errMsg))
+                          )
+                        )
+                      )
              )
            )
           )
@@ -601,16 +598,15 @@ class StepSpec extends CatsEffectSuite {
         sequences = Map(
           (seqId,
            Sequence.State.init(
-             Sequence(
-               id = seqId,
-               steps = List(
-                 Step.init(
-                   id = 1,
-                   executions = List(
-                     NonEmptyList.one(fatalError(errMsg))
-                   )
-                 )
-               )
+             Sequence(id = seqId,
+                      steps = List(
+                        Step.init(
+                          id = stepId(1),
+                          executions = List(
+                            NonEmptyList.one(fatalError(errMsg))
+                          )
+                        )
+                      )
              )
            )
           )
@@ -636,7 +632,7 @@ class StepSpec extends CatsEffectSuite {
                id = seqId,
                steps = List(
                  Step.init(
-                   id = 1,
+                   id = stepId(1),
                    executions = List(
                      NonEmptyList.one(
                        Action(
@@ -708,13 +704,13 @@ class StepSpec extends CatsEffectSuite {
     assert(stepzar1.next.nonEmpty)
   }
 
-  val step0: Step[IO] = Step.init(1, Nil)
-  val step1: Step[IO] = Step.init(1, List(NonEmptyList.one(action)))
+  val step0: Step[IO] = Step.init(stepId(1), Nil)
+  val step1: Step[IO] = Step.init(stepId(1), List(NonEmptyList.one(action)))
   val step2: Step[IO] =
-    Step.init(2, List(NonEmptyList.of(action, action), NonEmptyList.one(action)))
+    Step.init(stepId(2), List(NonEmptyList.of(action, action), NonEmptyList.one(action)))
 
   test("currentify should be None only when a Step is empty of executions") {
-    assert(Step.Zipper.currentify(Step.init(0, Nil)).isEmpty)
+    assert(Step.Zipper.currentify(Step.init(stepId(1), Nil)).isEmpty)
     assert(Step.Zipper.currentify(step0).isEmpty)
     assert(Step.Zipper.currentify(step1).nonEmpty)
     assert(Step.Zipper.currentify(step2).nonEmpty)
@@ -728,7 +724,7 @@ class StepSpec extends CatsEffectSuite {
     assert(
       Step
         .Zipper(
-          id = 1,
+          id = stepId(1),
           breakpoint = Step.BreakpointMark(false),
           skipMark = Step.SkipMark(false),
           pending = Nil,
@@ -745,7 +741,7 @@ class StepSpec extends CatsEffectSuite {
     assert(
       Step
         .Zipper(
-          id = 1,
+          id = stepId(1),
           breakpoint = Step.BreakpointMark(false),
           skipMark = Step.SkipMark(false),
           pending = Nil,
@@ -762,7 +758,7 @@ class StepSpec extends CatsEffectSuite {
     assert(
       Step
         .Zipper(
-          id = 1,
+          id = stepId(1),
           breakpoint = Step.BreakpointMark(false),
           skipMark = Step.SkipMark(false),
           pending = Nil,
@@ -779,7 +775,7 @@ class StepSpec extends CatsEffectSuite {
     assert(
       Step
         .Zipper(
-          id = 1,
+          id = stepId(1),
           breakpoint = Step.BreakpointMark(false),
           skipMark = Step.SkipMark(false),
           pending = Nil,
@@ -796,7 +792,7 @@ class StepSpec extends CatsEffectSuite {
     assert(
       Step
         .Zipper(
-          id = 1,
+          id = stepId(1),
           breakpoint = Step.BreakpointMark(false),
           skipMark = Step.SkipMark(false),
           pending = Nil,

--- a/modules/engine/src/test/scala/observe/engine/packageSpec.scala
+++ b/modules/engine/src/test/scala/observe/engine/packageSpec.scala
@@ -26,6 +26,7 @@ import observe.engine.TestUtil.TestState
 import scala.concurrent.duration._
 import org.scalatest.flatspec.AnyFlatSpec
 import cats.effect.std.Semaphore
+import eu.timepit.refined.types.numeric.PosLong
 
 class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
@@ -71,24 +72,24 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
   val executions: List[ParallelActions[IO]] =
     List(NonEmptyList.of(configureTcs, configureInst), NonEmptyList.one(observe))
 
-  val seqId: Observation.Id = Observation.Id.unsafeFromString("GS-2019A-Q-0-1")
+  val seqId: Observation.Id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(1))
   val qs1: TestState        =
     TestState(
       sequences = Map(
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-2"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(2)),
              steps = List(
                Step.init(
-                 id = 1,
+                 id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
                  executions = List(
                    NonEmptyList.of(configureTcs, configureInst), // Execution
                    NonEmptyList.one(observe)                     // Execution
                  )
                ),
                Step.init(
-                 id = 2,
+                 id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(2)),
                  executions = executions
                )
              )
@@ -149,10 +150,10 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
       Map(
         seqId -> Sequence.State.init(
           Sequence(
-            id = Observation.Id.unsafeFromString("GS-2018B-Q-0-1"),
+            id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(1)),
             steps = List(
               Step.init(
-                id = 1,
+                id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
                 executions = List(
                   NonEmptyList.one(
                     fromF[IO](ActionType.Undefined,
@@ -222,10 +223,10 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
           Map(
             seqId -> Sequence.State.init(
               Sequence(
-                id = Observation.Id.unsafeFromString("GS-2018B-Q-0-2"),
+                id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(2)),
                 steps = List(
                   Step.init(
-                    id = 1,
+                    id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
                     executions = List(
                       NonEmptyList.one(
                         fromF[IO](ActionType.Configure(TCS),
@@ -271,10 +272,10 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-4"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(4)),
              steps = List(
                Step.init(
-                 id = 1,
+                 id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
                  executions = List(
                    NonEmptyList.one(
                      fromF[IO](ActionType.Undefined,
@@ -303,11 +304,19 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-6"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(6)),
              steps = List(
-               Step.init(id = 1, executions = executions).copy(skipMark = Step.SkipMark(true)),
-               Step.init(id = 2, executions = executions),
-               Step.init(id = 3, executions = executions)
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
+                       executions = executions
+                 )
+                 .copy(skipMark = Step.SkipMark(true)),
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(2)),
+                         executions = executions
+               ),
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(3)),
+                         executions = executions
+               )
              )
            )
          )
@@ -328,11 +337,19 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-7"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(7)),
              steps = List(
-               Step.init(id = 1, executions = executions),
-               Step.init(id = 2, executions = executions).copy(skipMark = Step.SkipMark(true)),
-               Step.init(id = 3, executions = executions)
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
+                         executions = executions
+               ),
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(2)),
+                       executions = executions
+                 )
+                 .copy(skipMark = Step.SkipMark(true)),
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(3)),
+                         executions = executions
+               )
              )
            )
          )
@@ -353,13 +370,29 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-8"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(8)),
              steps = List(
-               Step.init(id = 1, executions = executions),
-               Step.init(id = 2, executions = executions).copy(skipMark = Step.SkipMark(true)),
-               Step.init(id = 3, executions = executions).copy(skipMark = Step.SkipMark(true)),
-               Step.init(id = 4, executions = executions).copy(skipMark = Step.SkipMark(true)),
-               Step.init(id = 5, executions = executions)
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
+                         executions = executions
+               ),
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(2)),
+                       executions = executions
+                 )
+                 .copy(skipMark = Step.SkipMark(true)),
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(3)),
+                       executions = executions
+                 )
+                 .copy(skipMark = Step.SkipMark(true)),
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(4)),
+                       executions = executions
+                 )
+                 .copy(skipMark = Step.SkipMark(true)),
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(5)),
+                         executions = executions
+               )
              )
            )
          )
@@ -387,11 +420,19 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-9"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(1)),
              steps = List(
-               Step.init(id = 1, executions = executions),
-               Step.init(id = 2, executions = executions),
-               Step.init(id = 3, executions = executions).copy(skipMark = Step.SkipMark(true))
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
+                         executions = executions
+               ),
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(2)),
+                         executions = executions
+               ),
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(3)),
+                       executions = executions
+                 )
+                 .copy(skipMark = Step.SkipMark(true))
              )
            )
          )
@@ -414,9 +455,13 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-10"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(1)),
              steps = List(
-               Step.init(id = 1, executions = executions).copy(skipMark = Step.SkipMark(true))
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
+                       executions = executions
+                 )
+                 .copy(skipMark = Step.SkipMark(true))
              )
            )
          )
@@ -437,13 +482,21 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-11"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(1)),
              steps = List(
-               Step.init(id = 1, executions = executions).copy(skipMark = Step.SkipMark(true)),
                Step
-                 .init(id = 2, executions = executions)
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
+                       executions = executions
+                 )
+                 .copy(skipMark = Step.SkipMark(true)),
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(2)),
+                       executions = executions
+                 )
                  .copy(skipMark = Step.SkipMark(true), breakpoint = Step.BreakpointMark(true)),
-               Step.init(id = 3, executions = executions)
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(3)),
+                         executions = executions
+               )
              )
            )
          )
@@ -464,14 +517,22 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             Observation.Id.unsafeFromString("GS-2019A-Q-3"),
+             lucuma.core.model.Observation.Id(PosLong.unsafeFrom(1)),
              steps = List(
-               Step.init(id = 1, executions = executions).copy(skipped = Step.Skipped(true)),
                Step
-                 .init(id = 2, executions = executions)
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
+                       executions = executions
+                 )
+                 .copy(skipped = Step.Skipped(true)),
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(2)),
+                       executions = executions
+                 )
                  .copy(skipMark = Step.SkipMark(true), breakpoint = Step.BreakpointMark(true)),
                Step
-                 .init(id = 2, executions = executions)
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(3)),
+                       executions = executions
+                 )
                  .copy(skipMark = Step.SkipMark(true), breakpoint = Step.BreakpointMark(true))
              )
            )
@@ -493,14 +554,24 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-12"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(1)),
              steps = List(
-               Step.init(id = 1, executions = executions),
-               Step.init(id = 2, executions = executions).copy(skipMark = Step.SkipMark(true)),
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
+                         executions = executions
+               ),
                Step
-                 .init(id = 3, executions = executions)
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(2)),
+                       executions = executions
+                 )
+                 .copy(skipMark = Step.SkipMark(true)),
+               Step
+                 .init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(3)),
+                       executions = executions
+                 )
                  .copy(skipMark = Step.SkipMark(true), breakpoint = Step.BreakpointMark(true)),
-               Step.init(id = 4, executions = executions)
+               Step.init(id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(4)),
+                         executions = executions
+               )
              )
            )
          )
@@ -518,7 +589,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
   it should "run single Action" in {
     val dummy         = new AtomicInteger(0)
     val markVal       = 1
-    val stepId        = 1
+    val stepId        = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1))
     val s0: TestState = TestState(
       Map(
         (seqId,
@@ -575,10 +646,10 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
         (seqId,
          Sequence.State.init(
            Sequence(
-             id = Observation.Id.unsafeFromString("GS-2018B-Q-0-2"),
+             id = lucuma.core.model.Observation.Id(PosLong.unsafeFrom(1)),
              steps = List(
                Step.init(
-                 id = 1,
+                 id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(1)),
                  executions = List(
                    NonEmptyList.one(
                      Action[IO](ActionType.Undefined,
@@ -589,15 +660,15 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
                  )
                ),
                Step.init(
-                 id = 2,
+                 id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(2)),
                  executions = executions
                ),
                Step.init(
-                 id = 3,
+                 id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(3)),
                  executions = executions
                ),
                Step.init(
-                 id = 4,
+                 id = lucuma.core.model.Step.Id(PosLong.unsafeFrom(4)),
                  executions = executions
                )
              )
@@ -609,7 +680,7 @@ class packageSpec extends AnyFlatSpec with NonImplicitAssertions {
 
   it should "be able to start sequence from arbitrary step" in {
     val event = Event.modifyState[IO, TestState, Unit](
-      executionEngine.startFrom(seqId, 3).void
+      executionEngine.startFrom(seqId, lucuma.core.model.Step.Id(PosLong.unsafeFrom(3))).void
     )
 
     val sf = executionEngine

--- a/modules/model/shared/src/main/scala/observe/model/Notification.scala
+++ b/modules/model/shared/src/main/scala/observe/model/Notification.scala
@@ -22,18 +22,19 @@ object Notification {
     }
 
   // Notification that user tried to run a sequence that used resource already in use
-  final case class ResourceConflict(sid: Observation.Id) extends Notification
+  final case class ResourceConflict(sidName: Observation.IdName) extends Notification
   object ResourceConflict {
     implicit lazy val eq: Eq[ResourceConflict] =
-      Eq.by(_.sid)
+      Eq.by(_.sidName)
   }
 
   // Notification that user tried to select a sequence for an instrument for which a sequence was already running
-  final case class InstrumentInUse(sid: Observation.Id, ins: Instrument) extends Notification
+  final case class InstrumentInUse(sidName: Observation.IdName, ins: Instrument)
+      extends Notification
 
   object InstrumentInUse {
     implicit lazy val eq: Eq[InstrumentInUse] =
-      Eq.by(x => (x.sid, x.ins))
+      Eq.by(x => (x.sidName, x.ins))
   }
 
   // Notification that a request to the backend failed
@@ -45,11 +46,11 @@ object Notification {
   }
 
   // Notification that a resource configuration failed as the resource was busy
-  final case class SubsystemBusy(oid: Observation.Id, stepId: StepId, resource: Resource)
+  final case class SubsystemBusy(sidName: Observation.IdName, stepId: StepId, resource: Resource)
       extends Notification
 
   object SubsystemBusy {
     implicit lazy val eq: Eq[SubsystemBusy] =
-      Eq.by(x => (x.oid, x.stepId, x.resource))
+      Eq.by(x => (x.sidName, x.stepId, x.resource))
   }
 }

--- a/modules/model/shared/src/main/scala/observe/model/Observation.scala
+++ b/modules/model/shared/src/main/scala/observe/model/Observation.scala
@@ -5,40 +5,49 @@ package observe.model
 
 import cats.Order
 import cats.Show
+import cats.Eq
 import lucuma.core.math.Index
 
 object Observation {
 
+  type Id = lucuma.core.model.Observation.Id
+
   /** An observation is identified by its program and a serial index. */
-  final case class Id(pid: Program.Id, index: Index) {
+  final case class Name(pid: Program.Id, index: Index) {
     def format: String =
       s"${ProgramId.fromString.reverseGet(pid)}-${Index.fromString.reverseGet(index)}"
   }
-  object Id {
+  object Name {
 
-    def fromString(s: String): Option[Observation.Id] =
+    def fromString(s: String): Option[Observation.Name] =
       s.lastIndexOf('-') match {
         case -1 => None
         case n  =>
           val (a, b) = s.splitAt(n)
           Index.fromString.getOption(b.drop(1)).flatMap { i =>
-            Program.Id.fromString.getOption(a).map(Observation.Id(_, i))
+            Program.Id.fromString.getOption(a).map(Observation.Name(_, i))
           }
       }
 
-    def unsafeFromString(s: String): Observation.Id =
-      fromString(s).getOrElse(sys.error("Malformed Observation.Id: " + s))
+    def unsafeFromString(s: String): Observation.Name =
+      fromString(s).getOrElse(sys.error("Malformed Observation.Name: " + s))
 
     /** Observations are ordered by program id and index. */
-    implicit val OrderId: Order[Id] =
+    implicit val OrderName: Order[Name] =
       Order.by(a => (a.pid, a.index))
 
-    implicit val OrderingId: scala.math.Ordering[Id] =
-      OrderId.toOrdering
+    implicit val OrderingName: scala.math.Ordering[Name] =
+      OrderName.toOrdering
 
-    implicit val showId: Show[Id] =
+    implicit val showId: Show[Name] =
       Show.fromToString
 
+  }
+
+  sealed case class IdName(id: Id, name: Name)
+
+  object IdName {
+    implicit val idNameEq: Eq[IdName] = Eq.by(x => (x.id, x.name))
   }
 
 }

--- a/modules/model/shared/src/main/scala/observe/model/ObservationProgress.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ObservationProgress.scala
@@ -13,7 +13,7 @@ import observe.model.Observation
 import squants.Time
 
 sealed trait Progress extends Product with Serializable {
-  val obsId: Observation.Id
+  val obsIdName: Observation.IdName
   val stepId: StepId
   val total: Time
   val remaining: Time
@@ -40,7 +40,7 @@ object Progress {
 }
 
 final case class ObservationProgress(
-  obsId:     Observation.Id,
+  obsIdName: Observation.IdName,
   stepId:    StepId,
   total:     Time,
   remaining: Time,
@@ -50,12 +50,12 @@ final case class ObservationProgress(
 object ObservationProgress {
 
   implicit val equalObservationProgress: Eq[ObservationProgress] =
-    Eq.by(x => (x.obsId, x.stepId, x.total, x.remaining, x.stage))
+    Eq.by(x => (x.obsIdName, x.stepId, x.total, x.remaining, x.stage))
 
 }
 
 final case class NSObservationProgress(
-  obsId:     Observation.Id,
+  obsIdName: Observation.IdName,
   stepId:    StepId,
   total:     Time,
   remaining: Time,
@@ -66,7 +66,7 @@ final case class NSObservationProgress(
 object NSObservationProgress {
 
   implicit val equalNSObservationProgress: Eq[NSObservationProgress] =
-    Eq.by(x => (x.obsId, x.stepId, x.total, x.remaining, x.stage, x.sub))
+    Eq.by(x => (x.obsIdName, x.stepId, x.total, x.remaining, x.stage, x.sub))
 
 }
 

--- a/modules/model/shared/src/main/scala/observe/model/RunningStep.scala
+++ b/modules/model/shared/src/main/scala/observe/model/RunningStep.scala
@@ -3,28 +3,31 @@
 
 package observe.model
 
-import cats._
-import cats.syntax.all._
+import cats.Show
+import cats.Eq
+import cats.syntax.option._
 
 sealed trait RunningStep {
-  val last: StepId
-  val total: StepId
+  val id: Option[StepId]
+  val last: Int
+  val total: Int
 }
 
 object RunningStep {
-  val Zero: RunningStep = RunningStepImpl(0, 0)
+  val Zero: RunningStep = RunningStepImpl(none, 0, 0)
 
-  private final case class RunningStepImpl(last: StepId, total: StepId) extends RunningStep
+  private final case class RunningStepImpl(id: Option[StepId], last: Int, total: Int)
+      extends RunningStep
 
-  def fromInt(last: StepId, total: StepId): Option[RunningStep] =
-    if (last >= 0 && total >= last) RunningStepImpl(last, total).some else none
+  def fromInt(id: Option[StepId], last: Int, total: Int): Option[RunningStep] =
+    if (total >= last) RunningStepImpl(id, last, total).some else none
 
-  def unapply(r: RunningStep): Option[(StepId, StepId)] =
-    Some((r.last, r.total))
+  def unapply(r: RunningStep): Option[(Option[StepId], Int, Int)] =
+    Some((r.id, r.last, r.total))
 
   implicit val show: Show[RunningStep] =
     Show.show(u => s"${u.last + 1}/${u.total}")
 
   implicit val eq: Eq[RunningStep] =
-    Eq.by(x => (x.last, x.total))
+    Eq.by(x => (x.id, x.last, x.total))
 }

--- a/modules/model/shared/src/main/scala/observe/model/SequenceView.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceView.scala
@@ -12,7 +12,7 @@ import observe.model.Observation
 
 @Lenses
 final case class SequenceView(
-  id:              Observation.Id,
+  idName:          Observation.IdName,
   metadata:        SequenceMetadata,
   status:          SequenceState,
   systemOverrides: SystemOverrides,
@@ -21,7 +21,9 @@ final case class SequenceView(
 ) {
 
   def progress: Option[RunningStep] =
-    RunningStep.fromInt(steps.count(_.isFinished), steps.length)
+    steps.zipWithIndex.find(!_._1.isFinished).flatMap { x =>
+      RunningStep.fromInt(x._1.id.some, x._2, steps.length)
+    }
 
   // Returns where on the sequence the execution is at
   def runningStep: Option[RunningStep] = status match {
@@ -34,7 +36,7 @@ final case class SequenceView(
 
 object SequenceView {
   implicit val eq: Eq[SequenceView] =
-    Eq.by(x => (x.id, x.metadata, x.status, x.steps, x.willStopIn))
+    Eq.by(x => (x.idName, x.metadata, x.status, x.steps, x.willStopIn))
 
   val stepT: Traversal[SequenceView, Step] =
     SequenceView.steps ^|->> each

--- a/modules/model/shared/src/main/scala/observe/model/SingleActionOp.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SingleActionOp.scala
@@ -5,22 +5,25 @@ package observe.model
 
 import cats.Eq
 import cats.syntax.all._
-import observe.model.Observation
 import observe.model.enum.Resource
 
 sealed trait SingleActionOp extends Product with Serializable {
-  val sid: Observation.Id
+  val sidName: Observation.IdName
   val stepId: StepId
   val resource: Resource
 }
 
 object SingleActionOp {
-  final case class Started(sid: Observation.Id, stepId: StepId, resource: Resource)
+  final case class Started(sidName: Observation.IdName, stepId: StepId, resource: Resource)
       extends SingleActionOp
-  final case class Completed(sid: Observation.Id, stepId: StepId, resource: Resource)
+  final case class Completed(sidName: Observation.IdName, stepId: StepId, resource: Resource)
       extends SingleActionOp
-  final case class Error(sid: Observation.Id, stepId: StepId, resource: Resource, msg: String)
-      extends SingleActionOp
+  final case class Error(
+    sidName:  Observation.IdName,
+    stepId:   StepId,
+    resource: Resource,
+    msg:      String
+  ) extends SingleActionOp
 
   implicit val equal: Eq[SingleActionOp] = Eq.instance {
     case (Started(a, c, e), Started(b, d, f))     => a === b && c === d && e === f

--- a/modules/model/shared/src/main/scala/observe/model/Step.scala
+++ b/modules/model/shared/src/main/scala/observe/model/Step.scala
@@ -133,8 +133,11 @@ object Step {
 
     def file: Option[String] = None
 
-    def canSetBreakpoint(i: Int, firstRunnable: Int): Boolean =
-      s.status.canSetBreakpoint(i, firstRunnable)
+    def canSetBreakpoint(steps: List[Step]): Boolean =
+      s.status.canSetBreakpoint && steps
+        .dropWhile(_.status.isFinished)
+        .drop(1)
+        .exists(_.id === s.id)
 
     def canSetSkipmark: Boolean = s.status.canSetSkipmark
 

--- a/modules/model/shared/src/main/scala/observe/model/StepState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/StepState.scala
@@ -31,10 +31,10 @@ object StepState {
     }
 
   implicit class StepStateOps(val s: StepState) extends AnyVal {
-    def canSetBreakpoint(i: Int, firstRunnable: Int): Boolean = s match {
+    def canSetBreakpoint: Boolean = s match {
       case StepState.Pending | StepState.Skipped | StepState.Paused | StepState.Running |
           StepState.Aborted =>
-        i > firstRunnable
+        true
       case _ => false
     }
 

--- a/modules/model/shared/src/main/scala/observe/model/UserPrompt.scala
+++ b/modules/model/shared/src/main/scala/observe/model/UserPrompt.scala
@@ -63,13 +63,15 @@ object UserPrompt {
 
   // UserPrompt whether to override start checks
   final case class ChecksOverride(
-    sid:    Observation.Id,
-    stepId: StepId,
-    checks: NonEmptyList[SeqCheck]
+    sidName: Observation.IdName,
+    stepId:  StepId,
+    stepIdx: Int,
+    checks:  NonEmptyList[SeqCheck]
   ) extends UserPrompt
 
   object ChecksOverride {
-    implicit lazy val eq: Eq[ChecksOverride] = Eq.by(x => (x.sid, x.stepId, x.checks))
+    implicit lazy val eq: Eq[ChecksOverride] =
+      Eq.by(x => (x.sidName, x.stepId, x.stepIdx, x.checks))
   }
 
 }

--- a/modules/model/shared/src/main/scala/observe/model/boopickle/ModelBooPicklers.scala
+++ b/modules/model/shared/src/main/scala/observe/model/boopickle/ModelBooPicklers.scala
@@ -4,8 +4,8 @@
 package observe.model.boopickle
 
 import java.time._
-
-import boopickle.Default.Pickler
+import boopickle.Pickler
+import boopickle.CompositePickler
 import boopickle.Default.UUIDPickler
 import boopickle.Default.booleanPickler
 import boopickle.Default.compositePickler
@@ -21,6 +21,8 @@ import boopickle.DefaultBasic.iterablePickler
 import boopickle.DefaultBasic.mapPickler
 import cats._
 import cats.syntax.all._
+import eu.timepit.refined.api.RefType
+import eu.timepit.refined.types.numeric.PosLong
 import lucuma.core.math.Index
 import lucuma.core.util.Enumerated
 import observe.model.GmosParameters._
@@ -34,6 +36,7 @@ import observe.model.enum._
 import observe.model.events._
 import shapeless.tag
 import shapeless.tag.@@
+import squants.time.Time
 import squants.time.TimeConversions._
 
 /**
@@ -50,6 +53,16 @@ trait ModelBooPicklers extends BooPicklerSyntax {
   implicit val observationIdPickler: Pickler[Observation.Id]        = generatePickler[Observation.Id]
   implicit val lObservationIdPickler: Pickler[List[Observation.Id]] =
     iterablePickler[Observation.Id, List]
+
+  implicit val posLongPickler: Pickler[PosLong] =
+    transformPickler[PosLong, Long]((l: Long) =>
+      RefType
+        .applyRef[PosLong](l)
+        .getOrElse(throw new RuntimeException(s"Failed to decode value"))
+    )(_.value)
+
+  implicit val stepIdPickler: Pickler[StepId] =
+    transformPickler[StepId, PosLong](lucuma.core.model.Step.Id.apply)(_.value)
 
   def valuesMap[F[_]: Traverse, A, B](c: F[A], f: A => B): Map[B, A] =
     c.fproduct(f).map(_.swap).toList.toMap
@@ -69,60 +82,66 @@ trait ModelBooPicklers extends BooPicklerSyntax {
   def enumeratedPickler[A: Enumerated]: Pickler[A] =
     valuesMapPickler[A, Int](sourceIndex[A])
 
-  implicit val timeProgressPickler =
+  implicit val timeProgressPickler: Pickler[Time]     =
     transformPickler((t: Double) => t.milliseconds)(_.toMilliseconds)
 
-  implicit val instrumentPickler   = enumeratedPickler[Instrument]
-  implicit val resourcePickler     = enumeratedPickler[Resource]
+  implicit val instrumentPickler: Pickler[Instrument] = enumeratedPickler[Instrument]
+  implicit val resourcePickler: Pickler[Resource]     = enumeratedPickler[Resource]
 
-  implicit val operatorPickler  = generatePickler[Operator]
-  implicit val overridesPickler = generatePickler[SystemOverrides]
+  implicit val operatorPickler: Pickler[Operator]         = generatePickler[Operator]
+  implicit val overridesPickler: Pickler[SystemOverrides] = generatePickler[SystemOverrides]
 
-  implicit val systemNamePickler = enumeratedPickler[SystemName]
+  implicit val systemNamePickler: Pickler[SystemName] = enumeratedPickler[SystemName]
 
-  implicit val observerPickler = generatePickler[Observer]
+  implicit val observerPickler: Pickler[Observer] = generatePickler[Observer]
 
-  implicit val userDetailsPickler = generatePickler[UserDetails]
+  implicit val userDetailsPickler: Pickler[UserDetails] = generatePickler[UserDetails]
 
-  implicit val instantPickler       =
+  implicit val instantPickler: Pickler[Instant]             =
     transformPickler((t: Long) => Instant.ofEpochMilli(t))(_.toEpochMilli)
 
-  implicit val cloudCoverPickler    = enumeratedPickler[CloudCover]
-  implicit val imageQualityPickler  = enumeratedPickler[ImageQuality]
-  implicit val skyBackgroundPickler = enumeratedPickler[SkyBackground]
-  implicit val waterVaporPickler    = enumeratedPickler[WaterVapor]
-  implicit val conditionsPickler    = generatePickler[Conditions]
+  implicit val cloudCoverPickler: Pickler[CloudCover]       = enumeratedPickler[CloudCover]
+  implicit val imageQualityPickler: Pickler[ImageQuality]   = enumeratedPickler[ImageQuality]
+  implicit val skyBackgroundPickler: Pickler[SkyBackground] = enumeratedPickler[SkyBackground]
+  implicit val waterVaporPickler: Pickler[WaterVapor]       = enumeratedPickler[WaterVapor]
+  implicit val conditionsPickler: Pickler[Conditions]       = generatePickler[Conditions]
 
-  implicit val sequenceStateCompletedPickler =
+  implicit val sequenceStateCompletedPickler: Pickler[SequenceState.Completed.type] =
     generatePickler[SequenceState.Completed.type]
-  implicit val sequenceStateIdlePickler      =
+  implicit val sequenceStateIdlePickler: Pickler[SequenceState.Idle.type]           =
     generatePickler[SequenceState.Idle.type]
-  implicit val sequenceStateRunningPickler   =
+  implicit val sequenceStateRunningPickler: Pickler[SequenceState.Running]          =
     generatePickler[SequenceState.Running]
-  implicit val sequenceStateFailedPickler    =
+  implicit val sequenceStateFailedPickler: Pickler[SequenceState.Failed]            =
     generatePickler[SequenceState.Failed]
-  implicit val sequenceStateAbortedPickler   =
+  implicit val sequenceStateAbortedPickler: Pickler[SequenceState.Aborted.type]     =
     generatePickler[SequenceState.Aborted.type]
 
-  implicit val sequenceStatePickler = compositePickler[SequenceState]
-    .addConcreteType[SequenceState.Completed.type]
-    .addConcreteType[SequenceState.Running]
-    .addConcreteType[SequenceState.Failed]
-    .addConcreteType[SequenceState.Aborted.type]
-    .addConcreteType[SequenceState.Idle.type]
+  implicit val sequenceStatePickler: CompositePickler[SequenceState] =
+    compositePickler[SequenceState]
+      .addConcreteType[SequenceState.Completed.type]
+      .addConcreteType[SequenceState.Running]
+      .addConcreteType[SequenceState.Failed]
+      .addConcreteType[SequenceState.Aborted.type]
+      .addConcreteType[SequenceState.Idle.type]
 
-  implicit val actionStatusPickler = enumeratedPickler[ActionStatus]
+  implicit val actionStatusPickler: Pickler[ActionStatus] = enumeratedPickler[ActionStatus]
 
-  implicit val stepStatePendingPickler   = generatePickler[StepState.Pending.type]
-  implicit val stepStateCompletedPickler =
+  implicit val stepStatePendingPickler: Pickler[StepState.Pending.type]     =
+    generatePickler[StepState.Pending.type]
+  implicit val stepStateCompletedPickler: Pickler[StepState.Completed.type] =
     generatePickler[StepState.Completed.type]
-  implicit val stepStateSkippedPickler   = generatePickler[StepState.Skipped.type]
-  implicit val stepStateFailedPickler    = generatePickler[StepState.Failed]
-  implicit val stepStateRunningPickler   = generatePickler[StepState.Running.type]
-  implicit val stepStatePausedPickler    = generatePickler[StepState.Paused.type]
-  implicit val stepStateAbortedPickler   = generatePickler[StepState.Aborted.type]
+  implicit val stepStateSkippedPickler: Pickler[StepState.Skipped.type]     =
+    generatePickler[StepState.Skipped.type]
+  implicit val stepStateFailedPickler: Pickler[StepState.Failed]            = generatePickler[StepState.Failed]
+  implicit val stepStateRunningPickler: Pickler[StepState.Running.type]     =
+    generatePickler[StepState.Running.type]
+  implicit val stepStatePausedPickler: Pickler[StepState.Paused.type]       =
+    generatePickler[StepState.Paused.type]
+  implicit val stepStateAbortedPickler: Pickler[StepState.Aborted.type]     =
+    generatePickler[StepState.Aborted.type]
 
-  implicit val stepStatePickler = compositePickler[StepState]
+  implicit val stepStatePickler: CompositePickler[StepState] = compositePickler[StepState]
     .addConcreteType[StepState.Pending.type]
     .addConcreteType[StepState.Completed.type]
     .addConcreteType[StepState.Skipped.type]
@@ -131,12 +150,13 @@ trait ModelBooPicklers extends BooPicklerSyntax {
     .addConcreteType[StepState.Running.type]
     .addConcreteType[StepState.Paused.type]
 
-  implicit val imageIdPickler                                  = transformPickler((s: String) => tag[ImageFileIdT](s))(identity)
-  implicit val standardStepPickler                             = generatePickler[StandardStep]
+  implicit val imageIdPickler: Pickler[String @@ ImageFileIdT] =
+    transformPickler((s: String) => tag[ImageFileIdT](s))(identity)
+  implicit val standardStepPickler: Pickler[StandardStep]      = generatePickler[StandardStep]
   implicit def taggedIntPickler[A]: Pickler[Int @@ A]          =
     transformPickler((s: Int) => tag[A](s))(identity)
-  implicit val nsStagePickler                                  = enumeratedPickler[NodAndShuffleStage]
-  implicit val nsActionPickler                                 = enumeratedPickler[NSAction]
+  implicit val nsStagePickler: Pickler[NodAndShuffleStage]     = enumeratedPickler[NodAndShuffleStage]
+  implicit val nsActionPickler: Pickler[NSAction]              = enumeratedPickler[NSAction]
   implicit val nsSubexposurePickler: Pickler[NSSubexposure]    =
     transformPickler[NSSubexposure, (NsCycles, NsCycles, Int)] {
       case (t: NsCycles, c: NsCycles, i: Int) =>
@@ -147,163 +167,202 @@ trait ModelBooPicklers extends BooPicklerSyntax {
           )
       case _                                  => throw new RuntimeException("Failed to decode ns subexposure")
     }((ns: NSSubexposure) => (ns.totalCycles, ns.cycle, ns.stageIndex))
-  implicit val nsRunningStatePickler                           = generatePickler[NSRunningState]
-  implicit val nsStatusPickler                                 = generatePickler[NodAndShuffleStatus]
+  implicit val nsRunningStatePickler: Pickler[NSRunningState]  = generatePickler[NSRunningState]
+  implicit val nsStatusPickler: Pickler[NodAndShuffleStatus]   = generatePickler[NodAndShuffleStatus]
   implicit val nsPendObsCmdPickler: Pickler[PendingObserveCmd] =
     enumeratedPickler[PendingObserveCmd]
-  implicit val nsStepPickler                                   = generatePickler[NodAndShuffleStep]
+  implicit val nsStepPickler: Pickler[NodAndShuffleStep]       = generatePickler[NodAndShuffleStep]
 
-  implicit val stepPickler = compositePickler[Step]
+  implicit val stepPickler: CompositePickler[Step] = compositePickler[Step]
     .addConcreteType[StandardStep]
     .addConcreteType[NodAndShuffleStep]
 
-  implicit val sequenceMetadataPickler = generatePickler[SequenceMetadata]
+  implicit val sequenceMetadataPickler: Pickler[SequenceMetadata] =
+    generatePickler[SequenceMetadata]
 
-  implicit val stepConfigPickler = generatePickler[SequenceView]
-  implicit val clientIdPickler   = generatePickler[ClientId]
+  implicit val stepConfigPickler: Pickler[SequenceView] = generatePickler[SequenceView]
+  implicit val clientIdPickler: Pickler[ClientId]       = generatePickler[ClientId]
 
-  implicit val queueIdPickler            = generatePickler[QueueId]
-  implicit val queueOpMovedPickler       = generatePickler[QueueManipulationOp.Moved]
-  implicit val queueOpStartedPickler     =
+  implicit val queueIdPickler: Pickler[QueueId]                                    = generatePickler[QueueId]
+  implicit val queueOpMovedPickler: Pickler[QueueManipulationOp.Moved]             =
+    generatePickler[QueueManipulationOp.Moved]
+  implicit val queueOpStartedPickler: Pickler[QueueManipulationOp.Started]         =
     generatePickler[QueueManipulationOp.Started]
-  implicit val queueOpStoppedPickler     =
+  implicit val queueOpStoppedPickler: Pickler[QueueManipulationOp.Stopped]         =
     generatePickler[QueueManipulationOp.Stopped]
-  implicit val queueOpClearPickler       = generatePickler[QueueManipulationOp.Clear]
-  implicit val queueOpAddedSeqsPickler   =
+  implicit val queueOpClearPickler: Pickler[QueueManipulationOp.Clear]             =
+    generatePickler[QueueManipulationOp.Clear]
+  implicit val queueOpAddedSeqsPickler: Pickler[QueueManipulationOp.AddedSeqs]     =
     generatePickler[QueueManipulationOp.AddedSeqs]
-  implicit val queueOpRemovedSeqsPickler =
+  implicit val queueOpRemovedSeqsPickler: Pickler[QueueManipulationOp.RemovedSeqs] =
     generatePickler[QueueManipulationOp.RemovedSeqs]
 
-  implicit val queueOpPickler = compositePickler[QueueManipulationOp]
-    .addConcreteType[QueueManipulationOp.Clear]
-    .addConcreteType[QueueManipulationOp.Started]
-    .addConcreteType[QueueManipulationOp.Stopped]
-    .addConcreteType[QueueManipulationOp.Moved]
-    .addConcreteType[QueueManipulationOp.AddedSeqs]
-    .addConcreteType[QueueManipulationOp.RemovedSeqs]
+  implicit val queueOpPickler: CompositePickler[QueueManipulationOp] =
+    compositePickler[QueueManipulationOp]
+      .addConcreteType[QueueManipulationOp.Clear]
+      .addConcreteType[QueueManipulationOp.Started]
+      .addConcreteType[QueueManipulationOp.Stopped]
+      .addConcreteType[QueueManipulationOp.Moved]
+      .addConcreteType[QueueManipulationOp.AddedSeqs]
+      .addConcreteType[QueueManipulationOp.RemovedSeqs]
 
-  implicit val singleActionOpStartedPickler   = generatePickler[SingleActionOp.Started]
-  implicit val singleActionOpCompletedPickler = generatePickler[SingleActionOp.Completed]
-  implicit val singleActionOpErrorPickler     = generatePickler[SingleActionOp.Error]
-  implicit val singleActionOpPickler          = compositePickler[SingleActionOp]
-    .addConcreteType[SingleActionOp.Started]
-    .addConcreteType[SingleActionOp.Completed]
-    .addConcreteType[SingleActionOp.Error]
+  implicit val singleActionOpStartedPickler: Pickler[SingleActionOp.Started]     =
+    generatePickler[SingleActionOp.Started]
+  implicit val singleActionOpCompletedPickler: Pickler[SingleActionOp.Completed] =
+    generatePickler[SingleActionOp.Completed]
+  implicit val singleActionOpErrorPickler: Pickler[SingleActionOp.Error]         =
+    generatePickler[SingleActionOp.Error]
+  implicit val singleActionOpPickler: CompositePickler[SingleActionOp]           =
+    compositePickler[SingleActionOp]
+      .addConcreteType[SingleActionOp.Started]
+      .addConcreteType[SingleActionOp.Completed]
+      .addConcreteType[SingleActionOp.Error]
 
-  implicit val batchCommandStateIdlePickler =
+  implicit val batchCommandStateIdlePickler: Pickler[BatchCommandState.Idle.type] =
     generatePickler[BatchCommandState.Idle.type]
-  implicit val batchCommandStateRun         = generatePickler[BatchCommandState.Run]
-  implicit val batchCommandStateStopPickler =
+  implicit val batchCommandStateRun: Pickler[BatchCommandState.Run]               =
+    generatePickler[BatchCommandState.Run]
+  implicit val batchCommandStateStopPickler: Pickler[BatchCommandState.Stop.type] =
     generatePickler[BatchCommandState.Stop.type]
 
-  implicit val batchCommandPickler = compositePickler[BatchCommandState]
-    .addConcreteType[BatchCommandState.Idle.type]
-    .addConcreteType[BatchCommandState.Run]
-    .addConcreteType[BatchCommandState.Stop.type]
+  implicit val batchCommandPickler: CompositePickler[BatchCommandState] =
+    compositePickler[BatchCommandState]
+      .addConcreteType[BatchCommandState.Idle.type]
+      .addConcreteType[BatchCommandState.Run]
+      .addConcreteType[BatchCommandState.Stop.type]
 
-  implicit val batchExecStatePickler = enumeratedPickler[BatchExecState]
+  implicit val batchExecStatePickler: Pickler[BatchExecState] = enumeratedPickler[BatchExecState]
 
-  implicit val executionQueuePickler = generatePickler[ExecutionQueueView]
+  implicit val executionQueuePickler: Pickler[ExecutionQueueView] =
+    generatePickler[ExecutionQueueView]
 
-  implicit val sequenceQueueIdPickler =
+  implicit val sequenceQueueIdPickler: Pickler[SequencesQueue[Observation.Id]] =
     generatePickler[SequencesQueue[Observation.Id]]
 
-  implicit val sequenceQueueViewPickler =
+  implicit val sequenceQueueViewPickler: Pickler[SequencesQueue[SequenceView]] =
     generatePickler[SequencesQueue[SequenceView]]
 
-  implicit val comaPickler = enumeratedPickler[ComaOption]
+  implicit val comaPickler: Pickler[ComaOption] = enumeratedPickler[ComaOption]
 
-  implicit val tipTiltSourcePickler  = enumeratedPickler[TipTiltSource]
-  implicit val serverLogLevelPickler = enumeratedPickler[ServerLogLevel]
-  implicit val m1SourcePickler       = enumeratedPickler[M1Source]
+  implicit val tipTiltSourcePickler: Pickler[TipTiltSource]   = enumeratedPickler[TipTiltSource]
+  implicit val serverLogLevelPickler: Pickler[ServerLogLevel] = enumeratedPickler[ServerLogLevel]
+  implicit val m1SourcePickler: Pickler[M1Source]             = enumeratedPickler[M1Source]
 
-  implicit val mountGuidePickler    = enumeratedPickler[MountGuideOption]
-  implicit val m1GuideOnPickler     = generatePickler[M1GuideConfig.M1GuideOn]
-  implicit val m1GuideOffPickler    =
+  implicit val mountGuidePickler: Pickler[MountGuideOption]              = enumeratedPickler[MountGuideOption]
+  implicit val m1GuideOnPickler: Pickler[M1GuideConfig.M1GuideOn]        =
+    generatePickler[M1GuideConfig.M1GuideOn]
+  implicit val m1GuideOffPickler: Pickler[M1GuideConfig.M1GuideOff.type] =
     generatePickler[M1GuideConfig.M1GuideOff.type]
-  implicit val m1GuideConfigPickler = compositePickler[M1GuideConfig]
-    .addConcreteType[M1GuideConfig.M1GuideOn]
-    .addConcreteType[M1GuideConfig.M1GuideOff.type]
+  implicit val m1GuideConfigPickler: CompositePickler[M1GuideConfig]     =
+    compositePickler[M1GuideConfig]
+      .addConcreteType[M1GuideConfig.M1GuideOn]
+      .addConcreteType[M1GuideConfig.M1GuideOff.type]
 
-  implicit val m2GuideOnPickler     = generatePickler[M2GuideConfig.M2GuideOn]
-  implicit val m2GuideOffPickler    =
+  implicit val m2GuideOnPickler: Pickler[M2GuideConfig.M2GuideOn]        =
+    generatePickler[M2GuideConfig.M2GuideOn]
+  implicit val m2GuideOffPickler: Pickler[M2GuideConfig.M2GuideOff.type] =
     generatePickler[M2GuideConfig.M2GuideOff.type]
-  implicit val m2GuideConfigPickler = compositePickler[M2GuideConfig]
-    .addConcreteType[M2GuideConfig.M2GuideOn]
-    .addConcreteType[M2GuideConfig.M2GuideOff.type]
+  implicit val m2GuideConfigPickler: CompositePickler[M2GuideConfig]     =
+    compositePickler[M2GuideConfig]
+      .addConcreteType[M2GuideConfig.M2GuideOn]
+      .addConcreteType[M2GuideConfig.M2GuideOff.type]
 
-  implicit val telescopeGuideconfigPickler =
+  implicit val telescopeGuideconfigPickler: Pickler[TelescopeGuideConfig] =
     generatePickler[TelescopeGuideConfig]
 
-  implicit val resourceConflictPickler                   = generatePickler[Notification.ResourceConflict]
-  implicit val instrumentInUsePickler                    = generatePickler[Notification.InstrumentInUse]
-  implicit val requestFailedPickler                      = generatePickler[Notification.RequestFailed]
-  implicit val subsystemlBusyPickler                     = generatePickler[Notification.SubsystemBusy]
-  implicit val notificatonPickler: Pickler[Notification] =
+  implicit val resourceConflictPickler: Pickler[Notification.ResourceConflict] =
+    generatePickler[Notification.ResourceConflict]
+  implicit val instrumentInUsePickler: Pickler[Notification.InstrumentInUse]   =
+    generatePickler[Notification.InstrumentInUse]
+  implicit val requestFailedPickler: Pickler[Notification.RequestFailed]       =
+    generatePickler[Notification.RequestFailed]
+  implicit val subsystemlBusyPickler: Pickler[Notification.SubsystemBusy]      =
+    generatePickler[Notification.SubsystemBusy]
+  implicit val notificatonPickler: Pickler[Notification]                       =
     compositePickler[Notification]
       .addConcreteType[Notification.ResourceConflict]
       .addConcreteType[Notification.InstrumentInUse]
       .addConcreteType[Notification.RequestFailed]
       .addConcreteType[Notification.SubsystemBusy]
 
-  implicit val observationCheckOverride               = generatePickler[UserPrompt.ObsConditionsCheckOverride]
-  implicit val targetCheckOverride                    = generatePickler[UserPrompt.TargetCheckOverride]
-  implicit val seqCheck                               =
+  implicit val observationCheckOverride: Pickler[UserPrompt.ObsConditionsCheckOverride] =
+    generatePickler[UserPrompt.ObsConditionsCheckOverride]
+  implicit val targetCheckOverride: Pickler[UserPrompt.TargetCheckOverride]             =
+    generatePickler[UserPrompt.TargetCheckOverride]
+  implicit val seqCheck: CompositePickler[SeqCheck]                                     =
     compositePickler[SeqCheck]
       .addConcreteType[UserPrompt.TargetCheckOverride]
       .addConcreteType[UserPrompt.ObsConditionsCheckOverride]
-  implicit val checksOverridePickler                  = generatePickler[UserPrompt.ChecksOverride]
-  implicit val userPromptPickler: Pickler[UserPrompt] =
+  implicit val checksOverridePickler: Pickler[ChecksOverride]                           =
+    generatePickler[UserPrompt.ChecksOverride]
+  implicit val userPromptPickler: Pickler[UserPrompt]                                   =
     compositePickler[UserPrompt]
       .addConcreteType[ChecksOverride]
 
-  implicit val connectionOpenEventPickler         = generatePickler[ConnectionOpenEvent]
-  implicit val sequenceStartPickler               = generatePickler[SequenceStart]
-  implicit val stepExecutedPickler                = generatePickler[StepExecuted]
-  implicit val fileIdStepExecutedPickler          = generatePickler[FileIdStepExecuted]
-  implicit val sequenceCompletedPickler           = generatePickler[SequenceCompleted]
-  implicit val sequenceLoadedPickler              = generatePickler[SequenceLoaded]
-  implicit val sequenceUnloadedPickler            = generatePickler[SequenceUnloaded]
-  implicit val stepBreakpointChangedPickler       =
+  implicit val connectionOpenEventPickler: Pickler[ConnectionOpenEvent]                 =
+    generatePickler[ConnectionOpenEvent]
+  implicit val sequenceStartPickler: Pickler[SequenceStart]                             = generatePickler[SequenceStart]
+  implicit val stepExecutedPickler: Pickler[StepExecuted]                               = generatePickler[StepExecuted]
+  implicit val fileIdStepExecutedPickler: Pickler[FileIdStepExecuted]                   =
+    generatePickler[FileIdStepExecuted]
+  implicit val sequenceCompletedPickler: Pickler[SequenceCompleted]                     =
+    generatePickler[SequenceCompleted]
+  implicit val sequenceLoadedPickler: Pickler[SequenceLoaded]                           = generatePickler[SequenceLoaded]
+  implicit val sequenceUnloadedPickler: Pickler[SequenceUnloaded]                       =
+    generatePickler[SequenceUnloaded]
+  implicit val stepBreakpointChangedPickler: Pickler[StepBreakpointChanged]             =
     generatePickler[StepBreakpointChanged]
-  implicit val operatorUpdatedPickler             = generatePickler[OperatorUpdated]
-  implicit val observerUpdatedPickler             = generatePickler[ObserverUpdated]
-  implicit val conditionsUpdatedPickler           = generatePickler[ConditionsUpdated]
-  implicit val loadSequenceUpdatedPickler         = generatePickler[LoadSequenceUpdated]
-  implicit val clearLoadedSequencesUpdatedPickler =
+  implicit val operatorUpdatedPickler: Pickler[OperatorUpdated]                         = generatePickler[OperatorUpdated]
+  implicit val observerUpdatedPickler: Pickler[ObserverUpdated]                         = generatePickler[ObserverUpdated]
+  implicit val conditionsUpdatedPickler: Pickler[ConditionsUpdated]                     =
+    generatePickler[ConditionsUpdated]
+  implicit val loadSequenceUpdatedPickler: Pickler[LoadSequenceUpdated]                 =
+    generatePickler[LoadSequenceUpdated]
+  implicit val clearLoadedSequencesUpdatedPickler: Pickler[ClearLoadedSequencesUpdated] =
     generatePickler[ClearLoadedSequencesUpdated]
-  implicit val stepSkipMarkChangedPickler         = generatePickler[StepSkipMarkChanged]
-  implicit val sequencePauseRequestedPickler      =
+  implicit val stepSkipMarkChangedPickler: Pickler[StepSkipMarkChanged]                 =
+    generatePickler[StepSkipMarkChanged]
+  implicit val sequencePauseRequestedPickler: Pickler[SequencePauseRequested]           =
     generatePickler[SequencePauseRequested]
-  implicit val sequencePauseCanceledPickler       =
+  implicit val sequencePauseCanceledPickler: Pickler[SequencePauseCanceled]             =
     generatePickler[SequencePauseCanceled]
-  implicit val sequenceRefreshedPickler           = generatePickler[SequenceRefreshed]
-  implicit val actionStopRequestedPickler         = generatePickler[ActionStopRequested]
-  implicit val sequenceStoppedPickler             = generatePickler[SequenceStopped]
-  implicit val sequenceAbortedPickler             = generatePickler[SequenceAborted]
-  implicit val sequenceUpdatedPickler             = generatePickler[SequenceUpdated]
-  implicit val sequenceErrorPickler               = generatePickler[SequenceError]
-  implicit val sequencePausedPickler              = generatePickler[SequencePaused]
-  implicit val exposurePausedPickler              = generatePickler[ExposurePaused]
-  implicit val serverLogMessagePickler            = generatePickler[ServerLogMessage]
-  implicit val userNotificationPickler            = generatePickler[UserNotification]
-  implicit val userPromptNotPickler               = generatePickler[UserPromptNotification]
-  implicit val guideConfigPickler                 = generatePickler[GuideConfigUpdate]
-  implicit val queueUpdatedPickler                = generatePickler[QueueUpdated]
-  implicit val observationStagePickler            = enumeratedPickler[ObserveStage]
-  implicit val observationProgressPickler         = generatePickler[ObservationProgress]
-  implicit val nsobseProgressPickler              = generatePickler[NSObservationProgress]
-  implicit val progressPickler                    = compositePickler[Progress]
+  implicit val sequenceRefreshedPickler: Pickler[SequenceRefreshed]                     =
+    generatePickler[SequenceRefreshed]
+  implicit val actionStopRequestedPickler: Pickler[ActionStopRequested]                 =
+    generatePickler[ActionStopRequested]
+  implicit val sequenceStoppedPickler: Pickler[SequenceStopped]                         = generatePickler[SequenceStopped]
+  implicit val sequenceAbortedPickler: Pickler[SequenceAborted]                         = generatePickler[SequenceAborted]
+  implicit val sequenceUpdatedPickler: Pickler[SequenceUpdated]                         = generatePickler[SequenceUpdated]
+  implicit val sequenceErrorPickler: Pickler[SequenceError]                             = generatePickler[SequenceError]
+  implicit val sequencePausedPickler: Pickler[SequencePaused]                           = generatePickler[SequencePaused]
+  implicit val exposurePausedPickler: Pickler[ExposurePaused]                           = generatePickler[ExposurePaused]
+  implicit val serverLogMessagePickler: Pickler[ServerLogMessage]                       =
+    generatePickler[ServerLogMessage]
+  implicit val userNotificationPickler: Pickler[UserNotification]                       =
+    generatePickler[UserNotification]
+  implicit val userPromptNotPickler: Pickler[UserPromptNotification]                    =
+    generatePickler[UserPromptNotification]
+  implicit val guideConfigPickler: Pickler[GuideConfigUpdate]                           = generatePickler[GuideConfigUpdate]
+  implicit val queueUpdatedPickler: Pickler[QueueUpdated]                               = generatePickler[QueueUpdated]
+  implicit val observationStagePickler: Pickler[ObserveStage]                           = enumeratedPickler[ObserveStage]
+  implicit val observationProgressPickler: Pickler[ObservationProgress]                 =
+    generatePickler[ObservationProgress]
+  implicit val nsobseProgressPickler: Pickler[NSObservationProgress]                    =
+    generatePickler[NSObservationProgress]
+  implicit val progressPickler: CompositePickler[Progress]                              = compositePickler[Progress]
     .addConcreteType[ObservationProgress]
     .addConcreteType[NSObservationProgress]
-  implicit val obsProgressPickler                 = generatePickler[ObservationProgressEvent]
-  implicit val acProgressPickler                  = generatePickler[AlignAndCalibEvent]
-  implicit val singleActionEventPickler           = generatePickler[SingleActionEvent]
-  implicit val nullEventPickler                   = generatePickler[NullEvent.type]
-  implicit val overridesUpdatedPickler            = generatePickler[OverridesUpdated]
+  implicit val obsProgressPickler: Pickler[ObservationProgressEvent]                    =
+    generatePickler[ObservationProgressEvent]
+  implicit val acProgressPickler: Pickler[AlignAndCalibEvent]                           = generatePickler[AlignAndCalibEvent]
+  implicit val singleActionEventPickler: Pickler[SingleActionEvent]                     =
+    generatePickler[SingleActionEvent]
+  implicit val nullEventPickler: Pickler[events.NullEvent.type]                         = generatePickler[NullEvent.type]
+  implicit val overridesUpdatedPickler: Pickler[OverridesUpdated]                       =
+    generatePickler[OverridesUpdated]
 
   // Composite pickler for the observe event hierarchy
-  implicit val eventsPickler = compositePickler[ObserveEvent]
+  implicit val eventsPickler: CompositePickler[ObserveEvent] = compositePickler[ObserveEvent]
     .addConcreteType[ConnectionOpenEvent]
     .addConcreteType[SequenceStart]
     .addConcreteType[StepExecuted]
@@ -339,6 +398,6 @@ trait ModelBooPicklers extends BooPicklerSyntax {
     .addConcreteType[OverridesUpdated]
     .addConcreteType[NullEvent.type]
 
-  implicit val userLoginPickler = generatePickler[UserLoginRequest]
+  implicit val userLoginPickler: Pickler[UserLoginRequest] = generatePickler[UserLoginRequest]
 
 }

--- a/modules/model/shared/src/main/scala/observe/model/events.scala
+++ b/modules/model/shared/src/main/scala/observe/model/events.scala
@@ -174,14 +174,14 @@ object events {
 
   final case class LoadSequenceUpdated(
     i:        Instrument,
-    sid:      Observation.Id,
+    sidName:  Observation.IdName,
     view:     SequencesQueue[SequenceView],
     clientId: ClientId
   ) extends ObserveModelUpdate
 
   object LoadSequenceUpdated {
     implicit lazy val equal: Eq[LoadSequenceUpdated] =
-      Eq.by(x => (x.i, x.sid, x.view, x.clientId))
+      Eq.by(x => (x.i, x.sidName, x.view, x.clientId))
   }
 
   final case class ClearLoadedSequencesUpdated(view: SequencesQueue[SequenceView])

--- a/modules/model/shared/src/main/scala/observe/model/package.scala
+++ b/modules/model/shared/src/main/scala/observe/model/package.scala
@@ -20,7 +20,7 @@ package object model {
   type ParamValue      = String
   type Parameters      = Map[ParamName, ParamValue]
   type StepConfig      = Map[SystemName, Parameters]
-  type StepId          = Int
+  type StepId          = lucuma.core.model.Step.Id
   type ObservationName = String
   type TargetName      = String
 

--- a/modules/model/shared/src/test/scala/observe/common/test/package.scala
+++ b/modules/model/shared/src/test/scala/observe/common/test/package.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.common
+
+import eu.timepit.refined.types.numeric.PosLong
+import observe.model.{ Observation, StepId }
+
+package object test {
+  def observationId(i: Int): Observation.Id =
+    lucuma.core.model.Observation.Id(PosLong.unsafeFrom(i.toLong))
+
+  def stepId(i: Int): StepId = lucuma.core.model.Step.Id(PosLong.unsafeFrom(i.toLong))
+}

--- a/modules/model/shared/src/test/scala/observe/model/ExecutionQueueViewSpec.scala
+++ b/modules/model/shared/src/test/scala/observe/model/ExecutionQueueViewSpec.scala
@@ -4,12 +4,11 @@
 package observe.model
 
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
 import monocle.law.discipline.LensTests
 import observe.model.ObserveModelArbitraries._
-import observe.model.arb.ArbObservationId
 
 final class ExecutionQueueViewSpec extends munit.DisciplineSuite {
-  import ArbObservationId._
 
   checkAll("ExecutionQueueView id lens", LensTests(ExecutionQueueView.id))
   checkAll("ExecutionQueueView name lens", LensTests(ExecutionQueueView.name))

--- a/modules/model/shared/src/test/scala/observe/model/ModelLensesSpec.scala
+++ b/modules/model/shared/src/test/scala/observe/model/ModelLensesSpec.scala
@@ -8,6 +8,7 @@ import lucuma.core.util.arb.ArbEnumerated._
 import lucuma.core.optics.laws.discipline.FormatTests
 import lucuma.core.math.arb.ArbOffset._
 import lucuma.core.math.arb.ArbAngle._
+import lucuma.core.util.arb.ArbGid._
 import lucuma.core.math.Axis
 import monocle.law.discipline._
 import org.scalacheck.Arbitrary._

--- a/modules/model/shared/src/test/scala/observe/model/SequenceEventsArbitraries.scala
+++ b/modules/model/shared/src/test/scala/observe/model/SequenceEventsArbitraries.scala
@@ -9,6 +9,7 @@ import org.scalacheck.Cogen
 import org.scalacheck.Gen
 import org.scalacheck.Arbitrary._
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
 import lucuma.core.arb.ArbTime._
 import java.time.Instant
 import observe.model.enum._
@@ -19,11 +20,11 @@ import observe.model.arb.all._
 
 trait SequenceEventsArbitraries {
 
-  implicit val gcuArb = Arbitrary[GuideConfigUpdate] {
+  implicit val gcuArb: Arbitrary[GuideConfigUpdate] = Arbitrary[GuideConfigUpdate] {
     arbitrary[TelescopeGuideConfig].map(GuideConfigUpdate.apply)
   }
 
-  implicit val coeArb = Arbitrary[ConnectionOpenEvent] {
+  implicit val coeArb: Arbitrary[ConnectionOpenEvent] = Arbitrary[ConnectionOpenEvent] {
     for {
       u  <- arbitrary[Option[UserDetails]]
       id <- arbitrary[ClientId]
@@ -31,7 +32,7 @@ trait SequenceEventsArbitraries {
     } yield ConnectionOpenEvent(u, id, v)
   }
 
-  implicit val sseArb = Arbitrary[SequenceStart] {
+  implicit val sseArb: Arbitrary[SequenceStart] = Arbitrary[SequenceStart] {
     for {
       id <- arbitrary[Observation.Id]
       si <- arbitrary[StepId]
@@ -39,81 +40,81 @@ trait SequenceEventsArbitraries {
     } yield SequenceStart(id, si, sv)
   }
 
-  implicit val seeArb = Arbitrary[StepExecuted] {
+  implicit val seeArb: Arbitrary[StepExecuted]                = Arbitrary[StepExecuted] {
     for {
       i <- arbitrary[Observation.Id]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield StepExecuted(i, s)
   }
-  implicit val sceArb = Arbitrary[SequenceCompleted] {
+  implicit val sceArb: Arbitrary[SequenceCompleted]           = Arbitrary[SequenceCompleted] {
     arbitrary[SequencesQueue[SequenceView]].map(SequenceCompleted.apply)
   }
-  implicit val sleArb = Arbitrary[SequenceLoaded] {
+  implicit val sleArb: Arbitrary[SequenceLoaded]              = Arbitrary[SequenceLoaded] {
     for {
       i <- arbitrary[Observation.Id]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield SequenceLoaded(i, s)
   }
-  implicit val sueArb = Arbitrary[SequenceUnloaded] {
+  implicit val sueArb: Arbitrary[SequenceUnloaded]            = Arbitrary[SequenceUnloaded] {
     for {
       i <- arbitrary[Observation.Id]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield SequenceUnloaded(i, s)
   }
-  implicit val sstArb = Arbitrary[SequenceStopped] {
+  implicit val sstArb: Arbitrary[SequenceStopped]             = Arbitrary[SequenceStopped] {
     for {
       i <- arbitrary[Observation.Id]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield SequenceStopped(i, s)
   }
-  implicit val ssaArb = Arbitrary[SequenceAborted] {
+  implicit val ssaArb: Arbitrary[SequenceAborted]             = Arbitrary[SequenceAborted] {
     for {
       i <- arbitrary[Observation.Id]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield SequenceAborted(i, s)
   }
-  implicit val sbeArb = Arbitrary[StepBreakpointChanged] {
+  implicit val sbeArb: Arbitrary[StepBreakpointChanged]       = Arbitrary[StepBreakpointChanged] {
     arbitrary[SequencesQueue[SequenceView]].map(StepBreakpointChanged.apply)
   }
-  implicit val smeArb = Arbitrary[StepSkipMarkChanged] {
+  implicit val smeArb: Arbitrary[StepSkipMarkChanged]         = Arbitrary[StepSkipMarkChanged] {
     arbitrary[SequencesQueue[SequenceView]].map(StepSkipMarkChanged.apply)
   }
-  implicit val speArb = Arbitrary[SequencePauseRequested] {
+  implicit val speArb: Arbitrary[SequencePauseRequested]      = Arbitrary[SequencePauseRequested] {
     arbitrary[SequencesQueue[SequenceView]].map(SequencePauseRequested.apply)
   }
-  implicit val spcArb = Arbitrary[SequencePauseCanceled] {
+  implicit val spcArb: Arbitrary[SequencePauseCanceled]       = Arbitrary[SequencePauseCanceled] {
     for {
       i <- arbitrary[Observation.Id]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield SequencePauseCanceled(i, s)
   }
-  implicit val srfArb = Arbitrary[SequenceRefreshed] {
+  implicit val srfArb: Arbitrary[SequenceRefreshed]           = Arbitrary[SequenceRefreshed] {
     for {
       s <- arbitrary[SequencesQueue[SequenceView]]
       c <- arbitrary[ClientId]
     } yield SequenceRefreshed(s, c)
   }
-  implicit val asrArb = Arbitrary[ActionStopRequested] {
+  implicit val asrArb: Arbitrary[ActionStopRequested]         = Arbitrary[ActionStopRequested] {
     arbitrary[SequencesQueue[SequenceView]].map(ActionStopRequested.apply)
   }
-  implicit val slmArb = Arbitrary[ServerLogMessage] {
+  implicit val slmArb: Arbitrary[ServerLogMessage]            = Arbitrary[ServerLogMessage] {
     for {
       l <- arbitrary[ServerLogLevel]
       t <- arbitrary[Instant]
       m <- Gen.alphaStr
     } yield ServerLogMessage(l, t, m)
   }
-  implicit val neArb  = Arbitrary[NullEvent.type](NullEvent)
-  implicit val opArb  = Arbitrary[OperatorUpdated] {
+  implicit val neArb: Arbitrary[events.NullEvent.type]        = Arbitrary[NullEvent.type](NullEvent)
+  implicit val opArb: Arbitrary[OperatorUpdated]              = Arbitrary[OperatorUpdated] {
     arbitrary[SequencesQueue[SequenceView]].map(OperatorUpdated.apply)
   }
-  implicit val obArb  = Arbitrary[ObserverUpdated] {
+  implicit val obArb: Arbitrary[ObserverUpdated]              = Arbitrary[ObserverUpdated] {
     arbitrary[SequencesQueue[SequenceView]].map(ObserverUpdated.apply)
   }
-  implicit val cuArb  = Arbitrary[ConditionsUpdated] {
+  implicit val cuArb: Arbitrary[ConditionsUpdated]            = Arbitrary[ConditionsUpdated] {
     arbitrary[SequencesQueue[SequenceView]].map(ConditionsUpdated.apply)
   }
-  implicit val qmArb  = Arbitrary[QueueManipulationOp] {
+  implicit val qmArb: Arbitrary[QueueManipulationOp]          = Arbitrary[QueueManipulationOp] {
     for {
       q <- arbitrary[QueueId]
       i <- arbitrary[List[Observation.Id]]
@@ -130,77 +131,78 @@ trait SequenceEventsArbitraries {
            )
     } yield m
   }
-  implicit val quArb  = Arbitrary[QueueUpdated] {
+  implicit val quArb: Arbitrary[QueueUpdated]                 = Arbitrary[QueueUpdated] {
     for {
       o <- arbitrary[QueueManipulationOp]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield QueueUpdated(o, s)
   }
-  implicit val suArb  = Arbitrary[LoadSequenceUpdated] {
+  implicit val suArb: Arbitrary[LoadSequenceUpdated]          = Arbitrary[LoadSequenceUpdated] {
     for {
       i <- arbitrary[Instrument]
-      o <- arbitrary[Observation.Id]
+      o <- arbitrary[Observation.IdName]
       s <- arbitrary[SequencesQueue[SequenceView]]
       c <- arbitrary[ClientId]
     } yield LoadSequenceUpdated(i, o, s, c)
   }
-  implicit val clsArb = Arbitrary[ClearLoadedSequencesUpdated] {
-    arbitrary[SequencesQueue[SequenceView]]
-      .map(ClearLoadedSequencesUpdated.apply)
-  }
-  implicit val serArb = Arbitrary[SequenceError] {
+  implicit val clsArb: Arbitrary[ClearLoadedSequencesUpdated] =
+    Arbitrary[ClearLoadedSequencesUpdated] {
+      arbitrary[SequencesQueue[SequenceView]]
+        .map(ClearLoadedSequencesUpdated.apply)
+    }
+  implicit val serArb: Arbitrary[SequenceError]               = Arbitrary[SequenceError] {
     for {
       i <- arbitrary[Observation.Id]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield SequenceError(i, s)
   }
 
-  implicit val supArb = Arbitrary[SequenceUpdated] {
+  implicit val supArb: Arbitrary[SequenceUpdated] = Arbitrary[SequenceUpdated] {
     arbitrary[SequencesQueue[SequenceView]].map(SequenceUpdated.apply)
   }
 
-  implicit val sspArb = Arbitrary[SequencePaused] {
+  implicit val sspArb: Arbitrary[SequencePaused] = Arbitrary[SequencePaused] {
     for {
       i <- arbitrary[Observation.Id]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield SequencePaused(i, s)
   }
 
-  implicit val sepArb = Arbitrary[ExposurePaused] {
+  implicit val sepArb: Arbitrary[ExposurePaused] = Arbitrary[ExposurePaused] {
     for {
       i <- arbitrary[Observation.Id]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield ExposurePaused(i, s)
   }
 
-  implicit val fidArb = Arbitrary[FileIdStepExecuted] {
+  implicit val fidArb: Arbitrary[FileIdStepExecuted] = Arbitrary[FileIdStepExecuted] {
     for {
       i <- arbitrary[ImageFileId]
       s <- arbitrary[SequencesQueue[SequenceView]]
     } yield FileIdStepExecuted(i, s)
   }
 
-  implicit val unArb = Arbitrary[UserNotification] {
+  implicit val unArb: Arbitrary[UserNotification] = Arbitrary[UserNotification] {
     for {
       i <- arbitrary[Notification]
       c <- arbitrary[ClientId]
     } yield UserNotification(i, c)
   }
 
-  implicit val unpArb = Arbitrary[UserPromptNotification] {
+  implicit val unpArb: Arbitrary[UserPromptNotification] = Arbitrary[UserPromptNotification] {
     for {
       i <- arbitrary[UserPrompt]
       c <- arbitrary[ClientId]
     } yield UserPromptNotification(i, c)
   }
 
-  implicit val oprArb = Arbitrary[ObservationProgressEvent] {
+  implicit val oprArb: Arbitrary[ObservationProgressEvent] = Arbitrary[ObservationProgressEvent] {
     for {
       p <- arbitrary[ObservationProgress]
     } yield ObservationProgressEvent(p)
   }
 
-  implicit val smuArb = Arbitrary[ObserveModelUpdate] {
+  implicit val smuArb: Arbitrary[ObserveModelUpdate] = Arbitrary[ObserveModelUpdate] {
     Gen.oneOf[ObserveModelUpdate](
       arbitrary[SequenceStart],
       arbitrary[StepExecuted],
@@ -227,13 +229,13 @@ trait SequenceEventsArbitraries {
     )
   }
 
-  implicit val acpArb = Arbitrary[AlignAndCalibEvent] {
+  implicit val acpArb: Arbitrary[AlignAndCalibEvent] = Arbitrary[AlignAndCalibEvent] {
     for {
       p <- Gen.posNum[Int]
     } yield AlignAndCalibEvent(p)
   }
 
-  implicit val seArb = Arbitrary[ObserveEvent] {
+  implicit val seArb: Arbitrary[ObserveEvent] = Arbitrary[ObserveEvent] {
     Gen.oneOf[ObserveEvent](
       arbitrary[ObserveModelUpdate],
       arbitrary[ConnectionOpenEvent],

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbNodAndShuffleStep.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbNodAndShuffleStep.scala
@@ -6,6 +6,7 @@ package observe.model.arb
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
 import org.scalacheck.Arbitrary._
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
 import observe.model._
 import observe.model.GmosParameters._
 import observe.model.NodAndShuffleStep.{ PauseGracefully, PendingObserveCmd, StopGracefully }

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbNotification.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbNotification.scala
@@ -4,6 +4,7 @@
 package observe.model.arb
 
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen
@@ -16,46 +17,46 @@ import observe.model.enum.Instrument
 import observe.model.enum.Resource
 
 trait ArbNotification {
-  import ArbObservationId._
+  import ArbObservationIdName._
 
-  implicit val rcArb = Arbitrary[ResourceConflict] {
+  implicit val rcArb: Arbitrary[ResourceConflict] = Arbitrary[ResourceConflict] {
     for {
-      id <- arbitrary[Observation.Id]
-    } yield ResourceConflict(id)
+      idName <- arbitrary[Observation.IdName]
+    } yield ResourceConflict(idName)
   }
 
   implicit val rcCogen: Cogen[ResourceConflict] =
-    Cogen[Observation.Id].contramap(_.sid)
+    Cogen[Observation.IdName].contramap(_.sidName)
 
-  implicit val rfArb = Arbitrary[RequestFailed] {
+  implicit val rfArb: Arbitrary[RequestFailed] = Arbitrary[RequestFailed] {
     arbitrary[List[String]].map(RequestFailed.apply)
   }
 
   implicit val rfCogen: Cogen[RequestFailed] =
     Cogen[List[String]].contramap(_.msgs)
 
-  implicit val inArb = Arbitrary[InstrumentInUse] {
+  implicit val inArb: Arbitrary[InstrumentInUse] = Arbitrary[InstrumentInUse] {
     for {
-      id <- arbitrary[Observation.Id]
+      id <- arbitrary[Observation.IdName]
       i  <- arbitrary[Instrument]
     } yield InstrumentInUse(id, i)
   }
 
   implicit val inCogen: Cogen[InstrumentInUse] =
-    Cogen[(Observation.Id, Instrument)].contramap(x => (x.sid, x.ins))
+    Cogen[(Observation.IdName, Instrument)].contramap(x => (x.sidName, x.ins))
 
-  implicit val subsArb = Arbitrary[SubsystemBusy] {
+  implicit val subsArb: Arbitrary[SubsystemBusy] = Arbitrary[SubsystemBusy] {
     for {
-      id <- arbitrary[Observation.Id]
+      id <- arbitrary[Observation.IdName]
       i  <- arbitrary[StepId]
       r  <- arbitrary[Resource]
     } yield SubsystemBusy(id, i, r)
   }
 
   implicit val subsCogen: Cogen[SubsystemBusy] =
-    Cogen[(Observation.Id, StepId, Resource)].contramap(x => (x.oid, x.stepId, x.resource))
+    Cogen[(Observation.IdName, StepId, Resource)].contramap(x => (x.sidName, x.stepId, x.resource))
 
-  implicit val notArb = Arbitrary[Notification] {
+  implicit val notArb: Arbitrary[Notification] = Arbitrary[Notification] {
     for {
       r <- arbitrary[ResourceConflict]
       a <- arbitrary[InstrumentInUse]

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbObservationIdName.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbObservationIdName.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.model.arb
+
+import observe.model.Observation
+import org.scalacheck.{ Arbitrary, Cogen }
+import org.scalacheck.Arbitrary._
+import lucuma.core.util.arb.ArbGid._
+import ArbObservationName._
+
+trait ArbObservationIdName {
+  implicit val arbObservationIdName: Arbitrary[Observation.IdName] = Arbitrary[Observation.IdName] {
+    for {
+      id   <- arbitrary[lucuma.core.model.Observation.Id]
+      name <- arbitrary[Observation.Name]
+    } yield Observation.IdName(id, name)
+  }
+
+  implicit val cogenObservationIdName: Cogen[Observation.IdName] =
+    Cogen[(Observation.Id, Observation.Name)].contramap(x => (x.id, x.name))
+}
+
+object ArbObservationIdName extends ArbObservationIdName

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbObservationName.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbObservationName.scala
@@ -15,22 +15,22 @@ import observe.model.arb.ArbProgramId
 import lucuma.core.math.Index
 import lucuma.core.optics.syntax.prism._
 
-trait ArbObservationId {
+trait ArbObservationName {
 
   import ArbIndex._
   import ArbProgramId._
 
-  implicit val arbObservationId: Arbitrary[Observation.Id] =
+  implicit val arbObservationId: Arbitrary[Observation.Name] =
     Arbitrary {
       for {
         pid <- arbitrary[ProgramId]
         num <- choose[Short](1, 100)
-      } yield Observation.Id(pid, Index.fromShort.unsafeGet(num))
+      } yield Observation.Name(pid, Index.fromShort.unsafeGet(num))
     }
 
-  implicit val cogObservationId: Cogen[Observation.Id] =
+  implicit val cogObservationId: Cogen[Observation.Name] =
     Cogen[(ProgramId, Index)].contramap(oid => (oid.pid, oid.index))
 
 }
 
-object ArbObservationId extends ArbObservationId
+object ArbObservationName extends ArbObservationName

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbObservationProgress.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbObservationProgress.scala
@@ -5,6 +5,7 @@ package observe.model.arb
 
 import observe.model.Observation
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
@@ -16,12 +17,12 @@ import observe.model.ObserveStage.observeStageEnum
 import squants.time._
 
 trait ArbObservationProgress {
-  import ArbObservationId._
+  import ArbObservationIdName._
 
   implicit val arbObservationProgress: Arbitrary[ObservationProgress] =
     Arbitrary {
       for {
-        o <- arbitrary[Observation.Id]
+        o <- arbitrary[Observation.IdName]
         s <- arbitrary[StepId]
         t <- arbitrary[Time]
         r <- arbitrary[Time]
@@ -30,13 +31,13 @@ trait ArbObservationProgress {
     }
 
   implicit val observationInProgressCogen: Cogen[ObservationProgress] =
-    Cogen[(Observation.Id, StepId, Time, Time, ObserveStage)]
-      .contramap(x => (x.obsId, x.stepId, x.total, x.remaining, x.stage))
+    Cogen[(Observation.IdName, StepId, Time, Time, ObserveStage)]
+      .contramap(x => (x.obsIdName, x.stepId, x.total, x.remaining, x.stage))
 
   implicit val arbNSObservationProgress: Arbitrary[NSObservationProgress] =
     Arbitrary {
       for {
-        o <- arbitrary[Observation.Id]
+        o <- arbitrary[Observation.IdName]
         s <- arbitrary[StepId]
         t <- arbitrary[Time]
         r <- arbitrary[Time]
@@ -46,8 +47,8 @@ trait ArbObservationProgress {
     }
 
   implicit val nsObservationInProgressCogen: Cogen[NSObservationProgress] =
-    Cogen[(Observation.Id, StepId, Time, Time, ObserveStage, NSSubexposure)]
-      .contramap(x => (x.obsId, x.stepId, x.total, x.remaining, x.stage, x.sub))
+    Cogen[(Observation.IdName, StepId, Time, Time, ObserveStage, NSSubexposure)]
+      .contramap(x => (x.obsIdName, x.stepId, x.total, x.remaining, x.stage, x.sub))
 
   implicit val arbProgress: Arbitrary[Progress] =
     Arbitrary {

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbRunningStep.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbRunningStep.scala
@@ -3,24 +3,28 @@
 
 package observe.model.arb
 
+import cats.syntax.option._
 import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Gen
 import observe.model.RunningStep
 import observe.model.StepId
+import lucuma.core.util.arb.ArbGid._
 
 trait ArbRunningStep {
 
   implicit val arbRunningStep: Arbitrary[RunningStep] =
     Arbitrary {
       for {
-        l <- Gen.posNum[Int]
-        i <- Gen.choose(l, Int.MaxValue)
-      } yield RunningStep.fromInt(l, i).getOrElse(RunningStep.Zero)
+        id <- arbitrary[StepId]
+        l  <- Gen.posNum[Int]
+        i  <- Gen.choose(l, Int.MaxValue)
+      } yield RunningStep.fromInt(id.some, l, i).getOrElse(RunningStep.Zero)
     }
 
   implicit val runningStepCogen: Cogen[RunningStep] =
-    Cogen[(StepId, StepId)].contramap(x => (x.last, x.total))
+    Cogen[(Option[StepId], Int, Int)].contramap(x => (x.id, x.last, x.total))
 
 }
 

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbStandardStep.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbStandardStep.scala
@@ -7,6 +7,7 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
 import observe.model._
 import observe.model.enum._
 import observe.model.arb.ArbStepConfig._
@@ -14,6 +15,7 @@ import observe.model.arb.ArbStepState._
 import observe.model.arb.ArbDhsTypes._
 
 trait ArbStandardStep {
+
   implicit val stsArb = Arbitrary[StandardStep] {
     for {
       id <- arbitrary[StepId]

--- a/modules/model/shared/src/test/scala/observe/model/arb/package.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/package.scala
@@ -24,6 +24,7 @@ package object arb {
       with ArbNSRunningState
       with ArbObservationProgress
       with ArbUserPrompt
-      with ArbObservationId
+      with ArbObservationName
       with ArbProgramId
+      with ArbObservationIdName
 }

--- a/modules/model/shared/src/test/scala/observe/model/boopickle/ModelBooPicklersSpec.scala
+++ b/modules/model/shared/src/test/scala/observe/model/boopickle/ModelBooPicklersSpec.scala
@@ -4,6 +4,7 @@
 package observe.model.boopickle
 
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
 import observe.model.enum._
 import observe.model._
 import observe.model.events._
@@ -23,7 +24,6 @@ import observe.model.arb._
  */
 final class BoopicklingSuite extends munit.DisciplineSuite with ModelBooPicklers {
   import ArbProgramId._
-  import ArbObservationId._
 
   checkAll("Pickler[Year]", PicklerTests[Year].pickler)
   checkAll("Pickler[LocalDate]", PicklerTests[LocalDate].pickler)

--- a/modules/model/shared/src/test/scala/observe/model/boopickle/package.scala
+++ b/modules/model/shared/src/test/scala/observe/model/boopickle/package.scala
@@ -8,7 +8,7 @@ import _root_.boopickle.Default.Pickle
 import _root_.boopickle.Default.Unpickle
 import cats.laws._
 import cats.laws.discipline._
-import cats.kernel.Eq
+import cats.Eq
 import org.scalacheck.{ Arbitrary, Prop, Shrink }
 import org.typelevel.discipline.Laws
 

--- a/modules/ocs2_api/src/main/scala/gem/ocs2/model/Dataset.scala
+++ b/modules/ocs2_api/src/main/scala/gem/ocs2/model/Dataset.scala
@@ -28,7 +28,7 @@ object Dataset {
    * Datasets are labeled by observation and index.
    * @group Data Types
    */
-  final case class Label(observationId: Observation.Id, index: Int) {
+  final case class Label(observationId: Observation.Name, index: Int) {
     override def toString =
       Label.fromString.productToString(this)
   }
@@ -59,7 +59,7 @@ object Dataset {
             case n  =>
               val (a, b) = s.splitAt(n)
               b.drop(1).parseIntOption.filter(_ > 0).flatMap { n =>
-                Observation.Id.fromString(a).map(oid => Dataset.Label(oid, n))
+                Observation.Name.fromString(a).map(oid => Dataset.Label(oid, n))
               }
           },
         l => f"${l.observationId.format}-${l.index}%03d"

--- a/modules/ocs2_api/src/main/scala/ocs2/Parsers.scala
+++ b/modules/ocs2_api/src/main/scala/ocs2/Parsers.scala
@@ -110,8 +110,8 @@ object Parsers {
   val progId: PioParse[Program.Id] =
     PioParse(Program.Id.fromString.getOption)
 
-  val obsId: PioParse[Observation.Id] =
-    PioParse(Observation.Id.fromString)
+  val obsId: PioParse[Observation.Name] =
+    PioParse(Observation.Name.fromString)
 
   val datasetLabel: PioParse[Dataset.Label] =
     PioParse(Dataset.Label.fromString.getOption)

--- a/modules/server/src/main/scala/observe/server/ODBSequencesLoader.scala
+++ b/modules/server/src/main/scala/observe/server/ODBSequencesLoader.scala
@@ -120,6 +120,7 @@ object ODBSequencesLoader {
         .sequences[F]
         .modify(ss =>
           ss + (seqId -> SequenceData[F](
+            seqg.name,
             None,
             SystemOverrides.AllEnabled,
             seqg,

--- a/modules/server/src/main/scala/observe/server/ObserveEnvironment.scala
+++ b/modules/server/src/main/scala/observe/server/ObserveEnvironment.scala
@@ -12,17 +12,17 @@ import observe.server.tcs.Tcs
  * Describes the parameters for an observation
  */
 final case class ObserveEnvironment[F[_]](
-  odb:      OdbProxy[F],
-  dhs:      DhsClient[F],
-  config:   CleanConfig,
-  stepType: StepType,
-  obsId:    Observation.Id,
-  dataId:   DataId,
-  inst:     InstrumentSystem[F],
-  insSpecs: InstrumentSpecifics,
-  otherSys: List[System[F]],
-  headers:  HeaderExtraData => List[Header[F]],
-  ctx:      HeaderExtraData
+  odb:       OdbProxy[F],
+  dhs:       DhsClient[F],
+  config:    CleanConfig,
+  stepType:  StepType,
+  obsIdName: Observation.IdName,
+  dataId:    DataId,
+  inst:      InstrumentSystem[F],
+  insSpecs:  InstrumentSpecifics,
+  otherSys:  List[System[F]],
+  headers:   HeaderExtraData => List[Header[F]],
+  ctx:       HeaderExtraData
 ) {
   def getTcs: Option[Tcs[F]] = otherSys.collectFirst { case x: Tcs[F] => x }
 }

--- a/modules/server/src/main/scala/observe/server/ObserveFailure.scala
+++ b/modules/server/src/main/scala/observe/server/ObserveFailure.scala
@@ -20,7 +20,7 @@ object ObserveFailure {
 
   /** Aborted sequence * */
   // TODO Reconsider if abort should be handled as an error
-  final case class Aborted(obsId: Observation.Id) extends ObserveFailure
+  final case class Aborted(obsIdName: Observation.IdName) extends ObserveFailure
 
   /** Exception thrown while running a sequence. */
   final case class ObserveException(ex: Throwable) extends ObserveFailure
@@ -59,7 +59,7 @@ object ObserveFailure {
   final case class ObsSystemTimeout(fileId: ImageFileId) extends ObserveFailure
 
   /** Observation command timeout */
-  final case class ObsCommandTimeout(obsId: Observation.Id) extends ObserveFailure
+  final case class ObsCommandTimeout(obsIdName: Observation.IdName) extends ObserveFailure
 
   /** Failed simulation */
   case object FailedSimulation extends ObserveFailure
@@ -67,7 +67,7 @@ object ObserveFailure {
   def explain(f: ObserveFailure): String = f match {
     case UnrecognizedInstrument(name) => s"Unrecognized instrument: $name"
     case Execution(errMsg)            => s"Sequence execution failed with error: $errMsg"
-    case Aborted(obsId)               => s"Observation ${obsId.format} aborted"
+    case Aborted(obsId)               => s"Observation ${obsId.name.format} aborted"
     case ObserveException(ex)         =>
       s"Application exception: ${Option(ex.getMessage).getOrElse(ex.toString)}"
     case ObserveExceptionWhile(c, e)  =>
@@ -84,7 +84,7 @@ object ObserveFailure {
     case NullEpicsError(channel)      => s"Failed to read epics channel: $channel"
     case ObsTimeout(fileId)           => s"Observation of $fileId timed out"
     case ObsSystemTimeout(fileId)     => s"Observation of $fileId timed out on a subsystem"
-    case ObsCommandTimeout(obsId)     => s"Observation command on ${obsId.format} timed out"
+    case ObsCommandTimeout(obsId)     => s"Observation command on ${obsId.name.format} timed out"
   }
 
 }

--- a/modules/server/src/main/scala/observe/server/SeqEvent.scala
+++ b/modules/server/src/main/scala/observe/server/SeqEvent.scala
@@ -37,7 +37,7 @@ object SeqEvent {
   final case class UnloadSequence(id: Observation.Id) extends SeqEvent
   final case class AddLoadedSequence(
     instrument: Instrument,
-    sid:        Observation.Id,
+    sidName:    Observation.IdName,
     user:       UserDetails,
     clientId:   ClientId
   )                        extends SeqEvent
@@ -64,13 +64,13 @@ object SeqEvent {
   final case class UpdateQueueMoved(qid: QueueId, cid: ClientId, oid: Observation.Id, pos: Int)
       extends SeqEvent
   final case class UpdateQueueClear(qid: QueueId) extends SeqEvent
-  final case class StartSysConfig(sid: Observation.Id, stepId: StepId, res: Resource)
+  final case class StartSysConfig(sidName: Observation.IdName, stepId: StepId, res: Resource)
       extends SeqEvent
-  final case class Busy(sid: Observation.Id, cid: ClientId) extends SeqEvent
+  final case class Busy(sidName: Observation.IdName, cid: ClientId) extends SeqEvent
   final case class SequenceStart(sid: Observation.Id, stepId: StepId) extends SeqEvent
   final case class SequencesStart(startedSeqs: List[(Observation.Id, StepId)]) extends SeqEvent
   final case class ResourceBusy(
-    sid:      Observation.Id,
+    sidName:  Observation.IdName,
     stepId:   StepId,
     res:      Resource,
     clientID: ClientId

--- a/modules/server/src/main/scala/observe/server/SequenceData.scala
+++ b/modules/server/src/main/scala/observe/server/SequenceData.scala
@@ -8,9 +8,11 @@ import observe.engine.Sequence
 import observe.model.NodAndShuffleStep.PendingObserveCmd
 import observe.model.Observer
 import observe.model.SystemOverrides
+import observe.model.Observation
 
 @Lenses
 final case class SequenceData[F[_]](
+  name:          Observation.Name,
   observer:      Option[Observer],
   overrides:     SystemOverrides,
   seqGen:        SequenceGen[F],

--- a/modules/server/src/main/scala/observe/server/SequenceGen.scala
+++ b/modules/server/src/main/scala/observe/server/SequenceGen.scala
@@ -27,6 +27,7 @@ import observe.model.enum.Resource
  */
 final case class SequenceGen[F[_]](
   id:         Observation.Id,
+  name:       Observation.Name,
   title:      String,
   instrument: Instrument,
   steps:      List[SequenceGen.StepGen[F]]
@@ -49,6 +50,8 @@ final case class SequenceGen[F[_]](
       .find(_.id === c.stepId)
       .collect { case p: SequenceGen.PendingStepGen[F] => p }
       .flatMap(_.generator.resourceAtCoords(c.execIdx, c.actIdx))
+
+  def stepIndex(stepId: StepId): Option[Int] = SequenceGen.stepIndex(steps, stepId)
 }
 
 object SequenceGen {
@@ -116,5 +119,8 @@ object SequenceGen {
     override val config: CleanConfig,
     fileId:              Option[ImageFileId]
   ) extends StepGen[Nothing]
+
+  def stepIndex[F[_]](steps: List[SequenceGen.StepGen[F]], stepId: StepId): Option[Int] =
+    steps.zipWithIndex.find(_._1.id === stepId).map(_._2)
 
 }

--- a/modules/server/src/main/scala/observe/server/altair/AltairControllerEpics.scala
+++ b/modules/server/src/main/scala/observe/server/altair/AltairControllerEpics.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.FiniteDuration
 import cats._
 import cats.effect.Async
 import cats.effect.Sync
-import cats.kernel.Eq
+import cats.Eq
 import cats.syntax.all._
 import edu.gemini.epics.acm.CarStateGEM5
 import edu.gemini.observe.server.altair.LgsSfoControl

--- a/modules/server/src/main/scala/observe/server/flamingos2/Flamingos2Controller.scala
+++ b/modules/server/src/main/scala/observe/server/flamingos2/Flamingos2Controller.scala
@@ -6,7 +6,7 @@ package observe.server.flamingos2
 import scala.concurrent.duration.Duration
 
 import cats.Show
-import cats.kernel.Eq
+import cats.Eq
 import fs2.Stream
 import observe.model.dhs.ImageFileId
 import observe.model.enum.ObserveCommandResult

--- a/modules/server/src/main/scala/observe/server/gmos/GmosInstrumentActions.scala
+++ b/modules/server/src/main/scala/observe/server/gmos/GmosInstrumentActions.scala
@@ -55,7 +55,7 @@ class GmosInstrumentActions[F[_]: Temporal: Logger, A <: GmosController.SiteDepe
       case ObserveCommandResult.Stopped =>
         okTail(fileId, stopped = true, env)
       case ObserveCommandResult.Aborted =>
-        abortTail(env.odb, env.obsId, fileId)
+        abortTail(env.odb, env.obsIdName, fileId)
       case ObserveCommandResult.Paused  =>
         env.inst
           .calcObserveTime(env.config)

--- a/modules/server/src/main/scala/observe/server/keywords/GdsClient.scala
+++ b/modules/server/src/main/scala/observe/server/keywords/GdsClient.scala
@@ -90,7 +90,7 @@ object GdsClient {
         <params>
           <param>
             <value>
-              <string>{obsId.format}</string>
+              <string>{obsId.toString}</string>
             </value>
           </param>
           <param>

--- a/modules/server/src/test/scala/observe/server/ExecutionQueueSpec.scala
+++ b/modules/server/src/test/scala/observe/server/ExecutionQueueSpec.scala
@@ -4,9 +4,9 @@
 package observe.server
 
 import cats.tests.CatsSuite
-import observe.model.arb.ArbObservationId._
 import monocle.law.discipline.LensTests
 import observe.model.ObserveModelArbitraries._
+import lucuma.core.util.arb.ArbGid._
 
 final class ExecutionQueueSpec extends CatsSuite with ObserveServerArbitraries {
   checkAll("ExecutionQueue name lens", LensTests(ExecutionQueue.name))

--- a/modules/server/src/test/scala/observe/server/ObserveServerArbitraries.scala
+++ b/modules/server/src/test/scala/observe/server/ObserveServerArbitraries.scala
@@ -5,8 +5,9 @@ package observe.server
 
 import cats.effect.IO
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
 import observe.model.Observation
-import observe.model.arb.ArbObservationId._
+import observe.model.arb.ArbObservationName._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{ Arbitrary, Cogen }
 import observe.model.BatchCommandState
@@ -16,9 +17,9 @@ import observe.model.ObserveModelArbitraries._
 
 trait ObserveServerArbitraries {
 
-  implicit val selectedCoGen: Cogen[Map[Instrument, Observation.Id]] =
-    Cogen[List[(Instrument, Observation.Id)]].contramap(_.toList)
-  implicit val engineStateArb: Arbitrary[EngineState[IO]]            = Arbitrary {
+  implicit val selectedCoGen: Cogen[Map[Instrument, Observation.Name]] =
+    Cogen[List[(Instrument, Observation.Name)]].contramap(_.toList)
+  implicit val engineStateArb: Arbitrary[EngineState[IO]]              = Arbitrary {
     for {
       q <- arbitrary[ExecutionQueues]
       s <- arbitrary[Map[Instrument, Observation.Id]]

--- a/modules/server/src/test/scala/observe/server/ObserveServerLensesSpec.scala
+++ b/modules/server/src/test/scala/observe/server/ObserveServerLensesSpec.scala
@@ -6,15 +6,16 @@ package observe.server
 import cats.Eq
 import cats.tests.CatsSuite
 import edu.gemini.spModel.config2.{ Config, ItemKey }
-import observe.model.arb.ArbObservationId
-import observe.model.Observation
+import observe.model.arb.ArbObservationName
 import monocle.law.discipline.LensTests
+import lucuma.core.util.arb.ArbGid._
 import observe.model.enum.Instrument
 import observe.model.SystemOverrides
 import observe.engine
 import observe.engine.{ Action, ParallelActions }
 import SequenceGen._
 import cats.effect.IO
+import observe.common.test.observationId
 
 /**
  * Tests ObserveServer Lenses
@@ -22,7 +23,7 @@ import cats.effect.IO
 final class ObserveServerLensesSpec
     extends CatsSuite
     with ObserveServerArbitraries
-    with ArbObservationId {
+    with ArbObservationName {
 
   implicit val eqItemKeys: Eq[Map[ItemKey, AnyRef]] = Eq.fromUniversalEquals
   implicit val eqLegacyConfig: Eq[Config]           = Eq.fromUniversalEquals
@@ -58,12 +59,12 @@ final class ObserveServerLensesSpec
 
   checkAll("selected optional", LensTests(EngineState.instrumentLoadedL[IO](Instrument.Gpi)))
 
-  private val seqId = Observation.Id.unsafeFromString("GS-2018B-Q-0-1")
+  private val seqId = observationId(1)
   // Some sanity checks
   test("Support inserting new loaded sequences") {
     val base = EngineState
       .default[IO]
-      .copy(selected = Map(Instrument.F2 -> Observation.Id.unsafeFromString("GS-2018B-Q-1-1")))
+      .copy(selected = Map(Instrument.F2 -> observationId(1)))
     EngineState
       .instrumentLoadedL(Instrument.Gpi)
       .set(seqId.some)
@@ -73,9 +74,7 @@ final class ObserveServerLensesSpec
     val base = EngineState
       .default[IO]
       .copy(
-        selected = Map(Instrument.Gpi -> Observation.Id.unsafeFromString("GS-2018B-Q-1-1"),
-                       Instrument.F2  -> Observation.Id.unsafeFromString("GS-2018B-Q-2-1")
-        )
+        selected = Map(Instrument.Gpi -> observationId(1), Instrument.F2 -> observationId(2))
       )
     EngineState
       .instrumentLoadedL(Instrument.Gpi)

--- a/modules/server/src/test/scala/observe/server/QueueExecutionSpec.scala
+++ b/modules/server/src/test/scala/observe/server/QueueExecutionSpec.scala
@@ -10,6 +10,7 @@ import cats.effect.unsafe.implicits.global
 import fs2.Stream
 import observe.model.Observation
 import monocle.Monocle.index
+import observe.common.test.observationId
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.Inside.inside
@@ -37,7 +38,7 @@ class QueueExecutionSpec extends TestCommon with Matchers with NonImplicitAssert
       }).unsafeRunSync()
     }
   it should "not add sequence id if sequence does not exists" in {
-    val badObsId = Observation.Id.unsafeFromString("NonExistent-1")
+    val badObsId = observationId(101)
     val s0       = ODBSequencesLoader
       .loadSequenceEndo[IO](seqObsId1, sequence(seqObsId1), executeEngine)
       .apply(EngineState.default[IO])

--- a/modules/server/src/test/scala/observe/server/StepsViewSpec.scala
+++ b/modules/server/src/test/scala/observe/server/StepsViewSpec.scala
@@ -19,6 +19,7 @@ import observe.model.enum._
 import observe.model.enum.Resource.TCS
 import observe.server.TestCommon._
 import monocle.Monocle._
+import observe.common.test.stepId
 
 class StepsViewSpec extends TestCommon with Matchers with NonImplicitAssertions {
 
@@ -283,11 +284,11 @@ class StepsViewSpec extends TestCommon with Matchers with NonImplicitAssertions 
 
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
-      sf <- advanceOne(q, s0, observeEngine.configSystem(q, seqObsId1, 1, TCS, clientId))
+      sf <- advanceOne(q, s0, observeEngine.configSystem(q, seqObsId1, stepId(1), TCS, clientId))
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Started))(
-          s.seqGen.configActionCoord(1, TCS).map(s.seq.getSingleState)
+          s.seqGen.configActionCoord(stepId(1), TCS).map(s.seq.getSingleState)
         )
     }).unsafeRunSync()
   }
@@ -303,11 +304,11 @@ class StepsViewSpec extends TestCommon with Matchers with NonImplicitAssertions 
 
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
-      sf <- advanceOne(q, s0, observeEngine.configSystem(q, seqObsId1, 1, TCS, clientId))
+      sf <- advanceOne(q, s0, observeEngine.configSystem(q, seqObsId1, stepId(1), TCS, clientId))
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
-          s.seqGen.configActionCoord(1, TCS).map(s.seq.getSingleState)
+          s.seqGen.configActionCoord(stepId(1), TCS).map(s.seq.getSingleState)
         )
     }).unsafeRunSync()
   }
@@ -328,11 +329,14 @@ class StepsViewSpec extends TestCommon with Matchers with NonImplicitAssertions 
 
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
-      sf <- advanceOne(q, s0, observeEngine.configSystem(q, seqObsId2, 1, Instrument.F2, clientId))
+      sf <- advanceOne(q,
+                       s0,
+                       observeEngine.configSystem(q, seqObsId2, stepId(1), Instrument.F2, clientId)
+            )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
-          s.seqGen.configActionCoord(1, Instrument.F2).map(s.seq.getSingleState)
+          s.seqGen.configActionCoord(stepId(1), Instrument.F2).map(s.seq.getSingleState)
         )
     }).unsafeRunSync()
   }
@@ -353,11 +357,14 @@ class StepsViewSpec extends TestCommon with Matchers with NonImplicitAssertions 
 
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
-      sf <- advanceOne(q, s0, observeEngine.configSystem(q, seqObsId2, 1, Instrument.F2, clientId))
+      sf <- advanceOne(q,
+                       s0,
+                       observeEngine.configSystem(q, seqObsId2, stepId(1), Instrument.F2, clientId)
+            )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Started))(
-          s.seqGen.configActionCoord(1, Instrument.F2).map(s.seq.getSingleState)
+          s.seqGen.configActionCoord(stepId(1), Instrument.F2).map(s.seq.getSingleState)
         )
     }).unsafeRunSync()
   }
@@ -366,7 +373,7 @@ class StepsViewSpec extends TestCommon with Matchers with NonImplicitAssertions 
     val s0        = ODBSequencesLoader
       .loadSequenceEndo[IO](seqObsId1, sequenceNSteps(seqObsId1, 5), executeEngine)
       .apply(EngineState.default[IO])
-    val runStepId = 3
+    val runStepId = stepId(3)
 
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
@@ -400,7 +407,7 @@ class StepsViewSpec extends TestCommon with Matchers with NonImplicitAssertions 
       (EngineState.sequenceStateIndex[IO](seqObsId1) ^|-> Sequence.State.status)
         .set(SequenceState.Running.init))(EngineState.default[IO])
 
-    val runStepId = 2
+    val runStepId = stepId(2)
 
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)

--- a/modules/server/src/test/scala/observe/server/TestCommon.scala
+++ b/modules/server/src/test/scala/observe/server/TestCommon.scala
@@ -15,7 +15,7 @@ import org.typelevel.log4cats.Logger
 
 import java.util.UUID
 import edu.gemini.spModel.core.Peer
-import observe.model.Observation
+import observe.model.{ ActionType, ClientId, Observation, SystemOverrides }
 import lucuma.core.enum.Site
 import giapi.client.ghost.GhostClient
 import giapi.client.gpi.GpiClient
@@ -25,11 +25,10 @@ import observe.engine
 import observe.engine.{ Action, Result }
 import observe.engine.Result.PauseContext
 import observe.engine.Result.PartialVal
-import observe.model.{ ActionType, ClientId }
 import observe.model.enum.{ Instrument, Resource }
 import observe.model.dhs._
-import observe.model.SystemOverrides
 import observe.model.config._
+import observe.common.test._
 import observe.server.altair.{ AltairControllerSim, AltairKeywordReaderDummy }
 import observe.server.flamingos2.Flamingos2ControllerSim
 import observe.server.gcal.{ DummyGcalKeywordsReader, GcalControllerSim }
@@ -254,21 +253,22 @@ object TestCommon {
       )
     )
 
-  val seqId1: String            = "GS-2018B-Q-0-1"
-  val seqObsId1: Observation.Id = Observation.Id.unsafeFromString(seqId1)
-  val seqId2: String            = "GS-2018B-Q-0-2"
-  val seqObsId2: Observation.Id = Observation.Id.unsafeFromString(seqId2)
-  val seqId3: String            = "GS-2018B-Q-0-3"
-  val seqObsId3: Observation.Id = Observation.Id.unsafeFromString(seqId3)
-  val clientId: ClientId        = ClientId(UUID.randomUUID)
+  val seqName1: Observation.Name = Observation.Name.unsafeFromString("GS-2018B-Q-0-1")
+  val seqObsId1: Observation.Id  = observationId(1)
+  val seqName2: Observation.Name = Observation.Name.unsafeFromString("GS-2018B-Q-0-2")
+  val seqObsId2: Observation.Id  = observationId(2)
+  val seqName3: Observation.Name = Observation.Name.unsafeFromString("GS-2018B-Q-0-3")
+  val seqObsId3: Observation.Id  = observationId(3)
+  val clientId: ClientId         = ClientId(UUID.randomUUID)
 
   def sequence(id: Observation.Id): SequenceGen[IO] = SequenceGen[IO](
     id = id,
+    name = Observation.Name.unsafeFromString("GS-ENG20210713-1"),
     title = "",
     instrument = Instrument.F2,
     steps = List(
       SequenceGen.PendingStepGen(
-        id = 1,
+        id = stepId(1),
         Monoid.empty[DataId],
         config = CleanConfig.empty,
         resources = Set.empty,
@@ -283,13 +283,14 @@ object TestCommon {
 
   def sequenceNSteps(id: Observation.Id, n: Int): SequenceGen[IO] = SequenceGen[IO](
     id = id,
+    name = Observation.Name.unsafeFromString("GS-ENG20210713-1"),
     title = "",
     instrument = Instrument.F2,
     steps = List
       .range(1, n)
-      .map(
+      .map(x =>
         SequenceGen.PendingStepGen(
-          _,
+          stepId(x),
           Monoid.empty[DataId],
           config = CleanConfig.empty,
           resources = Set.empty,
@@ -308,11 +309,12 @@ object TestCommon {
     resources: Set[Resource]
   ): SequenceGen[IO] = SequenceGen[IO](
     id = id,
+    name = Observation.Name.unsafeFromString("GS-ENG20210713-1"),
     title = "",
     instrument = ins,
     steps = List(
       SequenceGen.PendingStepGen(
-        id = 1,
+        id = stepId(1),
         Monoid.empty[DataId],
         config = CleanConfig.empty,
         resources = resources,
@@ -323,7 +325,7 @@ object TestCommon {
         )
       ),
       SequenceGen.PendingStepGen(
-        id = 2,
+        id = stepId(2),
         Monoid.empty[DataId],
         config = CleanConfig.empty,
         resources = resources,

--- a/modules/web/client/src/main/scala/observe/web/client/actions.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/actions.scala
@@ -49,63 +49,71 @@ object actions {
   case object VerifyLoggedStatus       extends Action
 
   // Action to select a sequence for display
-  final case class SelectIdToDisplay(i: Instrument, id: Observation.Id, step: StepIdDisplayed)
+  final case class SelectIdToDisplay(i: Instrument, obsId: Observation.Id, step: StepIdDisplayed)
       extends Action
-  final case class SelectSequencePreview(i: Instrument, id: Observation.Id, step: StepIdDisplayed)
-      extends Action
+  final case class SelectSequencePreview(
+    i:     Instrument,
+    obsId: Observation.Id,
+    step:  StepIdDisplayed
+  )                                  extends Action
   case object SelectCalibrationQueue extends Action
   case object SelectRoot             extends Action
-  final case class ShowStepConfig(i: Instrument, id: Observation.Id, step: StepId) extends Action
-  final case class ShowPreviewStepConfig(i: Instrument, id: Observation.Id, step: StepId)
+  final case class ShowStepConfig(i: Instrument, obsId: Observation.Id, step: StepId) extends Action
+  final case class ShowPreviewStepConfig(i: Instrument, obsId: Observation.Id, step: StepId)
       extends Action
 
   // Actions related to executing sequences
 
   final case class RequestRun(s: Observation.Id, options: RunOptions) extends Action
-  final case class RequestSync(s: Observation.Id) extends Action
-  final case class RequestPause(s: Observation.Id) extends Action
+  final case class RequestSync(s: Observation.IdName) extends Action
+  final case class RequestPause(s: Observation.IdName) extends Action
   final case class RequestCancelPause(s: Observation.Id) extends Action
-  final case class RequestStop(id: Observation.Id, step: StepId) extends Action
+  final case class RequestStop(idName: Observation.IdName, step: StepId) extends Action
   final case class RequestGracefulStop(id: Observation.Id, step: StepId) extends Action
-  final case class RequestAbort(id: Observation.Id, step: StepId) extends Action
+  final case class RequestAbort(idName: Observation.IdName, step: StepId) extends Action
   final case class RequestObsPause(id: Observation.Id, step: StepId) extends Action
   final case class RequestGracefulObsPause(id: Observation.Id, step: StepId) extends Action
   final case class RequestObsResume(id: Observation.Id, step: StepId) extends Action
   case object RequestSoundEcho extends Action
 
-  final case class RequestResourceRun(id: Observation.Id, step: StepId, resource: Resource)
+  final case class RequestResourceRun(idName: Observation.IdName, step: StepId, resource: Resource)
       extends Action
-  final case class RunResource(id: Observation.Id, step: StepId, resource: Resource) extends Action
+  final case class RunResource(idName: Observation.IdName, step: StepId, resource: Resource)
+      extends Action
   final case class RunResourceRemote(id: Observation.Id, step: StepId, resource: Resource)
       extends Action
   final case class RunResourceComplete(id: Observation.Id, step: StepId, resource: Resource)
       extends Action
   final case class RunResourceFailed(
-    id:       Observation.Id,
+    id:       Observation.IdName,
     step:     StepId,
     resource: Resource,
     msg:      String
   )                                    extends Action
-  final case class RequestRunFrom(qid: Observation.Id, step: StepId, options: RunOptions)
-      extends Action
-  final case class RunFromComplete(id: Observation.Id, step: StepId) extends Action
-  final case class RunFromFailed(id: Observation.Id, step: StepId) extends Action
+  final case class RequestRunFrom(
+    qidName: Observation.IdName,
+    stepId:  StepId,
+    stepIdx: Int,
+    options: RunOptions
+  )                                    extends Action
+  final case class RunFromComplete(idName: Observation.IdName, step: StepId) extends Action
+  final case class RunFromFailed(id: Observation.IdName, stepIndex: Int) extends Action
 
   final case class RunStarted(s: Observation.Id) extends Action
-  final case class RunPaused(s: Observation.Id) extends Action
+  final case class RunPaused(s: Observation.IdName) extends Action
   final case class RunCancelPaused(s: Observation.Id) extends Action
-  final case class RunSync(s: Observation.Id) extends Action
+  final case class RunSync(s: Observation.IdName) extends Action
   final case class RunStartFailed(s: Observation.Id) extends Action
-  final case class RunPauseFailed(s: Observation.Id) extends Action
+  final case class RunPauseFailed(s: Observation.IdName) extends Action
   final case class RunCancelPauseFailed(s: Observation.Id) extends Action
-  final case class RunSyncFailed(s: Observation.Id) extends Action
+  final case class RunSyncFailed(s: Observation.IdName) extends Action
   final case class RunStop(s: Observation.Id) extends Action
   final case class RunGracefulStop(s: Observation.Id) extends Action
   final case class RunStopCompleted(s: Observation.Id) extends Action
-  final case class RunStopFailed(s: Observation.Id) extends Action
+  final case class RunStopFailed(s: Observation.IdName) extends Action
   final case class RunGracefulStopFailed(s: Observation.Id) extends Action
   final case class RunAbort(s: Observation.Id) extends Action
-  final case class RunAbortFailed(s: Observation.Id) extends Action
+  final case class RunAbortFailed(s: Observation.IdName) extends Action
   final case class RunObsPause(s: Observation.Id) extends Action
   final case class RunGracefulObsPause(s: Observation.Id) extends Action
   final case class RunObsResume(s: Observation.Id) extends Action
@@ -134,13 +142,13 @@ object actions {
   final case class RequestStopCal(qid: QueueId) extends Action
   final case class StopCalCompleted(qid: QueueId) extends Action
   final case class StopCalFailed(qid: QueueId) extends Action
-  final case class RequestRemoveSeqCal(qid: QueueId, id: Observation.Id) extends Action
+  final case class RequestRemoveSeqCal(qid: QueueId, id: Observation.IdName) extends Action
   final case class RequestAddSeqCal(qid: QueueId, id: Observation.Id) extends Action
   final case class RemoveSeqCalCompleted(qid: QueueId) extends Action
-  final case class RemoveSeqCalFailed(qid: QueueId, id: Observation.Id) extends Action
-  final case class RequestMoveCal(qid: QueueId, id: Observation.Id, pos: Int) extends Action
+  final case class RemoveSeqCalFailed(qid: QueueId, id: Observation.IdName) extends Action
+  final case class RequestMoveCal(qid: QueueId, id: Observation.IdName, pos: Int) extends Action
   final case class MoveCalCompleted(qid: QueueId) extends Action
-  final case class MoveCalFailed(qid: QueueId, id: Observation.Id) extends Action
+  final case class MoveCalFailed(qid: QueueId, id: Observation.IdName) extends Action
   final case class ClearLastQueueOp(qid: QueueId) extends Action
 
   final case class AppendToLog(l: ServerLogMessage) extends Action
@@ -158,8 +166,8 @@ object actions {
 
   final case class FlipSubystemsControls(id: Observation.Id, state: SectionVisibilityState)
       extends Action
-  final case class FlipSkipStep(id: Observation.Id, step: Step) extends Action
-  final case class FlipBreakpointStep(id: Observation.Id, step: Step) extends Action
+  final case class FlipSkipStep(id: Observation.IdName, step: Step) extends Action
+  final case class FlipBreakpointStep(id: Observation.IdName, step: Step) extends Action
 
   final case object FlipSoundOnOff extends Action
 
@@ -182,16 +190,16 @@ object actions {
   final case class UpdateSelectedStepForce(id: Observation.Id, step: StepId) extends Action
   final case class UpdateCalTableState(id: QueueId, s: TableState[CalQueueTable.TableColumn])
       extends Action
-  final case class LoadSequence(observer: Observer, i: Instrument, id: Observation.Id)
+  final case class LoadSequence(observer: Observer, i: Instrument, id: Observation.IdName)
       extends Action
-  final case class SequenceLoadFailed(id: Observation.Id) extends Action
+  final case class SequenceLoadFailed(id: Observation.IdName) extends Action
   final case class RequestFailedNotification(r: RequestFailed) extends Action
   case object CleanSequences extends Action
 
   final case class UpdateSessionFilter(f: SessionQueueFilter => SessionQueueFilter) extends Action
 
   // Used for UI debugging
-  final case class MarkStepAsRunning(s: Observation.Id, step: Int) extends Action
+  final case class MarkStepAsRunning(s: Observation.Id, step: StepId) extends Action
 
   // This, together with the whole pprint library, is shaken off when linking
   // for production, since show is not called in that case (see LoggingProcessor).
@@ -210,12 +218,12 @@ object actions {
 
   implicit val show: Show[Action] = Show.show {
     case FlipBreakpointStep(oid, st)                     =>
-      s"FlipBreakpointStep(${oid.format}, ${st.id})"
+      s"FlipBreakpointStep(${oid.name.format}, ${st.id})"
     case FlipSkipStep(oid, st)                           =>
-      s"FlipSkipStep(${oid.format}, ${st.id})"
+      s"FlipSkipStep(${oid.name.format}, ${st.id})"
     case s @ ServerMessage(u @ ObserveModelUpdate(view)) =>
       val someSteps   = view.sessionQueue.map(s =>
-        (s"id: ${s.id.format}",
+        (s"id: ${s.idName.name.format}",
          s"steps: ${s.steps.length}",
          s"state: ${s.status}",
          s.steps

--- a/modules/web/client/src/main/scala/observe/web/client/circuit/CalQueueFocus.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/circuit/CalQueueFocus.scala
@@ -6,7 +6,7 @@ package observe.web.client.circuit
 import scala.collection.immutable.SortedMap
 
 import cats._
-import cats.syntax.all._
+import cats.implicits._
 import monocle.Getter
 import monocle.Lens
 import monocle.Traversal

--- a/modules/web/client/src/main/scala/observe/web/client/circuit/CalQueueSeq.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/circuit/CalQueueSeq.scala
@@ -16,27 +16,27 @@ import observe.model.SequencesQueue
 import observe.model.enum.Instrument
 
 @Lenses
-final case class CalQueueSeq(id: Observation.Id, i: Instrument, status: SequenceState)
+final case class CalQueueSeq(idName: Observation.IdName, i: Instrument, status: SequenceState)
 
 object CalQueueSeq {
   implicit val eq: Eq[CalQueueSeq] =
-    Eq.by(x => (x.id, x.id, x.status))
+    Eq.by(x => (x.idName, x.i, x.status))
 
   def calQueueSeqG(
     id: Observation.Id
   ): Getter[SequencesQueue[SequenceView], Option[CalQueueSeq]] = {
     val seqO =
-      SequencesQueue.queueItemG[SequenceView](_.id === id) ^<-?
+      SequencesQueue.queueItemG[SequenceView](_.idName.id === id) ^<-?
         std.option.some
 
-    val sidO = seqO ^|-> SequenceView.id
+    val sidO = seqO ^|-> SequenceView.idName
     val siO  = seqO ^|-> SequenceView.metadata ^|-> SequenceMetadata.instrument
     val siS  = seqO ^|-> SequenceView.status
 
     (Getter(sidO.headOption)
       .zip(Getter(siO.headOption).zip(Getter(siS.headOption)))) >>> {
-      case (Some(id), (Some(i), Some(s))) => CalQueueSeq(id, i, s).some
-      case _                              => none
+      case (Some(idName), (Some(i), Some(s))) => CalQueueSeq(idName, i, s).some
+      case _                                  => none
     }
   }
 }

--- a/modules/web/client/src/main/scala/observe/web/client/circuit/StatusAndLoadedSequencesFocus.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/circuit/StatusAndLoadedSequencesFocus.scala
@@ -18,7 +18,7 @@ import observe.web.client.model.lenses.obsClassT
 import web.client.table._
 
 final case class SequenceInSessionQueue(
-  id:            Observation.Id,
+  idName:        Observation.IdName,
   status:        SequenceState,
   instrument:    Instrument,
   active:        Boolean,
@@ -27,14 +27,14 @@ final case class SequenceInSessionQueue(
   obsClass:      ObsClass,
   targetName:    Option[TargetName],
   runningStep:   Option[RunningStep],
-  nextStepToRun: Option[Int],
+  nextStepToRun: Option[StepId],
   inDayCalQueue: Boolean
 )
 
 object SequenceInSessionQueue {
   implicit val eq: Eq[SequenceInSessionQueue] =
     Eq.by(x =>
-      (x.id,
+      (x.idName,
        x.status,
        x.instrument,
        x.active,
@@ -54,14 +54,14 @@ object SequenceInSessionQueue {
     dayCal: List[Observation.Id]
   ): List[SequenceInSessionQueue] =
     queue.map { s =>
-      val active     = sod.idDisplayed(s.id)
-      val loaded     = sod.loadedIds.contains(s.id)
+      val active     = sod.idDisplayed(s.idName.id)
+      val loaded     = sod.loadedIds.contains(s.idName)
       val targetName = firstScienceStepTargetNameT.headOption(s)
       val obsClass   = obsClassT
         .headOption(s)
         .map(ObsClass.fromString)
         .getOrElse(ObsClass.Nighttime)
-      SequenceInSessionQueue(s.id,
+      SequenceInSessionQueue(s.idName,
                              s.status,
                              s.metadata.instrument,
                              active,
@@ -71,7 +71,7 @@ object SequenceInSessionQueue {
                              targetName,
                              s.runningStep,
                              s.nextStepToRun,
-                             dayCal.contains(s.id)
+                             dayCal.contains(s.idName.id)
       )
     }
 
@@ -105,7 +105,7 @@ object StatusAndLoadedSequencesFocus {
       StatusAndLoadedSequencesFocus(s,
                                     SequenceInSessionQueue
                                       .toSequenceInSessionQueue(sod, queue, dayCal.foldMap(_.queue))
-                                      .sortBy(_.id),
+                                      .sortBy(_.idName.name),
                                     queueTable,
                                     filter
       )

--- a/modules/web/client/src/main/scala/observe/web/client/circuit/StepsTableFocus.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/circuit/StepsTableFocus.scala
@@ -17,11 +17,11 @@ import web.client.table._
 
 @Lenses
 final case class StepsTableFocus(
-  id:                  Observation.Id,
+  idName:              Observation.IdName,
   instrument:          Instrument,
   state:               SequenceState,
   steps:               List[Step],
-  stepConfigDisplayed: Option[Int],
+  stepConfigDisplayed: Option[StepId],
   nextStepToRun:       Option[StepId],
   selectedStep:        Option[StepId],
   runningStep:         Option[RunningStep],
@@ -33,7 +33,7 @@ final case class StepsTableFocus(
 object StepsTableFocus {
   implicit val eq: Eq[StepsTableFocus] =
     Eq.by(x =>
-      (x.id,
+      (x.idName,
        x.instrument,
        x.state,
        x.steps,
@@ -56,7 +56,7 @@ object StepsTableFocus {
       case (Some(ObserveTabActive(tab, _)), ts) =>
         val sequence = tab.sequence
         StepsTableFocus(
-          sequence.id,
+          sequence.idName,
           sequence.metadata.instrument,
           sequence.status,
           sequence.steps,

--- a/modules/web/client/src/main/scala/observe/web/client/circuit/TabContentFocus.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/circuit/TabContentFocus.scala
@@ -7,7 +7,7 @@ import cats.Eq
 import cats.data.NonEmptyList
 import cats.syntax.all._
 import monocle.Getter
-import observe.model.Observation
+import observe.model.{ Observation, StepId }
 import observe.model.enum._
 import observe.web.client.model._
 
@@ -36,12 +36,12 @@ object TabContentFocus {
           SequenceTabContentFocus(
             o,
             tab.instrument,
-            tab.sequence.id,
+            tab.sequence.idName.id,
             TabSelected.fromBoolean(active),
             StepsTableTypeSelection.fromStepId(tab.stepConfigDisplayed),
             log,
             tab.isPreview,
-            tab.sequence.steps.length
+            tab.sequence.steps.map(_.id)
           )
         case (_: CalibrationQueueTab, active) =>
           CalQueueTabContentFocus(o, TabSelected.fromBoolean(active), log)
@@ -58,7 +58,7 @@ final case class SequenceTabContentFocus(
   tableType:    StepsTableTypeSelection,
   logDisplayed: SectionVisibilityState,
   isPreview:    Boolean,
-  totalSteps:   Int
+  steps:        List[StepId]
 ) extends TabContentFocus {
   val hasControls: Boolean = canOperate && !isPreview
 }
@@ -73,7 +73,7 @@ object SequenceTabContentFocus {
        x.tableType,
        x.logDisplayed,
        x.isPreview,
-       x.totalSteps
+       x.steps
       )
     )
 }

--- a/modules/web/client/src/main/scala/observe/web/client/circuit/WebSocketFocus.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/circuit/WebSocketFocus.scala
@@ -58,7 +58,7 @@ object WebSocketsFocus {
         m.sequences,
         ObserveAppRootModel.sequenceTabsT
           .getAll(m)
-          .map(t => t.obsId -> t.tabOperations.resourceRunRequested)
+          .map(t => t.obsIdName.id -> t.tabOperations.resourceRunRequested)
           .toMap,
         m.uiModel.user,
         m.uiModel.defaultObserver,
@@ -78,7 +78,7 @@ object WebSocketsFocus {
             sequencesOnDisplay = SequencesOnDisplay.sequenceTabs.modify(seqTab =>
               SequenceTab.resourcesRunOperationsL.set(
                 v.resourceRunRequested
-                  .getOrElse(seqTab.obsId, SortedMap.empty)
+                  .getOrElse(seqTab.obsIdName.id, SortedMap.empty)
               )(seqTab)
             )(m.uiModel.sequencesOnDisplay),
             defaultObserver = v.defaultObserver,

--- a/modules/web/client/src/main/scala/observe/web/client/circuit/package.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/circuit/package.scala
@@ -146,7 +146,7 @@ package circuit {
     canOperate:          Boolean,
     instrument:          Instrument,
     obsId:               Observation.Id,
-    stepConfigDisplayed: Option[Int],
+    stepConfigDisplayed: Option[StepId],
     totalSteps:          Int,
     isPreview:           Boolean
   )
@@ -166,7 +166,7 @@ package circuit {
         st.map { case ObserveTabActive(tab, _) =>
           StatusAndStepFocus(canOperate,
                              tab.sequence.metadata.instrument,
-                             tab.obsId,
+                             tab.obsIdName.id,
                              tab.stepConfigDisplayed,
                              tab.sequence.steps.length,
                              tab.isPreview
@@ -178,22 +178,22 @@ package circuit {
 
   @Lenses
   final case class ControlModel(
-    id:                  Observation.Id,
+    idName:              Observation.IdName,
     isPartiallyExecuted: Boolean,
-    nextStepToRun:       Option[Int],
+    nextStepToRunIndex:  Option[Int],
     status:              SequenceState,
     tabOperations:       TabOperations
   )
 
   object ControlModel {
     implicit val eq: Eq[ControlModel] =
-      Eq.by(x => (x.id, x.isPartiallyExecuted, x.nextStepToRun, x.status, x.tabOperations))
+      Eq.by(x => (x.idName, x.isPartiallyExecuted, x.nextStepToRunIndex, x.status, x.tabOperations))
 
     val controlModelG: Getter[SequenceTab, ControlModel] =
       Getter[SequenceTab, ControlModel](t =>
-        ControlModel(t.obsId,
+        ControlModel(t.obsIdName,
                      t.sequence.isPartiallyExecuted,
-                     t.sequence.nextStepToRun,
+                     t.sequence.nextStepToRunIndex,
                      t.sequence.status,
                      t.tabOperations
         )
@@ -230,7 +230,7 @@ package circuit {
       ClientStatus.canOperateG.zip(getter) >>> {
         case (status, Some(ObserveTabActive(tab, _))) =>
           SequenceControlFocus(tab.instrument,
-                               tab.obsId,
+                               tab.obsIdName.id,
                                tab.sequence.systemOverrides,
                                tab.subsystemControlVisible,
                                status,

--- a/modules/web/client/src/main/scala/observe/web/client/components/ObserveUI.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/ObserveUI.scala
@@ -4,7 +4,6 @@
 package observe.web.client.components
 
 import scala.scalajs.js.timers.SetTimeoutHandle
-
 import cats.effect.Sync
 import cats.syntax.all._
 import diode.ModelRO
@@ -13,8 +12,9 @@ import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.extra.router._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.Site
+import lucuma.core.util.Gid
 import monocle.Prism
-import observe.model.Observation
+import observe.model.{ Observation, StepId }
 import observe.model.enum.Instrument
 import observe.web.client.actions.NavigateSilentTo
 import observe.web.client.actions.RequestSoundEcho
@@ -29,10 +29,10 @@ import observe.web.client.model.Pages._
 object ObserveUI {
   private def pageTitle(site: Site)(p: ObservePages): String =
     p match {
-      case SequenceConfigPage(_, id, _) => s"Observe - ${id.format}"
-      case SequencePage(_, id, _)       => s"Observe - ${id.format}"
-      case PreviewPage(_, id, _)        => s"Observe - ${id.format}"
-      case PreviewConfigPage(_, id, _)  => s"Observe - ${id.format}"
+      case SequenceConfigPage(_, id, _) => s"Observe - ${id}"
+      case SequencePage(_, id, _)       => s"Observe - ${id}"
+      case PreviewPage(_, id, _)        => s"Observe - ${id}"
+      case PreviewConfigPage(_, id, _)  => s"Observe - ${id}"
       case CalibrationQueuePage         => s"Observe - Daycal queue"
       case _                            => s"Observe - ${site.shortName}"
     }
@@ -40,43 +40,41 @@ object ObserveUI {
   // Prism from url params to config page
   private def configPageP(
     instrumentNames: Map[String, Instrument]
-  ): Prism[(String, String, Int), SequenceConfigPage] =
-    Prism[(String, String, Int), SequenceConfigPage] { case (i, s, step) =>
-      (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(SequenceConfigPage(_, _, step))
+  ): Prism[(String, Observation.Id, StepId), SequenceConfigPage] =
+    Prism[(String, Observation.Id, StepId), SequenceConfigPage] { case (i, s, step) =>
+      instrumentNames.get(i).map(SequenceConfigPage(_, s, step))
     } { p =>
-      (p.instrument.show, p.obsId.format, p.step)
+      (p.instrument.show, p.obsId, p.stepId)
     }
 
   // Prism from url params to sequence page
   private def sequencePageSP(
     instrumentNames: Map[String, Instrument]
-  ): Prism[(String, String, Option[Int]), SequencePage] =
-    Prism[(String, String, Option[Int]), SequencePage] { case (i, s, st) =>
-      (instrumentNames.get(i), Observation.Id.fromString(s))
-        .mapN(SequencePage(_, _, StepIdDisplayed(st.foldMap(_ - 1))))
+  ): Prism[(String, Observation.Id, Option[StepId]), SequencePage] =
+    Prism[(String, Observation.Id, Option[StepId]), SequencePage] { case (i, s, st) =>
+      instrumentNames.get(i).map(SequencePage(_, s, StepIdDisplayed(st)))
     } { p =>
-      (p.instrument.show, p.obsId.format, (p.step.step + 1).some)
+      (p.instrument.show, p.obsId, p.stepId.step)
     }
 
   // Prism from url params to the preview page to a given step
   private def previewPageSP(
     instrumentNames: Map[String, Instrument]
-  ): Prism[(String, String, Option[Int]), PreviewPage] =
-    Prism[(String, String, Option[Int]), PreviewPage] { case (i, s, st) =>
-      (instrumentNames.get(i), Observation.Id.fromString(s))
-        .mapN(PreviewPage(_, _, StepIdDisplayed(st.foldMap(_ - 1))))
+  ): Prism[(String, Observation.Id, Option[StepId]), PreviewPage] =
+    Prism[(String, Observation.Id, Option[StepId]), PreviewPage] { case (i, s, st) =>
+      instrumentNames.get(i).map(PreviewPage(_, s, StepIdDisplayed(st)))
     } { p =>
-      (p.instrument.show, p.obsId.format, (p.step.step + 1).some)
+      (p.instrument.show, p.obsId, p.stepId.step)
     }
 
   // Prism from url params to the preview page with config
   private def previewConfigPageP(
     instrumentNames: Map[String, Instrument]
-  ): Prism[(String, String, Int), PreviewConfigPage] =
-    Prism[(String, String, Int), PreviewConfigPage] { case (i, s, step) =>
-      (instrumentNames.get(i), Observation.Id.fromString(s)).mapN(PreviewConfigPage(_, _, step))
+  ): Prism[(String, Observation.Id, StepId), PreviewConfigPage] =
+    Prism[(String, Observation.Id, StepId), PreviewConfigPage] { case (i, s, step) =>
+      instrumentNames.get(i).map(PreviewConfigPage(_, s, step))
     } { p =>
-      (p.instrument.show, p.obsId.format, p.step)
+      (p.instrument.show, p.obsId, p.stepId)
     }
 
   def router[F[_]](site: Site)(implicit F: Sync[F]): F[Router[ObservePages]] = {
@@ -85,28 +83,31 @@ object ObserveUI {
     val routerConfig = RouterConfigDsl[ObservePages].buildConfig { dsl =>
       import dsl._
 
+      def id[Id](implicit gid: Gid[Id]): StaticDsl.RouteB[Id] =
+        string(gid.regexPattern).pmapL(gid.fromString)
+
       (emptyRule
         | staticRoute(root, Root) ~> renderR(r => ObserveMain(site, r))
         | staticRoute("/soundtest", SoundTest) ~> renderR(r => ObserveMain(site, r))
         | staticRoute("/daycal", CalibrationQueuePage) ~> renderR(r => ObserveMain(site, r))
         | dynamicRouteCT(
-          ("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ "/configuration/" ~ int)
+          ("/" ~ string("[a-zA-Z0-9-]+") / id[Observation.Id] / "configuration" / id[StepId])
             .pmapL(configPageP(instrumentNames))
         ) ~> dynRenderR((_: SequenceConfigPage, r) => ObserveMain(site, r))
         | dynamicRouteCT(
-          ("/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string("[a-zA-Z0-9-]+") ~ ("/step/" ~ int).option)
+          ("/" ~ string("[a-zA-Z0-9-]+") / id[Observation.Id] / ("step" / id[StepId]).option)
             .pmapL(sequencePageSP(instrumentNames))
         ) ~> dynRenderR((_: SequencePage, r) => ObserveMain(site, r))
         | dynamicRouteCT(
-          ("/preview/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string(
-            "[a-zA-Z0-9-]+"
-          ) ~ ("/step/" ~ int).option)
+          ("/preview/" ~ string("[a-zA-Z0-9-]+") / id[Observation.Id] / ("step" / id[
+            StepId
+          ]).option)
             .pmapL(previewPageSP(instrumentNames))
         ) ~> dynRenderR((_: PreviewPage, r) => ObserveMain(site, r))
         | dynamicRouteCT(
-          ("/preview/" ~ string("[a-zA-Z0-9-]+") ~ "/" ~ string(
-            "[a-zA-Z0-9-]+"
-          ) ~ "/configuration/" ~ int)
+          ("/preview/" ~ string("[a-zA-Z0-9-]+") / id[Observation.Id] / "configuration" / id[
+            StepId
+          ])
             .pmapL(previewConfigPageP(instrumentNames))
         ) ~> dynRenderR((_: PreviewConfigPage, r) => ObserveMain(site, r)))
         .notFound(redirectToPage(Root)(SetRouteVia.HistoryPush))

--- a/modules/web/client/src/main/scala/observe/web/client/components/UserNotificationBox.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/UserNotificationBox.scala
@@ -38,17 +38,17 @@ object UserNotificationBox {
 
   def body(n: Notification): List[String] =
     n match {
-      case ResourceConflict(sid)     =>
+      case ResourceConflict(sidName)     =>
         List(
-          s"There is a conflict trying to run the sequence '${sid.format}'",
+          s"There is a conflict trying to run the sequence '${sidName.name.format}'",
           "Possibly another sequence is being executed on the same instrument"
         )
-      case InstrumentInUse(sid, ins) =>
+      case InstrumentInUse(sidName, ins) =>
         List(
-          s"Cannot select sequence '${sid.format}' for instrument '${ins.label}'",
+          s"Cannot select sequence '${sidName.name.format}' for instrument '${ins.label}'",
           "Possibly another sequence is being executed on the same instrument"
         )
-      case RequestFailed(msgs)       =>
+      case RequestFailed(msgs)           =>
         s"Request to the observe server failed:" :: msgs
 
       case SubsystemBusy(_, _, resource) =>

--- a/modules/web/client/src/main/scala/observe/web/client/components/UserPromptBox.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/UserPromptBox.scala
@@ -31,11 +31,11 @@ object UserPromptBox {
 
   def title(n: UserPrompt): String =
     n match {
-      case ChecksOverride(sid, _, checks) =>
+      case ChecksOverride(sidName, _, _, checks) =>
         if (checks.length > 1)
-          s"Warning! There are problems running sequence ${sid.format}:"
+          s"Warning! There are problems running sequence ${sidName.name.format}:"
         else
-          s"Warning! There is a problem running sequence ${sid.format}:"
+          s"Warning! There is a problem running sequence ${sidName.name.format}:"
     }
 
   def okButton(n: UserPrompt): String =
@@ -60,7 +60,7 @@ object UserPromptBox {
 
   def question(n: UserPrompt): List[String] =
     n match {
-      case ChecksOverride(_, _, checks) =>
+      case ChecksOverride(_, _, _, checks) =>
         checks.toList.flatMap {
           case TargetCheckOverride(self)                  =>
             List("Targets in sequence and TCS do not match",
@@ -96,7 +96,7 @@ object UserPromptBox {
     .render_P { p =>
       val UserPromptState(not) = p.prompt
       Confirm(
-        header = not.foldMap(title(_)),
+        header = not.foldMap(title),
         size = ModalSize.Tiny,
         content = ModalContent()(
           <.div(

--- a/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/ObservationProgressBar.scala
@@ -4,10 +4,10 @@
 package observe.web.client.components.sequence.steps
 
 import scala.math.max
-
 import cats.syntax.all._
-import japgolly.scalajs.react.Reusability
-import japgolly.scalajs.react._
+import diode.react.ReactConnectProxy
+import japgolly.scalajs.react.{ CtorType, Reusability, _ }
+import japgolly.scalajs.react.component.Scala.Component
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
 import react.semanticui.colors._
@@ -65,7 +65,7 @@ final case class ObservationProgressBar(
   paused:   Boolean
 ) extends ReactProps[ObservationProgressBar](ObservationProgressBar.component) {
 
-  protected[steps] val connect =
+  protected[steps] val connect: ReactConnectProxy[Option[ObservationProgress]] =
     ObserveCircuit.connect(ObserveCircuit.obsProgressReader[ObservationProgress](obsId, stepId))
 }
 
@@ -74,7 +74,7 @@ object ObservationProgressBar {
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
-  val component = ScalaComponent
+  val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent
     .builder[Props]("ObservationProgressDisplay")
     .stateless
     .render_P(p =>

--- a/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/RunFromStep.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/RunFromStep.scala
@@ -13,7 +13,7 @@ import react.common._
 import react.semanticui.colors._
 import react.semanticui.elements.button.Button
 import react.semanticui.modules.popup.Popup
-import observe.model.Observation
+import observe.model.{ Observation, StepId }
 import observe.web.client.actions.RequestRunFrom
 import observe.web.client.actions.RunOptions
 import observe.web.client.circuit.ObserveCircuit
@@ -26,8 +26,9 @@ import observe.web.client.reusability._
  * Contains the control to start a step from an arbitrary point
  */
 final case class RunFromStep(
-  id:               Observation.Id,
-  stepId:           Int,
+  idName:           Observation.IdName,
+  stepId:           StepId,
+  stepIdx:          Int,
   resourceInFlight: Boolean,
   runFrom:          StartFromOperation
 ) extends ReactProps[RunFromStep](RunFromStep.component)
@@ -38,12 +39,13 @@ object RunFromStep {
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   def requestRunFrom(
-    id:     Observation.Id,
-    stepId: Int
+    idName:  Observation.IdName,
+    stepId:  StepId,
+    stepIdx: Int
   ): (ReactMouseEvent, Button.ButtonProps) => Callback =
     (e: ReactMouseEvent, _: Button.ButtonProps) =>
       ObserveCircuit
-        .dispatchCB(RequestRunFrom(id, stepId, RunOptions.Normal))
+        .dispatchCB(RequestRunFrom(idName, stepId, stepIdx, RunOptions.Normal))
         .unless_(e.altKey || e.button === StepsTable.MiddleButton)
 
   protected val component = ScalaComponent
@@ -56,10 +58,10 @@ object RunFromStep {
           trigger = Button(
             icon = true,
             color = Blue,
-            onClickE = requestRunFrom(p.id, p.stepId),
+            onClickE = requestRunFrom(p.idName, p.stepId, p.stepIdx),
             disabled = p.resourceInFlight || p.runFrom === StartFromOperation.StartFromInFlight
           )(IconPlay)
-        )(s"Run from step ${p.stepId + 1}")
+        )(s"Run from step ${p.stepIdx + 1}")
       )
     }
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/StepSettings.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/StepSettings.scala
@@ -13,9 +13,7 @@ import react.common._
 import react.semanticui.SemanticSize
 import react.semanticui.colors._
 import react.semanticui.elements.label.Label
-import observe.model.Observation
-import observe.model.Step
-import observe.model.StepState
+import observe.model.{ Observation, Step, StepId, StepState }
 import observe.model.enum.Instrument
 import observe.model.enum.StepType
 import observe.web.client.components.ObserveStyles
@@ -105,7 +103,7 @@ object StepIdCell {
   private val component = ScalaComponent
     .builder[Int]("StepIdCell")
     .stateless
-    .render_P(p => <.div(s"${p + 1}"))
+    .render_P(p => <.div(s"$p"))
     .configure(Reusability.shouldComponentUpdate)
     .build
 
@@ -119,7 +117,7 @@ final case class SettingsCell(
   ctl:        RouterCtl[Pages.ObservePages],
   instrument: Instrument,
   obsId:      Observation.Id,
-  index:      Int,
+  stepId:     StepId,
   isPreview:  Boolean
 ) extends ReactProps[SettingsCell](SettingsCell.component)
 
@@ -133,9 +131,9 @@ object SettingsCell {
     .stateless
     .render_P { p =>
       val page = if (p.isPreview) {
-        Pages.PreviewConfigPage(p.instrument, p.obsId, p.index + 1)
+        Pages.PreviewConfigPage(p.instrument, p.obsId, p.stepId)
       } else {
-        Pages.SequenceConfigPage(p.instrument, p.obsId, p.index + 1)
+        Pages.SequenceConfigPage(p.instrument, p.obsId, p.stepId)
       }
       <.div(ObserveStyles.settingsCell,
             p.ctl.link(page)(

--- a/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/StepsTools.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/StepsTools.scala
@@ -9,9 +9,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
 import react.semanticui.elements.icon.IconRotated
-import observe.model.Observation
-import observe.model.Step
-import observe.model.StepState
+import observe.model.{ Observation, Step, StepId, StepState }
 import observe.web.client.components.ObserveStyles
 import observe.web.client.icons._
 import observe.web.client.model.ClientStatus
@@ -22,17 +20,17 @@ import observe.web.client.services.HtmlConstants.iconEmpty
  * Component to display an icon for the state
  */
 final case class StepToolsCell(
-  clientStatus:       ClientStatus,
-  step:               Step,
-  rowHeight:          Int,
-  secondRowHeight:    Int,
-  isPreview:          Boolean,
-  nextStepToRun:      Option[Int],
-  obsId:              Observation.Id,
-  firstRunnableIndex: Int,
-  breakPointEnterCB:  Int => Callback,
-  breakPointLeaveCB:  Int => Callback,
-  heightChangeCB:     Int => Callback
+  clientStatus:      ClientStatus,
+  step:              Step,
+  rowHeight:         Int,
+  secondRowHeight:   Int,
+  isPreview:         Boolean,
+  nextStepToRun:     Option[StepId],
+  obsIdName:         Observation.IdName,
+  canSetBreakpoint:  Boolean,
+  breakPointEnterCB: StepId => Callback,
+  breakPointLeaveCB: StepId => Callback,
+  heightChangeCB:    StepId => Callback
 ) extends ReactProps[StepToolsCell](StepToolsCell.component)
 
 object StepToolsCell {
@@ -51,8 +49,8 @@ object StepToolsCell {
           p.clientStatus,
           p.step,
           p.rowHeight,
-          p.obsId,
-          p.firstRunnableIndex,
+          p.obsIdName,
+          p.canSetBreakpoint,
           p.breakPointEnterCB,
           p.breakPointLeaveCB,
           p.heightChangeCB

--- a/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/SubsystemControlCell.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/sequence/steps/SubsystemControlCell.scala
@@ -5,14 +5,11 @@ package observe.web.client.components.sequence.steps
 
 import scala.collection.immutable.SortedMap
 import scala.scalajs.js
-
 import cats.syntax.all._
 import cats.Order._
-import japgolly.scalajs.react.Callback
-import japgolly.scalajs.react.ReactMouseEvent
-import japgolly.scalajs.react.Reusability
+import japgolly.scalajs.react.{ Callback, CtorType, ReactMouseEvent, Reusability, ScalaComponent }
 import japgolly.scalajs.react.Reusability._
-import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.component.Scala.Component
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
 import react.semanticui.SemanticColor
@@ -36,8 +33,8 @@ import observe.web.client.reusability._
  * Contains the control buttons for each subsystem
  */
 final case class SubsystemControlCell(
-  id:             Observation.Id,
-  stepId:         Int,
+  idName:         Observation.IdName,
+  stepId:         StepId,
   resources:      List[Resource],
   resourcesCalls: SortedMap[Resource, ResourceRunOperation],
   canOperate:     Boolean
@@ -49,13 +46,13 @@ object SubsystemControlCell {
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   def requestResourceCall(
-    id:     Observation.Id,
+    idName: Observation.IdName,
     stepId: StepId,
     r:      Resource
   ): (ReactMouseEvent, Button.ButtonProps) => Callback =
     (e: ReactMouseEvent, _: Button.ButtonProps) =>
       (e.preventDefaultCB *> e.stopPropagationCB *>
-        ObserveCircuit.dispatchCB(RequestResourceRun(id, stepId, r)))
+        ObserveCircuit.dispatchCB(RequestResourceRun(idName, stepId, r)))
         .unless_(e.altKey || e.button === StepsTable.MiddleButton)
 
   private val CompletedIcon = IconCheckmark.copy(
@@ -96,7 +93,7 @@ object SubsystemControlCell {
       case _                                                  => none
     }
 
-  protected val component = ScalaComponent
+  protected val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent
     .builder[Props]
     .render_P { p =>
       <.div(
@@ -118,7 +115,7 @@ object SubsystemControlCell {
               labelPosition = labeled,
               icon = buttonIcon.isDefined,
               onClickE =
-                if (p.canOperate)(requestResourceCall(p.id, p.stepId, r)) else js.undefined,
+                if (p.canOperate) requestResourceCall(p.idName, p.stepId, r) else js.undefined,
               clazz = ObserveStyles.defaultCursor.unless_(p.canOperate)
             )(buttonIcon.whenDefined(identity), r.show)
           )(s"Configure ${r.show}")

--- a/modules/web/client/src/main/scala/observe/web/client/components/tabs/CalibrationQueueTab.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/tabs/CalibrationQueueTab.scala
@@ -15,7 +15,6 @@ import react.common._
 import react.semanticui.colors._
 import react.semanticui.elements.label.Label
 import observe.model.CalibrationQueueId
-import observe.model.Observation
 import observe.model.enum.BatchExecState
 import observe.web.client.actions.RequestAddSeqCal
 import observe.web.client.circuit.ObserveCircuit
@@ -58,7 +57,7 @@ object CalibrationQueueTab {
   def addToQueueE(e: ReactDragEvent): Callback =
     e.preventDefaultCB *>
       Option(e.dataTransfer.getData("text/plain"))
-        .flatMap(Observation.Id.fromString)
+        .flatMap(lucuma.core.model.Observation.Id.parse)
         .map(id => ObserveCircuit.dispatchCB(RequestAddSeqCal(CalibrationQueueId, id)))
         .getOrEmpty
 

--- a/modules/web/client/src/main/scala/observe/web/client/components/tabs/SequenceTabContent.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/components/tabs/SequenceTabContent.scala
@@ -53,7 +53,7 @@ object SequenceTabContent {
                           p.content.instrument,
                           p.content.id,
                           s,
-                          p.content.totalSteps,
+                          p.content.steps,
                           p.content.isPreview
         ): TagMod
     }
@@ -71,7 +71,7 @@ object SequenceTabContent {
 
           focus.stepsTable
             .foldMap(_.steps)
-            .lift(i)
+            .find(_.id === i)
             .map { steps =>
               val hs = focus.configTableState
               <.div(

--- a/modules/web/client/src/main/scala/observe/web/client/handlers/NotificationsHandler.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/handlers/NotificationsHandler.scala
@@ -27,10 +27,10 @@ class NotificationsHandler[M](modelRW: ModelRW[M, UserNotificationState])
       val openBoxE     = Effect(Future(OpenUserNotificationBox))
       // Update the model as load failed
       val modelUpdateE = not match {
-        case InstrumentInUse(id, _)  => Effect(Future(SequenceLoadFailed(id)))
-        case ResourceConflict(id)    => Effect(Future(RunStartFailed(id)))
-        case SubsystemBusy(id, _, r) => Effect(Future(ClearResourceOperations(id, r)))
-        case RequestFailed(_)        => VoidEffect
+        case InstrumentInUse(idName, _)  => Effect(Future(SequenceLoadFailed(idName)))
+        case ResourceConflict(idName)    => Effect(Future(RunStartFailed(idName.id)))
+        case SubsystemBusy(idName, _, r) => Effect(Future(ClearResourceOperations(idName.id, r)))
+        case RequestFailed(_)            => VoidEffect
       }
       updatedLE(lens, openBoxE >> modelUpdateE)
   }

--- a/modules/web/client/src/main/scala/observe/web/client/handlers/ObservationsProgressStateHandler.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/handlers/ObservationsProgressStateHandler.scala
@@ -77,14 +77,14 @@ class ObservationsProgressStateHandler[M](modelRW: ModelRW[M, AllObservationsPro
   ): ActionResult[M] = {
     val upd =
       for {
-        obs     <- sequenceViewT.find(_.id === obsId)(e)
-        curSIdx <- obs.runningStep.map(_.last)
-        curStep <- sequenceStepT.find(_.id === curSIdx)(obs)
+        obs     <- sequenceViewT.find(_.idName.id === obsId)(e)
+        curSId  <- obs.runningStep.flatMap(_.id)
+        curStep <- sequenceStepT.find(_.id === curSId)(obs)
       } yield
         if (condition(curStep)) {
           updatedL(
             AllObservationsProgressState
-              .progressByIdL(obsId, curSIdx)
+              .progressByIdL(obsId, curSId)
               .set(none)
           )
         } else {
@@ -98,7 +98,7 @@ class ObservationsProgressStateHandler[M](modelRW: ModelRW[M, AllObservationsPro
     case ServerMessage(ObservationProgressEvent(e)) =>
       updatedL(
         AllObservationsProgressState
-          .progressByIdL(e.obsId, e.stepId)
+          .progressByIdL(e.obsIdName.id, e.stepId)
           .modify(_.map(adjustProgress(e)).orElse(e.some))
       )
 

--- a/modules/web/client/src/main/scala/observe/web/client/handlers/OperationsStateHandler.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/handlers/OperationsStateHandler.scala
@@ -39,34 +39,34 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
         )
       )
 
-    case RequestStop(id, _) =>
+    case RequestStop(idName, _) =>
       updatedL(
         SequencesOnDisplay.markOperations(
-          id,
+          idName.id,
           TabOperations.stopRequested.set(StopOperation.StopInFlight)
         )
       )
 
-    case RequestAbort(id, _) =>
+    case RequestAbort(idName, _) =>
       updatedL(
         SequencesOnDisplay.markOperations(
-          id,
+          idName.id,
           TabOperations.abortRequested.set(AbortOperation.AbortInFlight)
         )
       )
 
-    case RequestSync(id) =>
+    case RequestSync(idName) =>
       updatedL(
         SequencesOnDisplay.markOperations(
-          id,
+          idName.id,
           TabOperations.syncRequested.set(SyncOperation.SyncInFlight)
         )
       )
 
-    case RequestPause(id) =>
+    case RequestPause(idName) =>
       updatedL(
         SequencesOnDisplay.markOperations(
-          id,
+          idName.id,
           TabOperations.pauseRequested.set(PauseOperation.PauseInFlight)
         )
       )
@@ -79,9 +79,9 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
         )
       )
 
-    case RunFromComplete(id, _) =>
+    case RunFromComplete(idName, _) =>
       updatedL(
-        SequencesOnDisplay.markOperations(id,
+        SequencesOnDisplay.markOperations(idName.id,
                                           TabOperations.startFromRequested
                                             .set(StartFromOperation.StartFromIdle)
         )
@@ -104,10 +104,10 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
   }
 
   def handleRequestResourceRun: PartialFunction[Any, ActionResult[M]] = {
-    case RequestResourceRun(id, s, r) =>
+    case RequestResourceRun(idName, s, r) =>
       updatedL(
         SequencesOnDisplay.markOperations(
-          id,
+          idName.id,
           TabOperations
             .resourceRun(r)
             .set(ResourceRunOperation.ResourceRunInFlight(s).some)
@@ -121,9 +121,9 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
         RunResource(_, _, _) =>
       noChange
 
-    case RunSync(id) =>
+    case RunSync(idName) =>
       updatedL(
-        SequencesOnDisplay.markOperations(id,
+        SequencesOnDisplay.markOperations(idName.id,
                                           TabOperations.syncRequested.set(SyncOperation.SyncIdle)
         )
       )
@@ -155,70 +155,70 @@ class OperationsStateHandler[M](modelRW: ModelRW[M, SequencesOnDisplay])
         )
       )
 
-    case RunSyncFailed(id) =>
-      val msg          = s"Failed to sync sequence ${id.format}"
+    case RunSyncFailed(idName) =>
+      val msg          = s"Failed to sync sequence ${idName.name.format}"
       val notification = Effect(
         Future(RequestFailedNotification(RequestFailed(List(msg))))
       )
       updatedLE(SequencesOnDisplay.markOperations(
-                  id,
+                  idName.id,
                   TabOperations.syncRequested.set(SyncOperation.SyncIdle)
                 ),
                 notification
       )
 
-    case RunAbortFailed(id) =>
-      val msg          = s"Failed to abort sequence ${id.format}"
+    case RunAbortFailed(idName) =>
+      val msg          = s"Failed to abort sequence ${idName.name.format}"
       val notification = Effect(
         Future(RequestFailedNotification(RequestFailed(List(msg))))
       )
-      updatedLE(SequencesOnDisplay.resetOperations(id), notification)
+      updatedLE(SequencesOnDisplay.resetOperations(idName.id), notification)
 
-    case RunStopFailed(id) =>
-      val msg          = s"Failed to stop sequence ${id.format}"
+    case RunStopFailed(idName) =>
+      val msg          = s"Failed to stop sequence ${idName.name.format}"
       val notification = Effect(
         Future(RequestFailedNotification(RequestFailed(List(msg))))
       )
       updatedLE(SequencesOnDisplay.markOperations(
-                  id,
+                  idName.id,
                   TabOperations.stopRequested.set(StopOperation.StopIdle)
                 ),
                 notification
       )
 
-    case RunPauseFailed(id) =>
-      val msg          = s"Failed to pause sequence ${id.format}"
+    case RunPauseFailed(idName) =>
+      val msg          = s"Failed to pause sequence ${idName.name.format}"
       val notification = Effect(
         Future(RequestFailedNotification(RequestFailed(List(msg))))
       )
       updatedLE(SequencesOnDisplay.markOperations(
-                  id,
+                  idName.id,
                   TabOperations.pauseRequested.set(PauseOperation.PauseIdle)
                 ),
                 notification
       )
 
-    case RunFromFailed(id, sid) =>
-      val msg          = s"Failed to start sequence ${id.format} from step ${sid + 1}"
+    case RunFromFailed(idName, stepIndex) =>
+      val msg          = s"Failed to start sequence ${idName.name.format} from step ${stepIndex + 1}"
       val notification = Effect(
         Future(RequestFailedNotification(RequestFailed(List(msg))))
       )
       updatedLE(
         SequencesOnDisplay.markOperations(
-          id,
+          idName.id,
           TabOperations.startFromRequested.set(StartFromOperation.StartFromIdle)
         ),
         notification
       )
 
-    case RunResourceFailed(id, s, r, m) =>
-      val msg          = s"Failed to configure ${r.show} for sequence ${id.format}"
+    case RunResourceFailed(idName, s, r, m) =>
+      val msg          = s"Failed to configure ${r.show} for sequence ${idName.name.format}"
       val notification = Effect(
         Future(RequestFailedNotification(RequestFailed(List(msg, m))))
       )
       updatedLE(SequencesOnDisplay
                   .markOperations(
-                    id,
+                    idName.id,
                     TabOperations
                       .resourceRun(r)
                       .set(ResourceRunOperation.ResourceRunFailed(s).some)

--- a/modules/web/client/src/main/scala/observe/web/client/handlers/QueueOperationsHandler.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/handlers/QueueOperationsHandler.scala
@@ -80,7 +80,7 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
         CalibrationQueues.calLastOpO(qid).set(none) >>>
           CalibrationQueues.modifyOrAddSeqOps(
             qid,
-            id,
+            id.id,
             _.copy(removeSeqQueue = RemoveSeqQueue.RemoveSeqQueueInFlight)
           )
       )
@@ -134,23 +134,23 @@ class QueueOperationsHandler[M](modelRW: ModelRW[M, CalibrationQueues])
   }
 
   def handleSeqRequestResultFailed: PartialFunction[Any, ActionResult[M]] = {
-    case RemoveSeqCalFailed(qid, id) =>
-      val msg          = s"Failed to remove sequence ${id.format} from the queue"
+    case RemoveSeqCalFailed(qid, idName) =>
+      val msg          = s"Failed to remove sequence ${idName.name.format} from the queue"
       val notification = Effect(Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updatedLE(CalibrationQueues.modifyOrAddSeqOps(
                   qid,
-                  id,
+                  idName.id,
                   _.copy(removeSeqQueue = RemoveSeqQueue.RemoveSeqQueueIdle)
                 ),
                 notification
       )
 
-    case MoveCalFailed(qid, id) =>
-      val msg          = s"Failed to move sequence ${id.format} on the queue"
+    case MoveCalFailed(qid, idName) =>
+      val msg          = s"Failed to move sequence ${idName.name.format} on the queue"
       val notification = Effect(Future(RequestFailedNotification(RequestFailed(List(msg)))))
       updatedLE(
         CalibrationQueues.modifyOrAddSeqOps(qid,
-                                            id,
+                                            idName.id,
                                             _.copy(moveSeqQueue = MoveSeqQueue.MoveSeqQueueIdle)
         ),
         notification

--- a/modules/web/client/src/main/scala/observe/web/client/handlers/QueueRequestsHandler.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/handlers/QueueRequestsHandler.scala
@@ -24,7 +24,7 @@ class QueueRequestsHandler[M](modelRW: ModelRW[M, QueueRequestsFocus])
 
   def handleAddAllDayCal: PartialFunction[Any, ActionResult[M]] = {
     case RequestAllSelectedSequences(qid) =>
-      val ids = value.seqFilter.filterS(value.sequences.sessionQueue).map(_.id)
+      val ids = value.seqFilter.filterS(value.sequences.sessionQueue).map(_.idName.id)
       effectOnly(
         requestEffect(qid,
                       ObserveWebClient.addSequencesToQueue(ids, _),
@@ -102,7 +102,7 @@ class QueueRequestsHandler[M](modelRW: ModelRW[M, QueueRequestsFocus])
       .map { cid =>
         effectOnly(
           requestEffect2((qid, cid),
-                         ObserveWebClient.moveSequenceQueue(_: QueueId, oid, i, _: ClientId),
+                         ObserveWebClient.moveSequenceQueue(_: QueueId, oid.id, i, _: ClientId),
                          MoveCalCompleted.apply,
                          MoveCalFailed.apply(_: QueueId, oid)
           )

--- a/modules/web/client/src/main/scala/observe/web/client/handlers/SequenceDisplayHandler.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/handlers/SequenceDisplayHandler.scala
@@ -24,7 +24,7 @@ class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesFocus])
 
     case SelectSequencePreview(i, id, _) =>
       val seq = SequencesQueue
-        .queueItemG[SequenceView](_.id === id)
+        .queueItemG[SequenceView](_.idName.id === id)
         .get(value.sequences)
       seq
         .map { s =>
@@ -45,20 +45,20 @@ class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesFocus])
   }
 
   private def handleShowHideStep: PartialFunction[Any, ActionResult[M]] = {
-    case ShowPreviewStepConfig(i, id, step) =>
+    case ShowPreviewStepConfig(i, id, stepId) =>
       val seq = SequencesQueue
-        .queueItemG[SequenceView](_.id === id)
+        .queueItemG[SequenceView](_.idName.id === id)
         .get(value.sequences)
       seq
         .map { s =>
-          updatedL(SequencesFocus.sod.modify(_.previewSequence(i, s).showStepConfig(id, step - 1)))
+          updatedL(SequencesFocus.sod.modify(_.previewSequence(i, s).showStepConfig(id, stepId)))
         }
         .getOrElse {
           noChange
         }
 
-    case ShowStepConfig(i, id, step) =>
-      updatedL(SequencesFocus.sod.modify(_.focusOnSequence(i, id).showStepConfig(id, step - 1)))
+    case ShowStepConfig(i, id, stepId) =>
+      updatedL(SequencesFocus.sod.modify(_.focusOnSequence(i, id).showStepConfig(id, stepId)))
 
   }
 
@@ -67,8 +67,8 @@ class SequenceDisplayHandler[M](modelRW: ModelRW[M, SequencesFocus])
   }
 
   private def handleLoadFailed: PartialFunction[Any, ActionResult[M]] = {
-    case SequenceLoadFailed(id) =>
-      updatedL(SequencesFocus.sod.modify(_.loadingFailed(id)))
+    case SequenceLoadFailed(idName) =>
+      updatedL(SequencesFocus.sod.modify(_.loadingFailed(idName.id)))
   }
 
   override def handle: PartialFunction[Any, ActionResult[M]] =

--- a/modules/web/client/src/main/scala/observe/web/client/handlers/SequenceExecutionHandler.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/handlers/SequenceExecutionHandler.scala
@@ -30,32 +30,32 @@ class SequenceExecutionHandler[M](modelRW: ModelRW[M, SequencesQueue[SequenceVie
       ) + Effect.action(UpdateDefaultObserver(name))
       val updatedSequences =
         value.copy(sessionQueue = value.sessionQueue.collect {
-          case s if s.id === sequenceId =>
+          case s if s.idName.id === sequenceId =>
             s.copy(metadata = s.metadata.copy(observer = Some(name)))
-          case s                        => s
+          case s                               => s
         })
       updated(updatedSequences, updateObserverE)
   }
 
   def handleFlipSkipBreakpoint: PartialFunction[Any, ActionResult[M]] = {
-    case FlipSkipStep(sequenceId, step) =>
-      val skipRequest = Effect(ObserveWebClient.skip(sequenceId, step.flipSkip).as(NoAction))
+    case FlipSkipStep(sequenceIdName, step) =>
+      val skipRequest = Effect(ObserveWebClient.skip(sequenceIdName.id, step.flipSkip).as(NoAction))
       updated(value.copy(sessionQueue = value.sessionQueue.collect {
-                case s if s.id === sequenceId => s.flipSkipMarkAtStep(step)
-                case s                        => s
+                case s if s.idName === sequenceIdName => s.flipSkipMarkAtStep(step)
+                case s                                => s
               }),
               skipRequest
       )
 
-    case FlipBreakpointStep(sequenceId, step) =>
+    case FlipBreakpointStep(sequenceIdName, step) =>
       val breakpointRequest = Effect(
         ObserveWebClient
-          .breakpoint(sequenceId, step.flipBreakpoint)
+          .breakpoint(sequenceIdName.id, step.flipBreakpoint)
           .as(NoAction)
       )
       updated(value.copy(sessionQueue = value.sessionQueue.collect {
-                case s if s.id === sequenceId => s.flipBreakpointAtStep(step)
-                case s                        => s
+                case s if s.idName === sequenceIdName => s.flipBreakpointAtStep(step)
+                case s                                => s
               }),
               breakpointRequest
       )

--- a/modules/web/client/src/main/scala/observe/web/client/handlers/UserPromptHandler.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/handlers/UserPromptHandler.scala
@@ -25,16 +25,16 @@ class UserPromptHandler[M](modelRW: ModelRW[M, UserPromptState])
       val lens         = UserPromptState.notification.set(not.some)
       // Update the model as load failed
       val modelUpdateE = not match {
-        case UserPrompt.ChecksOverride(id, _, _) => Effect(Future(RunStartFailed(id)))
+        case UserPrompt.ChecksOverride(idName, _, _, _) => Effect(Future(RunStartFailed(idName.id)))
       }
       updatedLE(lens, modelUpdateE)
   }
 
   def handleClosePrompt: PartialFunction[Any, ActionResult[M]] = { case CloseUserPromptBox(x) =>
     val overrideEffect = this.value.notification match {
-      case Some(UserPrompt.ChecksOverride(id, stp, _)) if x === UserPromptResult.Cancel =>
-        Effect(Future(RequestRunFrom(id, stp, RunOptions.ChecksOverride)))
-      case _                                                                            => VoidEffect
+      case Some(UserPrompt.ChecksOverride(id, stp, sidx, _)) if x === UserPromptResult.Cancel =>
+        Effect(Future(RequestRunFrom(id, stp, sidx, RunOptions.ChecksOverride)))
+      case _                                                                                  => VoidEffect
     }
     updatedLE(UserPromptState.notification.set(none), overrideEffect)
   }

--- a/modules/web/client/src/main/scala/observe/web/client/model/AllObservationsProgressState.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/model/AllObservationsProgressState.scala
@@ -6,6 +6,7 @@ package observe.web.client.model
 import scala.collection.immutable.SortedMap
 
 import cats.Eq
+import cats.implicits._
 import monocle.Lens
 import monocle.Optional
 import monocle.Prism

--- a/modules/web/client/src/main/scala/observe/web/client/model/CalibrationQueues.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/model/CalibrationQueues.scala
@@ -6,7 +6,7 @@ package observe.web.client.model
 import scala.collection.immutable.SortedMap
 
 import cats._
-import cats.syntax.all._
+import cats.implicits._
 import monocle.Optional
 import monocle.Traversal
 import monocle.function.At.at

--- a/modules/web/client/src/main/scala/observe/web/client/model/Pages.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/model/Pages.scala
@@ -21,31 +21,28 @@ object Pages {
   sealed trait ObservePages extends Product with Serializable
 
   // Indicates which step to display
-  final case class StepIdDisplayed(step: Int)
+  final case class StepIdDisplayed(step: Option[StepId])
 
   object StepIdDisplayed {
     implicit val equal: Eq[StepIdDisplayed] = Eq.fromUniversalEquals
-
-    implicit val monoid: Monoid[StepIdDisplayed] = new Monoid[StepIdDisplayed] {
-      override def empty: StepIdDisplayed = StepIdDisplayed(0)
-      override def combine(x: StepIdDisplayed, y: StepIdDisplayed): StepIdDisplayed =
-        StepIdDisplayed(x.step + y.step)
-    }
   }
 
   case object Root                 extends ObservePages
   case object SoundTest            extends ObservePages
   case object CalibrationQueuePage extends ObservePages
-  final case class PreviewPage(instrument: Instrument, obsId: Observation.Id, step: StepIdDisplayed)
-      extends ObservePages
-  final case class PreviewConfigPage(instrument: Instrument, obsId: Observation.Id, step: StepId)
+  final case class PreviewPage(
+    instrument: Instrument,
+    obsId:      Observation.Id,
+    stepId:     StepIdDisplayed
+  )                                extends ObservePages
+  final case class PreviewConfigPage(instrument: Instrument, obsId: Observation.Id, stepId: StepId)
       extends ObservePages
   final case class SequencePage(
     instrument: Instrument,
     obsId:      Observation.Id,
-    step:       StepIdDisplayed
+    stepId:     StepIdDisplayed
   )                                extends ObservePages
-  final case class SequenceConfigPage(instrument: Instrument, obsId: Observation.Id, step: StepId)
+  final case class SequenceConfigPage(instrument: Instrument, obsId: Observation.Id, stepId: StepId)
       extends ObservePages
 
   implicit val equal: Eq[ObservePages] = Eq.instance {

--- a/modules/web/client/src/main/scala/observe/web/client/model/StepItems.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/model/StepItems.scala
@@ -217,7 +217,8 @@ object StepItems {
 
   final case class StepStateSummary(
     step:          Step,
-    obsId:         Observation.Id,
+    stepIdx:       Int,
+    obsIdName:     Observation.IdName,
     instrument:    Instrument,
     tabOperations: TabOperations,
     state:         SequenceState
@@ -276,7 +277,7 @@ object StepItems {
 
   object StepStateSummary {
     implicit val EqStepStateSummary: Eq[StepStateSummary] =
-      Eq.by(x => (x.step, x.obsId, x.instrument, x.tabOperations, x.state))
+      Eq.by(x => (x.step, x.stepIdx, x.obsIdName, x.instrument, x.tabOperations, x.state))
   }
 
 }

--- a/modules/web/client/src/main/scala/observe/web/client/reusability/package.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/reusability/package.scala
@@ -41,10 +41,12 @@ package object reusability {
   implicit val imageIdReuse: Reusability[ImageFileId]                               = Reusability.byEq
   implicit val stepStateReuse: Reusability[StepState]                               = Reusability.byEq
   implicit val obsIdReuse: Reusability[Observation.Id]                              = Reusability.byEq
+  implicit val obsIdNameReuse: Reusability[Observation.IdName]                      = Reusability.byEq
   implicit val observerReuse: Reusability[Observer]                                 = Reusability.byEq
   implicit val operatorReuse: Reusability[Operator]                                 = Reusability.byEq
   implicit val colorReuse: Reusability[SemanticColor]                               = Reusability.by(_.toJs)
   implicit val cssReuse: Reusability[Css]                                           = Reusability.by(_.htmlClass)
+  implicit val stepIdReuse: Reusability[StepId]                                     = Reusability.byEq
   implicit val stepConfigReuse: Reusability[StepConfig]                             = Reusability.byEq
   val stdStepReuse: Reusability[StandardStep]                                       =
     Reusability.caseClassExcept("config")

--- a/modules/web/client/src/main/scala/observe/web/client/services/ObserveWebClient.scala
+++ b/modules/web/client/src/main/scala/observe/web/client/services/ObserveWebClient.scala
@@ -61,14 +61,14 @@ object ObserveWebClient extends ModelBooPicklers {
   def toggle(id: Observation.Id, enabled: Boolean, section: String): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(id.format)}/${section}/$enabled"
+        url = s"$baseUrl/commands/${encodeURI(id.toString)}/$section/$enabled"
       )
       .void
 
-  def sync(id: Observation.Id): Future[Unit] =
+  def sync(idName: Observation.IdName): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(id.format)}/sync"
+        url = s"$baseUrl/commands/${encodeURI(idName.id.toString)}/sync"
       )
       .void
 
@@ -83,7 +83,7 @@ object ObserveWebClient extends ModelBooPicklers {
     Ajax
       .post(
         url =
-          s"$baseUrl/commands/${encodeURI(id.format)}/start/${encodeURI(clientId.self.show)}$param"
+          s"$baseUrl/commands/${encodeURI(id.toString)}/start/${encodeURI(clientId.self.show)}$param"
       )
       .void
   }
@@ -94,7 +94,8 @@ object ObserveWebClient extends ModelBooPicklers {
   def breakpoint(sid: Observation.Id, step: Step): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(sid.format)}/${step.id}/breakpoint/${step.breakpoint}"
+        url =
+          s"$baseUrl/commands/${encodeURI(sid.toString)}/${step.id}/breakpoint/${step.breakpoint}"
       )
       .void
 
@@ -104,7 +105,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def skip(sid: Observation.Id, step: Step): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(sid.format)}/${step.id}/skip/${step.skip}"
+        url = s"$baseUrl/commands/${encodeURI(sid.toString)}/${step.id}/skip/${step.skip}"
       )
       .void
 
@@ -114,7 +115,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def stop(sid: Observation.Id, step: StepId): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/stop"
+        url = s"$baseUrl/commands/${encodeURI(sid.toString)}/$step/stop"
       )
       .void
 
@@ -124,7 +125,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def stopGracefully(sid: Observation.Id, step: StepId): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/stopGracefully"
+        url = s"$baseUrl/commands/${encodeURI(sid.toString)}/$step/stopGracefully"
       )
       .void
 
@@ -134,7 +135,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def abort(sid: Observation.Id, step: StepId): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/abort"
+        url = s"$baseUrl/commands/${encodeURI(sid.toString)}/$step/abort"
       )
       .void
 
@@ -144,7 +145,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def pauseObs(sid: Observation.Id, step: StepId): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/pauseObs"
+        url = s"$baseUrl/commands/${encodeURI(sid.toString)}/$step/pauseObs"
       )
       .void
 
@@ -154,7 +155,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def pauseObsGracefully(sid: Observation.Id, step: StepId): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/pauseObsGracefully"
+        url = s"$baseUrl/commands/${encodeURI(sid.toString)}/$step/pauseObsGracefully"
       )
       .void
 
@@ -164,7 +165,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def resumeObs(sid: Observation.Id, step: StepId): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(sid.format)}/$step/resumeObs"
+        url = s"$baseUrl/commands/${encodeURI(sid.toString)}/$step/resumeObs"
       )
       .void
 
@@ -184,7 +185,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def setObserver(id: Observation.Id, name: String): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(id.format)}/observer/${encodeURI(name)}"
+        url = s"$baseUrl/commands/${encodeURI(id.toString)}/observer/${encodeURI(name)}"
       )
       .void
 
@@ -245,10 +246,10 @@ object ObserveWebClient extends ModelBooPicklers {
   /**
    * Requests the backend to pause a sequence
    */
-  def pause(id: Observation.Id): Future[Unit] =
+  def pause(idName: Observation.IdName): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(id.format)}/pause"
+        url = s"$baseUrl/commands/${encodeURI(idName.id.toString)}/pause"
       )
       .void
 
@@ -258,7 +259,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def cancelPause(id: Observation.Id): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/${encodeURI(id.format)}/cancelpause"
+        url = s"$baseUrl/commands/${encodeURI(id.toString)}/cancelpause"
       )
       .void
 
@@ -307,7 +308,7 @@ object ObserveWebClient extends ModelBooPicklers {
     Ajax
       .post(
         url = s"$baseUrl/commands/load/${encodeURI(instrument.show)}/${encodeURI(
-          id.format
+          id.toString
         )}/${encodeURI(name.value)}/${encodeURI(clientId.self.show)}"
       )
       .void
@@ -325,11 +326,11 @@ object ObserveWebClient extends ModelBooPicklers {
   /**
    * Add a sequence from a queue
    */
-  def removeSequenceFromQueue(queueId: QueueId, id: Observation.Id): Future[Unit] =
+  def removeSequenceFromQueue(queueId: QueueId, idName: Observation.IdName): Future[Unit] =
     Ajax
       .post(
         url =
-          s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/remove/${encodeURI(id.format)}"
+          s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/remove/${encodeURI(idName.id.toString)}"
       )
       .void
 
@@ -382,7 +383,7 @@ object ObserveWebClient extends ModelBooPicklers {
   def addSequenceToQueue(id: Observation.Id, qid: QueueId): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/queue/${encodeURI(qid.self.show)}/add/${encodeURI(id.format)}"
+        url = s"$baseUrl/commands/queue/${encodeURI(qid.self.show)}/add/${encodeURI(id.toString)}"
       )
       .void
 
@@ -398,7 +399,7 @@ object ObserveWebClient extends ModelBooPicklers {
     Ajax
       .post(
         url = s"$baseUrl/commands/queue/${encodeURI(queueId.self.show)}/move/${encodeURI(
-          obsId.self.format
+          obsId.toString
         )}/$pos/${encodeURI(clientId.self.show)}"
       )
       .void
@@ -407,14 +408,14 @@ object ObserveWebClient extends ModelBooPicklers {
    * Runs a reusource
    */
   def runResource(
-    pos:      Int,
-    resource: Resource,
-    obsId:    Observation.Id,
-    clientId: ClientId
+    pos:       StepId,
+    resource:  Resource,
+    obsIdName: Observation.IdName,
+    clientId:  ClientId
   ): Future[Unit] =
     Ajax
       .post(
-        url = s"$baseUrl/commands/execute/${encodeURI(obsId.self.format)}/$pos/${encodeURI(
+        url = s"$baseUrl/commands/execute/${encodeURI(obsIdName.id.toString)}/$pos/${encodeURI(
           resource.show
         )}/${encodeURI(clientId.self.show)}"
       )
@@ -424,10 +425,10 @@ object ObserveWebClient extends ModelBooPicklers {
    * Runs a step starting at
    */
   def runFrom(
-    obsId:    Observation.Id,
-    stepId:   StepId,
-    clientId: ClientId,
-    options:  RunOptions
+    obsIdName: Observation.IdName,
+    stepId:    StepId,
+    clientId:  ClientId,
+    options:   RunOptions
   ): Future[Unit] = {
     val param = options match {
       case RunOptions.Normal         => ""
@@ -436,7 +437,7 @@ object ObserveWebClient extends ModelBooPicklers {
     Ajax
       .post(
         url =
-          s"$baseUrl/commands/${encodeURI(obsId.self.format)}/$stepId/startFrom/${encodeURI(clientId.self.show)}$param"
+          s"$baseUrl/commands/${encodeURI(obsIdName.id.toString)}/$stepId/startFrom/${encodeURI(clientId.self.show)}$param"
       )
       .void
   }

--- a/modules/web/client/src/test/scala/observe/web/client/model/ModelSpec.scala
+++ b/modules/web/client/src/test/scala/observe/web/client/model/ModelSpec.scala
@@ -7,6 +7,7 @@ import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import diode.data._
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
 import monocle.law.discipline.LensTests
 import monocle.law.discipline.PrismTests
 import monocle.law.discipline.OptionalTests

--- a/modules/web/client/src/test/scala/observe/web/client/model/PagesSpec.scala
+++ b/modules/web/client/src/test/scala/observe/web/client/model/PagesSpec.scala
@@ -7,6 +7,7 @@ import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 // import monocle.law.discipline.PrismTests
 import observe.web.client.model.Pages._
+import lucuma.core.util.arb.ArbGid._
 
 /**
  * Tests Client typeclasses
@@ -15,7 +16,6 @@ final class PagesSpec extends CatsSuite with ArbitrariesWebClient {
 
   checkAll("Eq[ObservePages]", EqTests[ObservePages].eqv)
   checkAll("Eq[StepIdDisplayed]", EqTests[StepIdDisplayed].eqv)
-  checkAll("Monoid[StepIdDisplayed]", MonoidTests[StepIdDisplayed].monoid)
 
   // lenses
   // checkAll("Prism[Action, ObservePages]", PrismTests(PageActionP))

--- a/modules/web/client/src/test/scala/observe/web/client/model/SequencesOnDisplaySpec.scala
+++ b/modules/web/client/src/test/scala/observe/web/client/model/SequencesOnDisplaySpec.scala
@@ -13,10 +13,7 @@ import observe.model.SequencesQueue
 import observe.model.Conditions
 import observe.model.SequenceState
 import observe.model.SystemOverrides
-import observe.web.client.model.PreviewSequenceTab
-import observe.web.client.model.SequencesOnDisplay
-import observe.web.client.model.CalibrationQueueTab
-import observe.web.client.model.InstrumentSequenceTab
+import observe.common.test._
 
 /**
  * Tests Sequences on display class
@@ -27,12 +24,13 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
   }
   test("Support adding preview") {
     val m   = SequenceMetadata(Instrument.Gpi, None, "Obs")
-    val s   = SequenceView(Observation.Id.unsafeFromString("GS-2018A-Q-0-1"),
-                         m,
-                         SequenceState.Idle,
-                         SystemOverrides.AllEnabled,
-                         Nil,
-                         None
+    val s   = SequenceView(
+      Observation.IdName(observationId(1), Observation.Name.unsafeFromString("GS-2018A-Q-0-1")),
+      m,
+      SequenceState.Idle,
+      SystemOverrides.AllEnabled,
+      Nil,
+      None
     )
     val sod =
       SequencesOnDisplay.Empty.previewSequence(s.metadata.instrument, s)
@@ -40,12 +38,13 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
   }
   test("Focus on preview") {
     val m   = SequenceMetadata(Instrument.Gpi, None, "Obs")
-    val s   = SequenceView(Observation.Id.unsafeFromString("GS-2018A-Q-0-1"),
-                         m,
-                         SequenceState.Idle,
-                         SystemOverrides.AllEnabled,
-                         Nil,
-                         None
+    val s   = SequenceView(
+      Observation.IdName(observationId(1), Observation.Name.unsafeFromString("GS-2018A-Q-0-1")),
+      m,
+      SequenceState.Idle,
+      SystemOverrides.AllEnabled,
+      Nil,
+      None
     )
     val sod =
       SequencesOnDisplay.Empty.previewSequence(s.metadata.instrument, s)
@@ -54,12 +53,13 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
   }
   test("Unset preview") {
     val m   = SequenceMetadata(Instrument.Gpi, None, "Obs")
-    val s   = SequenceView(Observation.Id.unsafeFromString("GS-2018A-Q-0-1"),
-                         m,
-                         SequenceState.Idle,
-                         SystemOverrides.AllEnabled,
-                         Nil,
-                         None
+    val s   = SequenceView(
+      Observation.IdName(observationId(1), Observation.Name.unsafeFromString("GS-2018A-Q-0-1")),
+      m,
+      SequenceState.Idle,
+      SystemOverrides.AllEnabled,
+      Nil,
+      None
     )
     val sod =
       SequencesOnDisplay.Empty.previewSequence(s.metadata.instrument, s)
@@ -67,15 +67,22 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     sod.tabs.focus.isPreview should be(true)
   }
   test("Replace preview") {
-    val obsId = Observation.Id.unsafeFromString("GS-2018A-Q-0-1")
+    val obsId = observationId(1)
     val m     = SequenceMetadata(Instrument.Gpi, None, "Obs")
-    val s     = SequenceView(obsId, m, SequenceState.Idle, SystemOverrides.AllEnabled, Nil, None)
+    val s     =
+      SequenceView(Observation.IdName(obsId, Observation.Name.unsafeFromString("GS-2018A-Q-0-1")),
+                   m,
+                   SequenceState.Idle,
+                   SystemOverrides.AllEnabled,
+                   Nil,
+                   None
+      )
     val sod   =
       SequencesOnDisplay.Empty.previewSequence(s.metadata.instrument, s)
 
     // Remove unknown
     val sod2 =
-      sod.unsetPreviewOn(Observation.Id.unsafeFromString("GS-2018A-Q-0-3"))
+      sod.unsetPreviewOn(observationId(3))
     sod2.tabs.length should be(2)
     sod2 === sod should be(true)
 
@@ -87,8 +94,15 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
   }
   test("Update loaded") {
     val m      = SequenceMetadata(Instrument.Gpi, None, "Obs")
-    val obsId  = Observation.Id.unsafeFromString("GS-2018A-Q-0-1")
-    val s      = SequenceView(obsId, m, SequenceState.Idle, SystemOverrides.AllEnabled, Nil, None)
+    val obsId  = observationId(1)
+    val s      =
+      SequenceView(Observation.IdName(obsId, Observation.Name.unsafeFromString("GN-ENG20071001-1")),
+                   m,
+                   SequenceState.Idle,
+                   SystemOverrides.AllEnabled,
+                   Nil,
+                   None
+      )
     val queue  = List(s)
     val loaded = Map((Instrument.Gpi: Instrument) -> obsId)
     val sod    = SequencesOnDisplay.Empty.updateFromQueue(
@@ -96,29 +110,37 @@ final class SequencesOnDisplaySpec extends CatsSuite with ArbitrariesWebClient {
     )
     sod.tabs.length should be(2)
     sod.tabs.toList.lift(1) should matchPattern {
-      case Some(InstrumentSequenceTab(_, Right(s), _, _, _, _, _)) if s.id === obsId =>
+      case Some(InstrumentSequenceTab(_, Right(s), _, _, _, _, _)) if s.idName.id === obsId =>
     }
   }
   test("Add preview with loaded") {
     val m      = SequenceMetadata(Instrument.Gpi, None, "Obs")
-    val obsId  = Observation.Id.unsafeFromString("GS-2018A-Q-0-1")
-    val s      = SequenceView(obsId, m, SequenceState.Idle, SystemOverrides.AllEnabled, Nil, None)
+    val obsId  = observationId(1)
+    val s      =
+      SequenceView(Observation.IdName(obsId, Observation.Name.unsafeFromString("GS-2018A-Q-0-1")),
+                   m,
+                   SequenceState.Idle,
+                   SystemOverrides.AllEnabled,
+                   Nil,
+                   None
+      )
     val queue  = List(s)
     val loaded = Map((Instrument.Gpi: Instrument) -> obsId)
     val sod    = SequencesOnDisplay.Empty.updateFromQueue(
       SequencesQueue(loaded, Conditions.Default, None, SortedMap.empty, queue)
     )
 
-    val obs2 = Observation.Id.unsafeFromString("GS-2018A-Q-0-2")
+    val obs2 =
+      Observation.IdName(observationId(2), Observation.Name.unsafeFromString("GS-2018A-Q-0-2"))
     val s2   = SequenceView(obs2, m, SequenceState.Idle, SystemOverrides.AllEnabled, Nil, None)
     val sod2 = sod.previewSequence(s2.metadata.instrument, s2)
 
     sod2.tabs.length should be(3)
     sod2.tabs.toList.lift(2) should matchPattern {
-      case Some(InstrumentSequenceTab(_, Right(s), _, _, _, _, _)) if s.id === obsId =>
+      case Some(InstrumentSequenceTab(_, Right(s), _, _, _, _, _)) if s.idName.id === obsId =>
     }
     sod2.tabs.focus should matchPattern {
-      case PreviewSequenceTab(s, _, _, _) if s.id === obs2 =>
+      case PreviewSequenceTab(s, _, _, _) if s.idName === obs2 =>
     }
   }
 }

--- a/modules/web/client/src/test/scala/observe/web/client/model/arb/ArbTabOperations.scala
+++ b/modules/web/client/src/test/scala/observe/web/client/model/arb/ArbTabOperations.scala
@@ -6,8 +6,11 @@ package observe.web.client.model.arb
 import cats._
 import org.scalacheck.Arbitrary._
 import org.scalacheck._
+
 import scala.collection.immutable.SortedMap
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
+import observe.model.StepId
 import observe.model.enum.Resource
 import observe.web.client.model._
 import observe.web.client.model.RunOperation
@@ -16,7 +19,7 @@ trait ArbTabOperations {
   implicit val arbResourceRunOperation: Arbitrary[ResourceRunOperation] =
     Arbitrary {
       for {
-        i <- arbitrary[Int]
+        i <- arbitrary[StepId]
         s <- Gen.oneOf(ResourceRunOperation.ResourceRunIdle,
                        ResourceRunOperation.ResourceRunInFlight(i),
                        ResourceRunOperation.ResourceRunCompleted(i)
@@ -25,7 +28,7 @@ trait ArbTabOperations {
     }
 
   implicit val rroCogen: Cogen[ResourceRunOperation] =
-    Cogen[Option[Either[Int, Either[Int, Int]]]].contramap {
+    Cogen[Option[Either[StepId, Either[StepId, StepId]]]].contramap {
       case ResourceRunOperation.ResourceRunIdle         => None
       case ResourceRunOperation.ResourceRunInFlight(i)  => Some(Left(i))
       case ResourceRunOperation.ResourceRunCompleted(i) => Some(Right(Right(i)))

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/package.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/package.scala
@@ -17,8 +17,7 @@ import observe.model.enum.RunOverride
 
 trait Var {
   object ObsIdVar {
-    def unapply(str: String): Option[Observation.Id] =
-      Observation.Id.fromString(str)
+    def unapply(str: String): Option[Observation.Id] = lucuma.core.model.Observation.Id.unapply(str)
   }
 
   object ObserverVar {


### PR DESCRIPTION
Used Observation.Id and Step.Id from lucuma. Step.Id was the more complicated, because the Id before was an Int that was usually treated as an index.
I left some placeholders that will be filled when coding the actual read of the observation from the GPP ODB.