### PR TITLE
Reconnection on error. Disable while in flight.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,8 +111,8 @@ lazy val observe_web_client = project
   .settings(esModule: _*)
   .enablePlugins(ScalaJSPlugin, LucumaCssPlugin, CluePlugin, BuildInfoPlugin)
   .settings(
-    Test / test                             := {},
-    coverageEnabled                         := false,
+    Test / test      := {},
+    coverageEnabled  := false,
     libraryDependencies ++= Seq(
       Kittens.value,
       CatsEffect.value,
@@ -123,9 +123,6 @@ lazy val observe_web_client = project
       Http4sDom.value,
       LucumaUI.value
     ) ++ ScalaJSReactIO.value ++ Cats.value ++ LucumaReact.value ++ Monocle.value ++ LucumaCore.value ++ Log4CatsLogLevel.value,
-    // TODO Remove this, only used for prototype:
-    libraryDependencies += ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0")
-      .cross(CrossVersion.for3Use2_13), // Do not use this, it's insecure. Substitute with GenUUID
     scalacOptions ~= (_.filterNot(Set("-Vtype-diffs"))),
     buildInfoKeys    := Seq[BuildInfoKey](
       scalaVersion,

--- a/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
+++ b/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
@@ -101,3 +101,5 @@ object ObserveStyles:
   val DefaultCursor: Css     = Css("ObserveStyles-defaultCursor")
   val ConfigButtonStrip: Css = Css("ObserveStyles-configButtonStrip")
   val ConfigButton: Css      = Css("ObserveStyles-configButton")
+
+  val SyncingPanel: Css = Css("ObserveStyles-syncingPanel")

--- a/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
@@ -21,13 +21,13 @@ import observe.ui.ObserveStyles
 import observe.ui.model.AppContext
 import observe.ui.services.ConfigApi
 
-case class ConfigSection(
+case class ConfigPanel(
   operator:   Option[Operator],
   conditions: View[Conditions]
-) extends ReactFnProps(ConfigSection.component)
+) extends ReactFnProps(ConfigPanel.component)
 
-object ConfigSection:
-  private type Props = ConfigSection
+object ConfigPanel:
+  private type Props = ConfigPanel
 
   private val component = ScalaFnComponent
     .withHooks[Props]
@@ -57,7 +57,6 @@ object ConfigSection:
           .zoom(Conditions.sb)
           .withOnMod(_.map(configApi.setSkyBackground).orEmpty.runAsync)
 
-        // Card(clazz = ObserveStyles.HeaderSideBarCard)(
       <.div(ObserveStyles.ConfigSection)(
         <.div(ObserveStyles.ObserverArea)(
           <.label(^.htmlFor := "observer")("Observer Name"),
@@ -72,7 +71,8 @@ object ConfigSection:
             id = "imageQuality".refined,
             label = "Image Quality",
             value = iq,
-            showClear = false
+            showClear = false,
+            disabled = configApi.isBlocked
           )
         ),
         <.div(ObserveStyles.CloudExtinctionArea)(
@@ -80,7 +80,8 @@ object ConfigSection:
             id = "cloudExtinction".refined,
             label = "Cloud Extinction",
             value = ce,
-            showClear = false
+            showClear = false,
+            disabled = configApi.isBlocked
           )
         ),
         <.div(ObserveStyles.WaterVaporArea)(
@@ -88,7 +89,8 @@ object ConfigSection:
             id = "waterVapor".refined,
             label = "Water Vapor",
             value = wv,
-            showClear = false
+            showClear = false,
+            disabled = configApi.isBlocked
           )
         ),
         <.div(ObserveStyles.SkyBackgroundArea)(
@@ -96,8 +98,8 @@ object ConfigSection:
             id = "skyBackground".refined,
             label = "Sky Background",
             value = sb,
-            showClear = false
+            showClear = false,
+            disabled = configApi.isBlocked
           )
         )
-        // )
       )

--- a/modules/web/client/src/main/scala/observe/ui/components/Layout.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/Layout.scala
@@ -12,6 +12,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.Css
 import lucuma.react.common.ReactFnProps
 import lucuma.react.common.given
+import lucuma.react.primereact.Toast
 import lucuma.refined.*
 import lucuma.ui.components.SideTabs
 import lucuma.ui.components.state.IfLogged
@@ -68,6 +69,7 @@ object Layout:
               .zoom(RootModel.userVault)
               .mapValue: (userVault: View[UserVault]) =>
                 TopBar(props.rootModel.get.environment, userVault, theme, IO.unit),
+            Toast(Toast.Position.BottomRight, baseZIndex = 2000).withRef(ctx.toast.ref),
             SideTabs(
               "side-tabs".refined,
               appTabView,

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -6,13 +6,13 @@ package observe.ui.components
 import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.std.Dispatcher
+import cats.effect.std.Semaphore
 import cats.syntax.all.*
 import clue.js.WebSocketJSBackend
 import clue.js.WebSocketJSClient
 import clue.websocket.ReconnectionStrategy
 import crystal.Pot
 import crystal.react.*
-import crystal.react.given
 import crystal.react.hooks.*
 import crystal.syntax.*
 import eu.timepit.refined.types.string.NonEmptyString
@@ -24,24 +24,32 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import log4cats.loglevel.LogLevelLogger
 import lucuma.core.model.StandardRole
 import lucuma.core.model.StandardUser
+import lucuma.react.common.*
+import lucuma.react.primereact.Dialog
+import lucuma.react.primereact.Message
+import lucuma.react.primereact.MessageItem
+import lucuma.react.primereact.hooks.all.*
 import lucuma.schemas.ObservationDB
-import lucuma.ui.reusability.given
+import lucuma.ui.components.SolarProgress
 import lucuma.ui.sso.SSOClient
 import lucuma.ui.sso.UserVault
 import lucuma.ui.syntax.pot.*
+import observe.model.ClientId
 import observe.model.Environment
 import observe.model.events.client.ClientEvent
+import observe.ui.ObserveStyles
 import observe.ui.model.AppConfig
 import observe.ui.model.AppContext
 import observe.ui.model.RootModel
 import observe.ui.model.RootModelData
 import observe.ui.model.enums.AppTab
-import observe.ui.model.reusability.given
 import observe.ui.services.ConfigApi
 import observe.ui.services.ConfigApiImpl
 import org.http4s.Uri
 import org.http4s.circe.*
 import org.http4s.client.Client
+import org.http4s.client.middleware.Retry
+import org.http4s.client.middleware.RetryPolicy
 import org.http4s.client.websocket.WSFrame
 import org.http4s.client.websocket.WSRequest
 import org.http4s.dom.FetchClientBuilder
@@ -55,10 +63,11 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
 
 object MainApp:
-  private val ConfigFile: Uri = uri"/environments.conf.json"
-  private val ApiBaseUri: Uri = uri"/api/observe"
-  private val EventWsUri: Uri =
+  private val ConfigFile: Uri     = uri"/environments.conf.json"
+  private val ApiBaseUri: Uri     = uri"/api/observe"
+  private val EventWsUri: Uri     =
     Uri.unsafeFromString("wss://" + dom.window.location.host + ApiBaseUri + "/events")
+  private val RefreshBaseUri: Uri = ApiBaseUri / "refresh"
 
   // Set up logging
   private def setupLogger(level: LogLevelDesc): IO[Logger[IO]] = IO:
@@ -81,12 +90,18 @@ object MainApp:
           TimeUnit.SECONDS
         ).some
 
+  // Only idempotent requests are retried
+  private val FetchRetryPolicy =
+    RetryPolicy[IO](RetryPolicy.exponentialBackoff(15.seconds, Int.MaxValue))
+
   // Build regular HTTP client
   private val fetchClient: Client[IO] =
-    FetchClientBuilder[IO]
-      .withRequestTimeout(5.seconds)
-      .withCache(dom.RequestCache.`no-store`)
-      .create
+    Retry(FetchRetryPolicy)(
+      FetchClientBuilder[IO]
+        .withRequestTimeout(5.seconds)
+        .withCache(dom.RequestCache.`no-store`)
+        .create
+    )
 
   // Fetch environment configuration (from environments.conf.json)
   private val fetchConfig: IO[AppConfig] =
@@ -102,6 +117,9 @@ object MainApp:
             .orElse:
               confs.find(_.hostName === "*")
         )(orElse = new Exception("Host not found in configuration."))
+
+  private def reSync(clientId: ClientId): IO[Unit] =
+    fetchClient.get(RefreshBaseUri / clientId.toString)(_ => IO.unit)
 
   // Log in from cookie and switch to staff role
   private def enforceStaffRole(ssoClient: SSOClient[IO]): IO[Option[UserVault]] =
@@ -121,12 +139,37 @@ object MainApp:
       case WSFrame.Text(text, _) => fs2.Stream(decode[ClientEvent](text))
       case _                     => fs2.Stream.empty
 
-  // TODO IN CRYSTAL: It would be nice to have a .useEffectWhenDepReady instead of doing .void in dependencies!
+  def processStreamEvent(
+    environment:        View[Pot[Environment]],
+    rootModelData:      View[RootModelData],
+    isSynced:           View[Boolean],
+    configApiIsBlocked: View[Boolean]
+  )(
+    event:              ClientEvent
+  )(using Logger[IO]): IO[Unit] =
+    event match
+      case ClientEvent.InitialEvent(env)                           =>
+        environment.async.set(env.ready)
+      case ClientEvent.ObserveState(sequenceExecution, conditions) =>
+        rootModelData.zoom(RootModelData.sequenceExecution).async.set(sequenceExecution) >>
+          rootModelData.zoom(RootModelData.conditions).async.set(conditions) >>
+          isSynced.async.set(true) >>
+          configApiIsBlocked.async.set(false)
+
+  def processStreamError(
+    rootModelData: View[RootModelData]
+  )(error: Throwable)(using Logger[IO]): IO[Unit] =
+    rootModelData
+      .zoom(RootModelData.log)
+      .async
+      .mod(_ :+ NonEmptyString.unsafeFrom(s"ERROR Receiving Client Event: ${error.getMessage}"))
 
   private val component =
     ScalaFnComponent
       .withHooks[Unit]
-      .useResourceOnMount: // Build AppContext
+      .useToastRef
+      .useStateView(false) // UI is synced with server
+      .useResourceOnMountBy: (_, toastRef, _) => // Build AppContext
         for
           appConfig                                  <- Resource.eval(fetchConfig)
           given Logger[IO]                           <- Resource.eval(setupLogger(LogLevelDesc.DEBUG))
@@ -145,80 +188,112 @@ object MainApp:
           AppContext.version(appConfig.environment),
           SSOClient(appConfig.sso),
           (tab: AppTab) => MainApp.routerCtl.urlFor(tab.getPage).value,
-          (tab: AppTab, via: SetRouteVia) => MainApp.routerCtl.set(tab.getPage, via)
+          (tab: AppTab, via: SetRouteVia) => MainApp.routerCtl.set(tab.getPage, via),
+          toastRef
         )
       .useStateView(Pot.pending[RootModelData])
-      .useEffectWithDepsBy((_, ctxPot, _) => ctxPot.void): (_, ctxPot, rootModelData) =>
-        _ => // Once AppContext is ready, proceed to attempt login.
-          ctxPot.toOption
-            .map: ctx =>
-              import ctx.given
+      .useEffectWhenDepsReady((_, _, _, ctxPot, _) => ctxPot): (_, _, _, _, rootModelData) =>
+        ctx => // Once AppContext is ready, proceed to attempt login.
+          import ctx.given
 
-              enforceStaffRole(ctx.ssoClient).attempt
-                .flatMap(userVault =>
-                  rootModelData.async.set(RootModelData.initial(userVault).ready)
-                )
-            .orEmpty
+          enforceStaffRole(ctx.ssoClient).attempt
+            .flatMap(userVault => rootModelData.async.set(RootModelData.initial(userVault).ready))
       .useStateView(Pot.pending[Environment])
       // Subscribe to client event stream (and initialize Environment)
       // TODO Reconnecting middleware
-      .useResourceOnMount(WebSocketClient[IO].connectHighLevel(WSRequest(EventWsUri)))
-      .useAsyncEffectWithDepsBy((_, ctx, rootModelData, environment, wsConnection) =>
-        (wsConnection.void, rootModelData.get.void, ctx.void).tupled
-      ): (_, ctxPot, rootModelDataPot, environment, wsConnectionPot) =>
-        _ =>
-          (wsConnectionPot, rootModelDataPot.toPotView, ctxPot).tupled.toOption
-            .map: (wsConnection, rootModelData, ctx) =>
-              import ctx.given
+      .useResourceOnMount:
+        // Reconnect(WebSocketClient[IO]).connectHighLevel(WSRequest(EventWsUri))
+        WebSocketClient[IO].connectHighLevel(WSRequest(EventWsUri))
+      .useStateView(false) // ConfigApi.isBlocked
+      .useAsyncEffectWhenDepsReady(
+        (_, _, _, ctxPot, rootModelDataPot, environment, wsConnection, _) =>
+          (wsConnection, rootModelDataPot.toPotView, ctxPot).tupled
+      ): (_, _, isSynced, _, _, environment, _, configApiIsBlocked) =>
+        (wsConnection, rootModelData, ctx) =>
+          import ctx.given
 
-              wsConnection.receiveStream
-                .through(parseClientEvents)
-                .evalMap:
-                  // Process client event stream
-                  case Right(event) =>
-                    event match
-                      case ClientEvent.InitialEvent(env)           =>
-                        environment.async.set(env.ready)
-                      case ClientEvent.ObserveState(_, conditions) =>
-                        rootModelData.zoom(RootModelData.conditions).async.set(conditions)
-                  case Left(error)  =>
-                    rootModelData
-                      .zoom(RootModelData.log)
-                      .async
-                      .mod(
-                        _ :+
-                          NonEmptyString.unsafeFrom(
-                            s"ERROR Receiving Client Event: ${error.getMessage}"
-                          )
-                      )
-                .compile
-                .drain
-                .start
-                .map(_.cancel)
-            .orEmpty
+          wsConnection.receiveStream
+            .through(parseClientEvents)
+            .evalMap: // Process client event stream
+              case Right(event) =>
+                processStreamEvent(environment, rootModelData, isSynced, configApiIsBlocked)(event)
+              case Left(error)  => processStreamError(rootModelData)(error)
+            .compile
+            .drain
+            .start
+            .map(_.cancel)
       // RootModel is not initialized until RootModelData and Environment are available
       .useStateView(Pot.pending[RootModel])
-      .useEffectWithDepsBy((_, ctx, rootModelData, environment, _, _) =>
-        (rootModelData.get, environment.get).tupled.toOption
-      ): (_, _, _, _, _, rootModel) =>
+      .useEffectWhenDepsReady((_, _, _, _, rootModelData, environment, _, _, _) =>
+        (rootModelData.get, environment.get).tupled
+      ): (_, _, _, _, _, _, _, _, rootModelPot) =>
         // Once RootModelData and Environment are ready, build RootModel
-        _.map: (rootModelData, environment) =>
-          rootModel.set(RootModel(environment, rootModelData).ready)
-        .orEmpty
-      // Build ConfigApi instance only when token changes
-      .useMemoBy((_, _, rootModelData, _, _, _) =>
-        rootModelData.get.toOption.flatMap(_.userVault.map(_.token))
-      ): (_, _, _, _, _, _) =>
-        _.map: token =>
-          ConfigApiImpl(fetchClient, ApiBaseUri, token)
-      .render: (_, ctxPot, _, _, _, rootModelPot, configApiOpt) =>
-        def provideApiCtx(vdom: VdomNode) =
-          configApiOpt.fold(vdom)(ConfigApi.ctx.provide(_)(vdom))
+        (rootModelData, environment) =>
+          rootModelPot.set(RootModel(environment, rootModelData).ready)
+      .useEffectResultOnMount(Semaphore[IO](1).map(_.permit))
+      .render:
+        (
+          _,
+          toastRef,
+          isSynced,
+          ctxPot,
+          _,
+          environmentPot,
+          _,
+          configApiIsBlocked,
+          rootModelPot,
+          permitPot
+        ) =>
+          val configApiOpt: Option[ConfigApi[IO]] =
+            (rootModelPot.toPotView.toOption,
+             rootModelPot.get.toOption.flatMap(_.userVault.map(_.token)),
+             permitPot.toOption,
+             ctxPot.toOption,
+             environmentPot.toPotView.toOption
+            ).mapN: (rootModel, token, permit, ctx, environment) =>
+              import ctx.given
 
-        // When both AppContext and RootModel are ready, proceed to render.
-        (ctxPot, rootModelPot.toPotView).tupled.renderPot: (ctx, rootModel) =>
-          AppContext.ctx.provide(ctx)(
-            provideApiCtx(router(rootModel))
-          )
+              ConfigApiImpl(
+                client = fetchClient,
+                baseUri = ApiBaseUri,
+                token = token,
+                isBlockedView = configApiIsBlocked,
+                latch = permit,
+                onError = t =>
+                  toastRef
+                    .show(
+                      MessageItem(
+                        id = "configApiError",
+                        content = "Error saving changes",
+                        severity = Message.Severity.Error
+                      )
+                    )
+                    .to[IO] >>
+                    isSynced.async.set(false) >>
+                    rootModel.async
+                      .zoom(RootModel.log)
+                      .mod(_ :+ NonEmptyString.unsafeFrom(t.getMessage)) >>
+                    reSync(environment.get.clientId)
+              )
+
+          def provideApiCtx(children: VdomNode*) =
+            configApiOpt.fold(React.Fragment(children: _*))(ConfigApi.ctx.provide(_)(children: _*))
+
+          // When both AppContext and RootModel are ready, proceed to render.
+          (ctxPot, rootModelPot.toPotView).tupled.renderPot: (ctx, rootModel) =>
+            AppContext.ctx.provide(ctx)(
+              provideApiCtx(
+                Dialog(
+                  header = "Reestablishing connection to server...",
+                  closable = false,
+                  visible = !isSynced.get,
+                  onHide = Callback.empty,
+                  clazz = ObserveStyles.SyncingPanel
+                )(
+                  SolarProgress()
+                ),
+                router(rootModel)
+              )
+            )
 
   inline def apply() = component()

--- a/modules/web/client/src/main/scala/observe/ui/components/Routing.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/Routing.scala
@@ -25,8 +25,7 @@ object Routing:
           | staticRoute(root / "excluded", Excluded) ~> renderP(rootModel => <.div("Excluded")))
           | staticRoute(root / "configuration", Configuration) ~> renderP(rootModel =>
             <.div(
-              ConfigSection(
-                // rootModel.get.status,
+              ConfigPanel(
                 rootModel.get.operator,
                 rootModel.zoom(RootModel.conditions)
               )

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/ObservationProgressBar.scala
@@ -18,8 +18,6 @@ import observe.model.ObservationProgress
 import observe.model.ObserveStage
 import observe.ui.ObserveStyles
 
-import java.util.UUID
-
 /**
  * Component to wrap the progress bar
  */
@@ -39,17 +37,18 @@ object ObservationProgressBar extends ProgressLabel:
 
   private val component = ScalaFnComponent
     .withHooks[Props]
-    .useMemo[Unit, Pot[ObservationProgress]](())(_ =>
-      ObservationProgress
-        .Regular(
-          obsId = Observation.Id.fromLong(133742).get,
-          // obsName = "Test observation",
-          stepId = Step.Id.fromUuid(UUID.randomUUID),
-          total = TimeSpan.unsafeFromMicroseconds(1200000000L),
-          remaining = TimeSpan.unsafeFromMicroseconds(932000000L),
-          stage = ObserveStage.Acquiring
-        )
-        .ready
+    .useMemoBy[Unit, Pot[ObservationProgress]](_ => ())(props =>
+      _ =>
+        ObservationProgress
+          .Regular(
+            obsId = Observation.Id.fromLong(133742).get,
+            // obsName = "Test observation",
+            stepId = props.stepId,
+            total = TimeSpan.unsafeFromMicroseconds(1200000000L),
+            remaining = TimeSpan.unsafeFromMicroseconds(932000000L),
+            stage = ObserveStage.Acquiring
+          )
+          .ready
     )
     .render((props, progress) =>
       progress.value.toOption match

--- a/modules/web/client/src/main/scala/observe/ui/model/AppContext.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/AppContext.scala
@@ -14,6 +14,7 @@ import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.React
 import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.feature.Context
+import lucuma.react.primereact.ToastRef
 import lucuma.schemas.ObservationDB
 import lucuma.ui.enums.ExecutionEnvironment
 import lucuma.ui.sso.SSOClient
@@ -29,7 +30,8 @@ case class AppContext[F[_]: FlatMap](
   version:       NonEmptyString,
   ssoClient:     SSOClient[F],
   pageUrl:       AppTab => String,
-  setPageVia:    (AppTab, SetRouteVia) => Callback
+  setPageVia:    (AppTab, SetRouteVia) => Callback,
+  toast:         ToastRef
 )(using
   val logger:    Logger[F],
   val odbClient: WebSocketJSClient[F, ObservationDB]

--- a/modules/web/client/src/main/scala/observe/ui/model/RootModel.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/RootModel.scala
@@ -16,6 +16,7 @@ import observe.ui.model.enums.ClientMode
 
 case class RootModelData(
   userVault:            Option[UserVault],
+  sequenceExecution:    Map[Observation.Id, ExecutionState],
   conditions:           Conditions,
   operator:             Option[Operator],
   userSelectionMessage: Option[NonEmptyString],
@@ -26,7 +27,8 @@ case class RootModelData(
 object RootModelData:
   def initial(userVault: Either[Throwable, Option[UserVault]]): RootModelData =
     RootModelData(
-      userVault.toOption.flatten,
+      userVault = userVault.toOption.flatten,
+      sequenceExecution = Map.empty,
       conditions = Conditions.Default,
       operator = none,
       userSelectionMessage =
@@ -34,21 +36,25 @@ object RootModelData:
       log = List.empty
     )
 
-  val userVault: Lens[RootModelData, Option[UserVault]]                 = Focus[RootModelData](_.userVault)
-  val conditions: Lens[RootModelData, Conditions]                       = Focus[RootModelData](_.conditions)
-  val operator: Lens[RootModelData, Option[Operator]]                   = Focus[RootModelData](_.operator)
-  val userSelectionMessage: Lens[RootModelData, Option[NonEmptyString]] =
+  val userVault: Lens[RootModelData, Option[UserVault]]                           = Focus[RootModelData](_.userVault)
+  val sequenceExecution: Lens[RootModelData, Map[Observation.Id, ExecutionState]] =
+    Focus[RootModelData](_.sequenceExecution)
+  val conditions: Lens[RootModelData, Conditions]                                 = Focus[RootModelData](_.conditions)
+  val operator: Lens[RootModelData, Option[Operator]]                             = Focus[RootModelData](_.operator)
+  val userSelectionMessage: Lens[RootModelData, Option[NonEmptyString]]           =
     Focus[RootModelData](_.userSelectionMessage)
-  val log: Lens[RootModelData, List[NonEmptyString]]                    = Focus[RootModelData](_.log)
+  val log: Lens[RootModelData, List[NonEmptyString]]                              = Focus[RootModelData](_.log)
 
 case class RootModel(environment: Environment, data: RootModelData) derives Eq:
   export data.*
 
 object RootModel:
-  private val data: Lens[RootModel, RootModelData]                  = Focus[RootModel](_.data)
-  val userVault: Lens[RootModel, Option[UserVault]]                 = data.andThen(RootModelData.userVault)
-  val conditions: Lens[RootModel, Conditions]                       = data.andThen(RootModelData.conditions)
-  val operator: Lens[RootModel, Option[Operator]]                   = data.andThen(RootModelData.operator)
-  val userSelectionMessage: Lens[RootModel, Option[NonEmptyString]] =
+  private val data: Lens[RootModel, RootModelData]                            = Focus[RootModel](_.data)
+  val userVault: Lens[RootModel, Option[UserVault]]                           = data.andThen(RootModelData.userVault)
+  val sequenceExecution: Lens[RootModel, Map[Observation.Id, ExecutionState]] =
+    data.andThen(RootModelData.sequenceExecution)
+  val conditions: Lens[RootModel, Conditions]                                 = data.andThen(RootModelData.conditions)
+  val operator: Lens[RootModel, Option[Operator]]                             = data.andThen(RootModelData.operator)
+  val userSelectionMessage: Lens[RootModel, Option[NonEmptyString]]           =
     data.andThen(RootModelData.userSelectionMessage)
-  val log: Lens[RootModel, List[NonEmptyString]]                    = data.andThen(RootModelData.log)
+  val log: Lens[RootModel, List[NonEmptyString]]                              = data.andThen(RootModelData.log)

--- a/modules/web/client/src/main/scala/observe/ui/services/ConfigApi.scala
+++ b/modules/web/client/src/main/scala/observe/ui/services/ConfigApi.scala
@@ -23,6 +23,8 @@ trait ConfigApi[F[_]: MonadThrow]:
   def setSkyBackground(sb:   SkyBackground): F[Unit]   = NotAuthorized
   def refresh(clientId:      ClientId): F[Unit]        = NotAuthorized
 
+  def isBlocked: Boolean = false
+
 object ConfigApi:
   // Default value is NotAuthorized implementations
   val ctx: Context[ConfigApi[IO]] = React.createContext(new ConfigApi[IO] {})

--- a/modules/web/client/src/main/webapp/styles/observe.scss
+++ b/modules/web/client/src/main/webapp/styles/observe.scss
@@ -891,3 +891,12 @@ html {
   padding: 0 0.5em;
   height: 100%;
 }
+
+.ObserveStyles-syncingPanel {
+  height: var(--solar-system-size);
+  width: var(--solar-system-size);
+
+  .p-dialog-header {
+    text-align: center;
+  }
+}

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
@@ -25,6 +25,7 @@ import org.http4s.server.middleware.GZip
 // import observe.web.server.security.TokenRefresher
 // import lucuma.core.model.Observation.{Id => ObsId}
 // import lucuma.core.model.sequence.Step.{Id => StepId}
+import scala.concurrent.duration.*
 
 /**
  * Rest Endpoints under the /api route

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,7 +10,7 @@ object Settings {
   /** Library versions */
   object LibraryVersions {
     // ScalaJS libraries
-    val crystal      = "0.34.5"
+    val crystal      = "0.34.6"
     val javaTimeJS   = "2.5.0"
     val lucumaReact  = "0.45.0"
     val scalaDom     = "2.3.0"


### PR DESCRIPTION
This PR disables the UI if an invocation to the API results in an error and immediately requests a server state refresh, retrying if said request fails.

When the state is received in the Web Socket, UI is reenabled.

Furthermore, condition changing is disabled while a condition change request is in flight (not 100% sure we need to keep this).

To do in future PR: reestablish Web Socket if it's lost. There's some commented code attempting to use the `Reconnect` middleware @armanbilge is developing in http4s, but it's still WIP.