### PR TITLE
Send the initial state on the first connection

### DIFF
--- a/modules/model/jvm/src/main/scala/observe/model/config/LucumaSSOConfiguration.scala
+++ b/modules/model/jvm/src/main/scala/observe/model/config/LucumaSSOConfiguration.scala
@@ -7,19 +7,9 @@ import cats.Eq
 import cats.derived.*
 
 /**
- * Configuration for the general authentication service
- * @param devMode
- *   Indicates if we are in development mode, In this mode there is an internal list of users
- * @param sessionLifeHrs
- *   How long will the session live in hours
- * @param cookieName
- *   Name of the cookie to store the token
- * @param secretKey
- *   Secret key to encrypt jwt tokens
- * @param useSsl
- *   Whether we use SSL setting the cookie to be https only
- * @param ldap
- *   URL of the ldap servers
+ * Parameeters to configure SSO
+ *
+ * @param serviceToken
  */
 case class LucumaSSOConfiguration(
   serviceToken: String

--- a/modules/model/shared/src/main/scala/observe/model/client.scala
+++ b/modules/model/shared/src/main/scala/observe/model/client.scala
@@ -8,15 +8,35 @@ import cats.derived.*
 import cats.syntax.all.*
 import io.circe.Decoder
 import io.circe.Encoder
+import io.circe.syntax.*
+import lucuma.core.enums.Site
 import lucuma.core.util.Enumerated
+import observe.model.ClientId
 import observe.model.Conditions
 
 enum ObserveEventType(val tag: String) derives Enumerated:
+  case StateRefresh      extends ObserveEventType("state_refreshed")
   case ConditionsUpdated extends ObserveEventType("conditions_updated")
 
-case class ObserveClientState(conditions: Conditions) derives Eq, Encoder.AsObject, Decoder
+sealed trait ClientEvent derives Eq
 
-case class ObserveClientEvent(state: ObserveClientState, event: ObserveEventType)
-    derives Eq,
-      Encoder.AsObject,
-      Decoder
+object ClientEvent:
+  case class InitialEvent(site: Site, clientId: ClientId, version: String) extends ClientEvent
+      derives Eq,
+        Encoder.AsObject,
+        Decoder
+
+  case class ObserveState(conditions: Conditions) extends ClientEvent
+      derives Eq,
+        Encoder.AsObject,
+        Decoder
+
+  given Encoder[ClientEvent] = Encoder.instance:
+    case e @ InitialEvent(_, _, _) => e.asJson
+    case e @ ObserveState(_)       => e.asJson
+
+  given Decoder[ClientEvent] =
+    List[Decoder[ClientEvent]](
+      Decoder[InitialEvent].widen,
+      Decoder[ObserveState].widen
+    ).reduceLeft(_ or _)

--- a/modules/model/shared/src/main/scala/observe/model/package.scala
+++ b/modules/model/shared/src/main/scala/observe/model/package.scala
@@ -4,6 +4,7 @@
 package observe
 
 import cats.*
+import lucuma.core.util.NewType
 import observe.model.enums.*
 import squants.time.Time
 import squants.time.TimeUnit
@@ -11,8 +12,10 @@ import squants.time.TimeUnit
 import java.util.UUID
 
 package model {
-  case class QueueId(self: UUID)  extends AnyVal
-  case class ClientId(self: UUID) extends AnyVal
+  case class QueueId(self: UUID) extends AnyVal
+
+  object ClientId extends NewType[UUID]
+  type ClientId = ClientId.Type
 }
 
 package object model {
@@ -30,13 +33,7 @@ package object model {
   given scala.math.Ordering[QueueId] =
     Order[QueueId].toOrdering
 
-  given Eq[ClientId]                  = Eq.by(x => x.self)
-  given Show[ClientId]                = Show.fromToString
-  given Order[ClientId]               =
-    Order.by(_.self)
-  given scala.math.Ordering[ClientId] =
-    Order[ClientId].toOrdering
-  val UnknownTargetName               = "None"
+  val UnknownTargetName = "None"
 
   val CalibrationQueueName: String = "Calibration Queue"
   val CalibrationQueueId: QueueId  =

--- a/modules/model/shared/src/test/scala/observe/model/ClientEventSuite.scala
+++ b/modules/model/shared/src/test/scala/observe/model/ClientEventSuite.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.model.events.client
+
+import cats.kernel.laws.discipline.*
+import io.circe.testing.CodecTests
+import io.circe.testing.instances.*
+import observe.model.arb.ArbClientEvent.given
+
+/**
+ * Tests Client Event typeclasses
+ */
+class ClientEventSuite extends munit.DisciplineSuite:
+  checkAll("Eq[InitialEvent]", EqTests[ClientEvent.InitialEvent].eqv)
+  checkAll("Eq[ObserveState]", EqTests[ClientEvent.ObserveState].eqv)
+  checkAll("Eq[ClientEvent]", EqTests[ClientEvent].eqv)
+  checkAll("Codec[InitialEvent]", CodecTests[ClientEvent.InitialEvent].unserializableCodec)
+  checkAll("Codec[ObserveState]", CodecTests[ClientEvent.ObserveState].unserializableCodec)
+  checkAll("Codec[ClientEvent]", CodecTests[ClientEvent].unserializableCodec)

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbClientEvent.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbClientEvent.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.model.arb
+
+import lucuma.core.enums.Site
+import lucuma.core.util.arb.ArbEnumerated.given
+import observe.model.ClientId
+import observe.model.Conditions
+import observe.model.ObserveModelArbitraries.given
+import observe.model.arb.ArbClientId.given
+import observe.model.events.client.*
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbClientEvent:
+
+  given Arbitrary[ClientEvent.ObserveState] = Arbitrary:
+    arbitrary[Conditions].map(ClientEvent.ObserveState(_))
+
+  given Cogen[ClientEvent.ObserveState] = Cogen[Conditions].contramap(_.conditions)
+
+  given Arbitrary[ClientEvent.InitialEvent] = Arbitrary:
+    for
+      site     <- arbitrary[Site]
+      clientId <- arbitrary[ClientId]
+      version  <- arbitrary[String]
+    yield ClientEvent.InitialEvent(site, clientId, version)
+
+  given Cogen[ClientEvent.InitialEvent] =
+    Cogen[(Site, ClientId, String)].contramap(x => (x.site, x.clientId, x.version))
+
+  given Arbitrary[ClientEvent] = Arbitrary:
+    for
+      initial <- arbitrary[ClientEvent.InitialEvent]
+      state   <- arbitrary[ClientEvent.ObserveState]
+      r       <- Gen.oneOf(initial, state)
+    yield r
+
+  given Cogen[ClientEvent] =
+    Cogen[Either[ClientEvent.InitialEvent, ClientEvent.ObserveState]].contramap:
+      case e: ClientEvent.InitialEvent => Left(e)
+      case e: ClientEvent.ObserveState => Right(e)
+
+end ArbClientEvent
+
+object ArbClientEvent extends ArbClientEvent

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbClientId.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbClientId.scala
@@ -14,14 +14,14 @@ import java.util.UUID
 trait ArbClientId {
 
   given clientIdArb: Arbitrary[ClientId] = Arbitrary {
-    arbitrary[UUID].map(ClientId.apply)
+    arbitrary[UUID].map(ClientId(_))
   }
 
   given cogenUUID: Cogen[UUID] =
     Cogen[(Long, Long)].contramap(u => (u.getMostSignificantBits, u.getLeastSignificantBits))
 
   given cidCogen: Cogen[ClientId] =
-    Cogen[UUID].contramap(_.self)
+    Cogen[UUID].contramap(_.value)
 
 }
 

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
@@ -164,7 +164,7 @@ class ObserveCommandRoutes[F[_]: Async: Compression](
     case req @ POST -> Root / "sb" =>
       req.decode[SkyBackground](sb => oe.setSkyBackground(sb, userDetails) *> NoContent())
 
-    case req @ POST -> Root / "ce"        =>
+    case req @ POST -> Root / "ce" =>
       req.decode[CloudExtinction](ce => oe.setCloudExtinction(ce, userDetails) *> NoContent())
     //
     // case req @ POST -> Root / "sb" as user =>
@@ -230,9 +230,9 @@ class ObserveCommandRoutes[F[_]: Async: Compression](
     // }
     //
     // val refreshCommand: HttpRoutes[F] = HttpRoutes.of[F] {
-    //   case GET -> Root / "refresh" / ClientIDVar(clientId) =>
-    //     se.requestRefresh(inputQueue, clientId) *> NoContent()
-    //
+    // case GET -> Root / "refresh" / ClientIDVar(clientId) =>
+    //   oe.requestRefresh(clientId) *> NoContent()
+
     case POST -> Root / "resetconditions" =>
       oe.resetConditions *> NoContent()
   }


### PR DESCRIPTION
Upon connection a client will get two messages. The first is some metadata like client id and then a message with the current state

The ability to send messages to a single client is now restored:

```json
{"site":"GS","clientId":"edfb83fd-4582-4df4-9678-f4f264e876ee","version":"20230929-0bccfdac-UNCOMMITED"}
{"conditions":{"cc":null,"iq":null,"sb":null,"wv":null}}
```