### PR TITLE
Migrate to latest version of clue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ package-lock.json
 
 # Project specific
 modules/edu.gemini.observe.web/edu.gemini.observe.web.server/log/
+
+# Nix
+.direnv/

--- a/modules/server/src/main/scala/observe/server/package.scala
+++ b/modules/server/src/main/scala/observe/server/package.scala
@@ -12,6 +12,7 @@ import cats.MonadError
 import cats.data._
 import cats.effect.IO
 import cats.syntax.all._
+import clue.ErrorPolicy
 import edu.gemini.spModel.`type`.SequenceableSpType
 import edu.gemini.spModel.guide.StandardGuideOptions
 import fs2.Stream
@@ -98,6 +99,8 @@ package server {
 }
 
 package object server    {
+  implicit val DefaultErrorPolicy: ErrorPolicy.RaiseAlways.type = ErrorPolicy.RaiseAlways
+
   implicit def geEq[D <: SequenceableSpType]: Eq[D] =
     Eq[String].contramap(_.sequenceValue())
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -93,7 +93,7 @@ object Settings {
     val lucumaSchemas = "0.33.0"
 
     // Clue
-    val clue = "0.24.1"
+    val clue = "0.30.0"
 
     val sttp = "3.8.15"
   }


### PR DESCRIPTION
The `.applyP(client)` are not necessary in Scala 3 with an implicit client, but in Scala 2 all the necessary implicit combinations do not seem to kick in. I'll check what I can do in clue to improve this, but in the meantime this works.

