### PR TITLE
Atom boundaries

### DIFF
--- a/modules/web/src/main/scala/observe/ui/ObserveStyles.scala
+++ b/modules/web/src/main/scala/observe/ui/ObserveStyles.scala
@@ -61,6 +61,7 @@ object ObserveStyles:
   val StepRowError: Css          = Css("ObserveStyles-stepRowError")
   val StepRowDone: Css           = Css("ObserveStyles-stepRowDone")
   val StepRowWithBreakpoint: Css = Css("ObserveStyles-stepRowWithBreakpoint")
+  val StepRowFirstInAtom: Css    = Css("ObserveStyles-stepRowFirstInAtom")
 
   val ObservationProgressBar: Css = Css("ObserveStyles-observationProgressBar")
   val ControlButtonStrip: Css     = Css("ObserveStyles-controlButtonStrip")

--- a/modules/web/src/main/scala/observe/ui/components/sequence/SequenceTables.scala
+++ b/modules/web/src/main/scala/observe/ui/components/sequence/SequenceTables.scala
@@ -304,6 +304,8 @@ private sealed trait SequenceTablesBuilder[S: Eq, D: Eq]:
           onColumnSizingChange = dynTable.onColumnSizingChangeHandler
         )
       .render: (props, _, resize, _, _, _, acquisitionTable, scienceTable) =>
+        println("HELLO")
+
         extension (row: SequenceTableRow)
           def isRunning: Boolean =
             props.runningStepId match
@@ -318,13 +320,21 @@ private sealed trait SequenceTablesBuilder[S: Eq, D: Eq]:
           // val index                      = row.original.index
           val stepIdOpt: Option[Step.Id] = row.original.step.id.toOption
 
+          println(step.firstOf)
+
           (props.runningStepId match
             case Some(stepId) if stepIdOpt.contains(stepId) => ObserveStyles.RowRunning
             case _                                          => ObserveStyles.RowIdle
           ) |+|
             ObserveStyles.StepRowWithBreakpoint.when_(
               stepIdOpt.exists(props.executionState.breakpoints.contains)
-            ) |+| (step match
+            ) |+|
+            ObserveStyles.StepRowFirstInAtom.when_(step.firstOf.isDefined) |+|
+            // (step match
+            //   case FutureStep(_, _, Some(_), _) =>
+            //   case _                                             => Css.Empty
+            // ) |+|
+            (step match
               // case s if s.hasError                       => ObserveStyles.StepRowError
               // case s if s.status === StepState.Running   => ObserveStyles.StepRowRunning
               // case s if s.status === StepState.Paused    => ObserveStyles.StepRowWarning

--- a/modules/web/src/main/scala/observe/ui/components/sequence/SequenceTables.scala
+++ b/modules/web/src/main/scala/observe/ui/components/sequence/SequenceTables.scala
@@ -304,8 +304,6 @@ private sealed trait SequenceTablesBuilder[S: Eq, D: Eq]:
           onColumnSizingChange = dynTable.onColumnSizingChangeHandler
         )
       .render: (props, _, resize, _, _, _, acquisitionTable, scienceTable) =>
-        println("HELLO")
-
         extension (row: SequenceTableRow)
           def isRunning: Boolean =
             props.runningStepId match
@@ -320,8 +318,6 @@ private sealed trait SequenceTablesBuilder[S: Eq, D: Eq]:
           // val index                      = row.original.index
           val stepIdOpt: Option[Step.Id] = row.original.step.id.toOption
 
-          println(step.firstOf)
-
           (props.runningStepId match
             case Some(stepId) if stepIdOpt.contains(stepId) => ObserveStyles.RowRunning
             case _                                          => ObserveStyles.RowIdle
@@ -330,10 +326,6 @@ private sealed trait SequenceTablesBuilder[S: Eq, D: Eq]:
               stepIdOpt.exists(props.executionState.breakpoints.contains)
             ) |+|
             ObserveStyles.StepRowFirstInAtom.when_(step.firstOf.isDefined) |+|
-            // (step match
-            //   case FutureStep(_, _, Some(_), _) =>
-            //   case _                                             => Css.Empty
-            // ) |+|
             (step match
               // case s if s.hasError                       => ObserveStyles.StepRowError
               // case s if s.status === StepState.Running   => ObserveStyles.StepRowRunning

--- a/modules/web/src/main/webapp/styles/observe.scss
+++ b/modules/web/src/main/webapp/styles/observe.scss
@@ -294,67 +294,9 @@ html {
   padding-right: 20px;
 }
 
-// .ObserveStyles-observationProgressRow {
-//   display: flex;
-//   flex-grow: 1;
-//   flex-direction: column;
-//   width: 100%;
-//   padding-right: 7px;
-//   margin-bottom: 1em;
-
-//   // & .bar {
-//   //   height: 100% !important;
-//   // }
-
-//   // & .label {
-//   //   text-align: center;
-//   //   width: 100%;
-//   // }
-// }
-
-// @mixin borderRight {
-//   border-right-style: solid;
-//   border-right-color: var(--surface-border);
-//   border-right-width: 1px;
-// }
-
-// @mixin borderLeft {
-//   border-left-style: solid;
-//   border-left-color: var(--surface-border);
-//   border-left-width: 1px;
-// }
-
-// @mixin borderTop {
-//   border-top-style: solid;
-//   border-top-color: var(--surface-border);
-//   border-top-width: 1px;
-
-//   .ObserveStyles-stepRowFirstInAtom {
-//     border-top-width: 5px;
-//   }
-// }
-
-// @mixin borderBottom {
-//   border-bottom-style: solid;
-//   border-bottom-color: var(--surface-border);
-//   border-bottom-width: 1px;
-
-//   .ObserveStyles-stepRowWithBreakpoint {
-//     border-bottom-color: var(--red-500);
-//   }
-// }
-
-// @mixin borderAll {
-//   @include borderRight();
-//   @include borderLeft();
-//   @include borderTop();
-//   @include borderBottom();
-// }
-
 .pl-react-table.p-datatable {
   &.ObserveStyles-observeTable {
     width: 100%;
-    // border-collapse: collapse;
 
     thead {
       z-index: 1;
@@ -366,9 +308,6 @@ html {
     }
 
     tr>td {
-      // @include borderLeft;
-      // @include borderTop;
-      // @include borderBottom;
       min-width: 20px;
       font-size: small;
       text-overflow: ellipsis;
@@ -391,16 +330,6 @@ html {
   }
 
   &.ObserveStyles-stepTable {
-    // table-layout: auto;
-
-    tr>td {
-      // max-height: 40px !important;
-      padding-top: 1px;
-      padding-bottom  : 1px;
-      // border: none;
-
-      // border-bottom-width: 2px;
-    }
 
     tr.ObserveStyles-stepRowDone {
       pointer-events: none;
@@ -408,81 +337,261 @@ html {
       background: var(--disabled-row-background);
     }
 
+    $separator-color: var(--gray-200);
+    $hover-color: var(--green-500);
+    $atom-color: var(--gray-400);
+    $breakpoint-color: var(--red-500);
+
     // ALL COMBINATIONS MUST BE EXPLICIT
+    @function row-line($height, $color) {
+      @return inset 0 $height $color;
+    }
+
+    @function top-line($color) {
+      @return inset 0 1px $color;
+    }
+
+    @function top-thick-line($color) {
+      @return inset 0 2px $color;
+    }
+
+    @function bottom-line($color) {
+      @return inset 0 -1px $color;
+    }
+
+    @function bottom-thick-line($color) {
+      @return inset 0 -2px $color;
+    }
+
+    @function top-double-line($outer, $inner) {
+      // Thinner lines must be first since they have precedence.
+      @return top-line($outer), top-thick-line($inner);
+    }
+
+    @function bottom-double-line($outer, $inner) {
+      // Thinner lines must be first since they have precedence.
+      @return bottom-line($outer), bottom-thick-line($inner);
+    }
+
 
     tr {
       box-shadow: none !important;
       
       td {
+        padding-top: 1px;
+        padding-bottom: 1px;
+        // We have some row separators which are split betwen the previous and next row.
+        // This is easier to deal with with border 0 and box-shadows.
         border-bottom: 0;
       }
 
+      // Regular row.
+      // -----------------------------
+      //
+      //
+      // ROW CONTENTS
+      //
+      //
+      // SEPARATOR-SEPARATOR-SEPARATOR
       td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-        box-shadow: inset 0 -1px var(--gray-200) !important;
+        box-shadow: bottom-line($separator-color) !important;
       }
 
       &:hover {
+        // Regular hovering row.
+        // HOVER-HOVER-HOVER-HOVER-HOVER
+        //
+        //
+        // ROW CONTENTS
+        //
+        //
+        // HOVER-HOVER-HOVER-HOVER-HOVER
         td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-          box-shadow: inset 0 1px 0 0 var(--green-500),
-            inset 0 -1px var(--green-500) !important;
+          box-shadow: top-line($hover-color), bottom-line($hover-color) !important;
         }
       }
     }
 
     tr.ObserveStyles-stepRowFirstInAtom:not(:first-of-type) {
+      // First-in-atom row.
+      // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
+      //
+      //
+      // ROW CONTENTS
+      //
+      //
+      // SEPARATOR-SEPARATOR-SEPARATOR
       td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-        box-shadow: inset 0 2px var(--gray-400) !important;
+        box-shadow: top-line($atom-color), bottom-line($separator-color) !important;
+      }
+
+      &:hover {
+        // First-in-atom hovering row.
+        // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
+        // HOVER-HOVER-HOVER-HOVER-HOVER
+        //
+        // ROW CONTENTS
+        //
+        //
+        // HOVER-HOVER-HOVER-HOVER-HOVER
+        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+          box-shadow: top-double-line($atom-color, $hover-color), bottom-line($hover-color) !important;
+        }
+      }
+
+      &:has(+ .ObserveStyles-stepRowWithBreakpoint) {
+        // First-in-atom row with next row with breakpoint.
+        // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
+        //
+        //
+        // ROW CONTENTS
+        //
+        //
+        // BREAKPOINT-BREAKPOINT-BREAKPO
+        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+          box-shadow: top-line($atom-color), bottom-line($breakpoint-color) !important;
+        }
+
+        &:hover {
+          // First-in-atom hovering row with next row with breakpoint.
+          // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
+          // HOVER-HOVER-HOVER-HOVER-HOVER
+          //
+          // ROW CONTENTS
+          //
+          // HOVER-HOVER-HOVER-HOVER-HOVER
+          // BREAKPOINT-BREAKPOINT-BREAKPO
+          td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+            box-shadow: top-double-line($atom-color, $hover-color), bottom-double-line($breakpoint-color, $hover-color) !important;
+          }
+        }
+      }
+    }
+
+    tr:has(+ .ObserveStyles-stepRowFirstInAtom) {
+      // Regular row with next row first-in-atom.
+      // -----------------------------
+      //
+      //
+      // ROW CONTENTS
+      //
+      //
+      // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
+      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+        box-shadow: bottom-line($atom-color) !important;
+      }
+
+      &:hover {
+        // Regular hovering row with next row first-in-atom.
+        // HOVER-HOVER-HOVER-HOVER-HOVER
+        //
+        //
+        // ROW CONTENTS
+        //
+        // HOVER-HOVER-HOVER-HOVER-HOVER
+        // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
+        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+          box-shadow: top-line($hover-color), bottom-double-line($atom-color, $hover-color) !important;
+        }
       }
     }
 
     tr:has(+ .ObserveStyles-stepRowWithBreakpoint) {
+      // Regular row with next row with breakpoint.
+      // -----------------------------
+      //
+      //
+      // ROW CONTENTS
+      //
+      //
+      // BREAKPOINT-BREAKPOINT-BREAKPO
       td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-        box-shadow: inset 0 -1px var(--red-500) !important;
+        box-shadow: bottom-line($breakpoint-color) !important;
       }
 
       &:hover {
+        // Regular hovering row with next row with breakpoint.
+        // HOVER-HOVER-HOVER-HOVER-HOV
+        //
+        //
+        // ROW CONTENTS
+        //
+        // HOVER-HOVER-HOVER-HOVER-HOV
+        // BREAKPOINT-BREAKPOINT-BREAK
         td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-          box-shadow: inset 0 1px 0 0 var(--green-500),
-            inset 0 -1px var(--red-500),
-            inset 0 -2px var(--green-500) !important;
+          box-shadow: top-line($hover-color), bottom-double-line($breakpoint-color, $hover-color) !important;
         }
       }
     }
 
-    tr.ObserveStyles-stepRowWithBreakpoint:not(ObserveStyles-stepRowFirstInAtom) {
+    tr.ObserveStyles-stepRowWithBreakpoint, tr.ObserveStyles-stepRowWithBreakpoint:not(:first-of-type) {
+      // Breakpoint row.
+      // BREAKPOINT-BREAKPOINT-BREAKPO
+      //
+      //
+      // ROW CONTENTS
+      //
+      // 
+      // SEPARATOR-SEPARATOR-SEPARATOR
       td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-        box-shadow: inset 0 1px var(--red-500),
-          inset 0 -1px var(--gray-200) !important;
+        box-shadow: top-line($breakpoint-color), bottom-line($separator-color) !important;
       }
 
-      &:has(+ .ObserveStyles-stepRowWithBreakpoint) {
+      &:has(+ .ObserveStyles-stepRowWithBreakpoint), &:has(+ .ObserveStyles-stepRowWithBreakpoint):has(+ .ObserveStyles-stepRowFirstInAtom){
+        // Breakpoint row with next row with breakpoint.
+        // BREAKPOINT-BREAKPOINT-BREAKPO
+        //
+        //
+        // ROW CONTENTS
+        //
+        // 
+        // BREAKPOINT-BREAKPOINT-BREAKPO
         td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-          box-shadow: inset 0 1px var(--red-500),
-            inset 0 -1px var(--red-500) !important;
+          box-shadow: top-line($breakpoint-color), bottom-line($breakpoint-color) !important;
+        }
+      }
+
+      &:has(+ .ObserveStyles-stepRowFirstInAtom) {
+        // Breakpoint row with next row first-in-atom.
+        // -----------------------------
+        // BREAKPOINT-BREAKPOINT-BREAKPO
+        //
+        // ROW CONTENTS
+        //
+        //
+        // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
+        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+          box-shadow: top-line($breakpoint-color), bottom-line($atom-color) !important;
         }
       }
 
       &:hover {
+        // Breakpoint hovering row.
+        // BREAKPOINT-BREAKPOINT-BREAKPO
+        // HOVER-HOVER-HOVER-HOVER-HOVER
+        //
+        // ROW CONTENTS
+        //
+        // 
+        // HOVER-HOVER-HOVER-HOVER-HOVER
         td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-          box-shadow: inset 0 1px var(--red-500),
-            inset 0 2px 0 0 var(--green-500),
-            inset 0 -1px var(--green-500) !important;
+          box-shadow: top-double-line($breakpoint-color, $hover-color), bottom-line($hover-color) !important;
         }
 
         &:has(+ .ObserveStyles-stepRowWithBreakpoint) {
+          // Breakpoint hovering row with next row with breakpoint.
+          // BREAKPOINT-BREAKPOINT-BREAKPO
+          // HOVER-HOVER-HOVER-HOVER-HOVER
+          //
+          // ROW CONTENTS
+          //
+          // HOVER-HOVER-HOVER-HOVER-HOVER
+          // BREAKPOINT-BREAKPOINT-BREAKPO
           td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-            box-shadow: inset 0 1px var(--red-500),
-              inset 0 2px 0 0 var(--green-500),
-              inset 0 -1px var(--red-500),
-              inset 0 -2px 0 0 var(--green-500) !important;
+            box-shadow: top-double-line($breakpoint-color, $hover-color), bottom-double-line($breakpoint-color, $hover-color) !important;
           }
         }
       }
-
-
-      
-
-
 
       // padding-top: 4px;
       // background-image: linear-gradient(to right, #a5673f 0px, #a5673f);
@@ -740,17 +849,17 @@ html {
   height: 100%;
 }
 
-// .ObserveStyles-iconCell {
-//   justify-content: center;
-//   height: 100%;
-//   width: 100%;
-//   display: flex;
-//   align-items: center;
+.ObserveStyles-iconCell {
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
 
-//   &.ObserveStyles-skippedIconCell {
-//     padding-right: 10px;
-//   }
-// }
+  &.ObserveStyles-skippedIconCell {
+    padding-right: 10px;
+  }
+}
 
 .ObserveStyles-breakpointHandle {
   cursor: pointer;

--- a/modules/web/src/main/webapp/styles/observe.scss
+++ b/modules/web/src/main/webapp/styles/observe.scss
@@ -412,36 +412,36 @@ html {
 
     tr {
       box-shadow: none !important;
-
+      
       td {
         border-bottom: 0;
+      }
+
+      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
         box-shadow: inset 0 -1px var(--gray-200) !important;
       }
 
       &:hover {
-        td {
+        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
           box-shadow: inset 0 1px 0 0 var(--green-500),
             inset 0 -1px var(--green-500) !important;
         }
       }
     }
 
-    tr.ObserveStyles-stepRowFirstInAtom {
-      td:not(.ObserveStyles-breakpointTableCell) {
-        
-        // border-image:linear-gradient(to right,blue 2px,transparent 0) 2;
-        // border-top-width: 4px;
-        // box-sizing: border-box;
+    tr.ObserveStyles-stepRowFirstInAtom:not(:first-of-type) {
+      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+        box-shadow: inset 0 2px var(--gray-400) !important;
       }
     }
 
     tr:has(+ .ObserveStyles-stepRowWithBreakpoint) {
-      td:not(.ObserveStyles-breakpointTableCell) {
+      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
         box-shadow: inset 0 -1px var(--red-500) !important;
       }
 
       &:hover {
-        td:not(.ObserveStyles-breakpointTableCell) {
+        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
           box-shadow: inset 0 1px 0 0 var(--green-500),
             inset 0 -1px var(--red-500),
             inset 0 -2px var(--green-500) !important;
@@ -450,27 +450,27 @@ html {
     }
 
     tr.ObserveStyles-stepRowWithBreakpoint:not(ObserveStyles-stepRowFirstInAtom) {
-      td:not(.ObserveStyles-breakpointTableCell) {
+      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
         box-shadow: inset 0 1px var(--red-500),
           inset 0 -1px var(--gray-200) !important;
       }
 
       &:has(+ .ObserveStyles-stepRowWithBreakpoint) {
-        td:not(.ObserveStyles-breakpointTableCell) {
+        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
           box-shadow: inset 0 1px var(--red-500),
             inset 0 -1px var(--red-500) !important;
         }
       }
 
       &:hover {
-        td:not(.ObserveStyles-breakpointTableCell) {
+        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
           box-shadow: inset 0 1px var(--red-500),
             inset 0 2px 0 0 var(--green-500),
             inset 0 -1px var(--green-500) !important;
         }
 
         &:has(+ .ObserveStyles-stepRowWithBreakpoint) {
-          td:not(.ObserveStyles-breakpointTableCell) {
+          td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
             box-shadow: inset 0 1px var(--red-500),
               inset 0 2px 0 0 var(--green-500),
               inset 0 -1px var(--red-500),

--- a/modules/web/src/main/webapp/styles/observe.scss
+++ b/modules/web/src/main/webapp/styles/observe.scss
@@ -312,45 +312,49 @@ html {
 //   // }
 // }
 
-@mixin borderRight {
-  border-right-style: solid;
-  border-right-color: var(--surface-border);
-  border-right-width: 1px;
-}
+// @mixin borderRight {
+//   border-right-style: solid;
+//   border-right-color: var(--surface-border);
+//   border-right-width: 1px;
+// }
 
-@mixin borderLeft {
-  border-left-style: solid;
-  border-left-color: var(--surface-border);
-  border-left-width: 1px;
-}
+// @mixin borderLeft {
+//   border-left-style: solid;
+//   border-left-color: var(--surface-border);
+//   border-left-width: 1px;
+// }
 
-@mixin borderTop {
-  border-top-style: solid;
-  border-top-color: var(--surface-border);
-  border-top-width: 1px;
-}
+// @mixin borderTop {
+//   border-top-style: solid;
+//   border-top-color: var(--surface-border);
+//   border-top-width: 1px;
 
-@mixin borderBottom {
-  border-bottom-style: solid;
-  border-bottom-color: var(--surface-border);
-  border-bottom-width: 1px;
+//   .ObserveStyles-stepRowFirstInAtom {
+//     border-top-width: 5px;
+//   }
+// }
 
-  .ObserveStyles-stepRowWithBreakpoint {
-    border-bottom-color: var(--red-500);
-  }
-}
+// @mixin borderBottom {
+//   border-bottom-style: solid;
+//   border-bottom-color: var(--surface-border);
+//   border-bottom-width: 1px;
 
-@mixin borderAll {
-  @include borderRight();
-  @include borderLeft();
-  @include borderTop();
-  @include borderBottom();
-}
+//   .ObserveStyles-stepRowWithBreakpoint {
+//     border-bottom-color: var(--red-500);
+//   }
+// }
+
+// @mixin borderAll {
+//   @include borderRight();
+//   @include borderLeft();
+//   @include borderTop();
+//   @include borderBottom();
+// }
 
 .pl-react-table.p-datatable {
   &.ObserveStyles-observeTable {
     width: 100%;
-    border-collapse: collapse;
+    // border-collapse: collapse;
 
     thead {
       z-index: 1;
@@ -362,8 +366,9 @@ html {
     }
 
     tr>td {
-      @include borderLeft;
-      @include borderBottom;
+      // @include borderLeft;
+      // @include borderTop;
+      // @include borderBottom;
       min-width: 20px;
       font-size: small;
       text-overflow: ellipsis;
@@ -390,9 +395,11 @@ html {
 
     tr>td {
       // max-height: 40px !important;
-      padding-top: 0;
-      padding-bottom: 0;
+      padding-top: 1px;
+      padding-bottom  : 1px;
       // border: none;
+
+      // border-bottom-width: 2px;
     }
 
     tr.ObserveStyles-stepRowDone {
@@ -401,20 +408,79 @@ html {
       background: var(--disabled-row-background);
     }
 
-    @mixin stepRowWithBreakpointCell {
-      border-top-color: var(--red-500);
-      border-top-width: 2px;
-      // transform: translate(0, -1px);
-    }
+    // ALL COMBINATIONS MUST BE EXPLICIT
 
-    tr.ObserveStyles-stepRowWithBreakpoint {
-      td:not(.ObserveStyles-skipTableCell):not(.ObserveStyles-breakpointTableCell) {
-        @include stepRowWithBreakpointCell;
+    tr {
+      box-shadow: none !important;
+
+      td {
+        border-bottom: 0;
+        box-shadow: inset 0 -1px var(--gray-200) !important;
       }
 
-      // td .ObserveStyles-iconCell {
-      //   @include stepRowWithBreakpointCell;
-      // }
+      &:hover {
+        td {
+          box-shadow: inset 0 1px 0 0 var(--green-500),
+            inset 0 -1px var(--green-500) !important;
+        }
+      }
+    }
+
+    tr.ObserveStyles-stepRowFirstInAtom {
+      td:not(.ObserveStyles-breakpointTableCell) {
+        
+        // border-image:linear-gradient(to right,blue 2px,transparent 0) 2;
+        // border-top-width: 4px;
+        // box-sizing: border-box;
+      }
+    }
+
+    tr:has(+ .ObserveStyles-stepRowWithBreakpoint) {
+      td:not(.ObserveStyles-breakpointTableCell) {
+        box-shadow: inset 0 -1px var(--red-500) !important;
+      }
+
+      &:hover {
+        td:not(.ObserveStyles-breakpointTableCell) {
+          box-shadow: inset 0 1px 0 0 var(--green-500),
+            inset 0 -1px var(--red-500),
+            inset 0 -2px var(--green-500) !important;
+        }
+      }
+    }
+
+    tr.ObserveStyles-stepRowWithBreakpoint:not(ObserveStyles-stepRowFirstInAtom) {
+      td:not(.ObserveStyles-breakpointTableCell) {
+        box-shadow: inset 0 1px var(--red-500),
+          inset 0 -1px var(--gray-200) !important;
+      }
+
+      &:has(+ .ObserveStyles-stepRowWithBreakpoint) {
+        td:not(.ObserveStyles-breakpointTableCell) {
+          box-shadow: inset 0 1px var(--red-500),
+            inset 0 -1px var(--red-500) !important;
+        }
+      }
+
+      &:hover {
+        td:not(.ObserveStyles-breakpointTableCell) {
+          box-shadow: inset 0 1px var(--red-500),
+            inset 0 2px 0 0 var(--green-500),
+            inset 0 -1px var(--green-500) !important;
+        }
+
+        &:has(+ .ObserveStyles-stepRowWithBreakpoint) {
+          td:not(.ObserveStyles-breakpointTableCell) {
+            box-shadow: inset 0 1px var(--red-500),
+              inset 0 2px 0 0 var(--green-500),
+              inset 0 -1px var(--red-500),
+              inset 0 -2px 0 0 var(--green-500) !important;
+          }
+        }
+      }
+
+
+      
 
 
 
@@ -674,17 +740,17 @@ html {
   height: 100%;
 }
 
-.ObserveStyles-iconCell {
-  justify-content: center;
-  height: 100%;
-  width: 100%;
-  display: flex;
-  align-items: center;
+// .ObserveStyles-iconCell {
+//   justify-content: center;
+//   height: 100%;
+//   width: 100%;
+//   display: flex;
+//   align-items: center;
 
-  &.ObserveStyles-skippedIconCell {
-    padding-right: 10px;
-  }
-}
+//   &.ObserveStyles-skippedIconCell {
+//     padding-right: 10px;
+//   }
+// }
 
 .ObserveStyles-breakpointHandle {
   cursor: pointer;

--- a/modules/web/vite.config.js
+++ b/modules/web/vite.config.js
@@ -50,7 +50,7 @@ const pathExists = async (path) => {
 
 // https://vitejs.dev/config/
 export default defineConfig(async ({ mode }) => {
-  const scalaClassesDir = path.resolve(__dirname, 'target/scala-3.3.1-RC6');
+  const scalaClassesDir = path.resolve(__dirname, 'target/scala-3.3.1');
   const isProduction = mode == 'production';
   const sjs = isProduction
     ? path.resolve(scalaClassesDir, 'observe_web_client-opt')


### PR DESCRIPTION
This implied a general table row separator rework, where we stop using `border` in favor of `box-shadow` to paint row separators, hover indicator, breakpoints and atom boundaries.