### PR TITLE
Restored the watchdog of the main stream process.

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -841,14 +841,15 @@ object ObserveEngine {
     }
 
     override def eventStream: Stream[F, ObserveEvent] =
-      stream(EngineState.default[F]).flatMap(x => Stream.eval(notifyODB(x).attempt)).flatMap {
-        case Right((ev, qState)) =>
-          val sequences = List(qState.selected.gmosNorth, qState.selected.gmosSouth).flattenOption
-            .map(viewSequence)
-          toObserveEvent[F](ev, qState)
-        case Left(x)             =>
-          Stream.eval(Logger[F].error(x)("Error notifying the ODB").as(NullEvent))
-      }
+      Stream.eval(executeEngine.offer(Event.getState(_ => heartbeatStream.some)).as(NullEvent)) ++
+        stream(EngineState.default[F]).flatMap(x => Stream.eval(notifyODB(x).attempt)).flatMap {
+          case Right((ev, qState)) =>
+            val sequences = List(qState.selected.gmosNorth, qState.selected.gmosSouth).flattenOption
+              .map(viewSequence)
+            toObserveEvent[F](ev, qState)
+          case Left(x)             =>
+            Stream.eval(Logger[F].error(x)("Error notifying the ODB").as(NullEvent))
+        }
 
     override def stream(
       s0: EngineState[F]

--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -843,10 +843,7 @@ object ObserveEngine {
     override def eventStream: Stream[F, ObserveEvent] =
       Stream.eval(executeEngine.offer(Event.getState(_ => heartbeatStream.some)).as(NullEvent)) ++
         stream(EngineState.default[F]).flatMap(x => Stream.eval(notifyODB(x).attempt)).flatMap {
-          case Right((ev, qState)) =>
-            val sequences = List(qState.selected.gmosNorth, qState.selected.gmosSouth).flattenOption
-              .map(viewSequence)
-            toObserveEvent[F](ev, qState)
+          case Right((ev, qState)) => toObserveEvent[F](ev, qState)
           case Left(x)             =>
             Stream.eval(Logger[F].error(x)("Error notifying the ODB").as(NullEvent))
         }


### PR DESCRIPTION
The implementation is a bit of a hack. It uses an existing event to join the heartbeat stream with the main event stream.