### PR TITLE
More robust resync. Fix state update.

### DIFF
--- a/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
@@ -36,7 +36,6 @@ object ConfigPanel:
     .render: (props, ctx, configApi) =>
       import ctx.given
 
-      // TODO Error handling in API requests
       val iq: View[Option[ImageQuality]] =
         props.conditions
           .zoom(Conditions.iq)

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -65,12 +65,11 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
 
 object MainApp:
-  private val ConfigFile: Uri            = uri"/environments.conf.json"
-  private val ApiBaseUri: Uri            = uri"/api/observe"
-  private val EventWsUri: Uri            =
+  private val ConfigFile: Uri     = uri"/environments.conf.json"
+  private val ApiBaseUri: Uri     = uri"/api/observe"
+  private val EventWsUri: Uri     =
     Uri.unsafeFromString("wss://" + dom.window.location.host + ApiBaseUri + "/events")
-  private val RefreshBaseUri: Uri        = ApiBaseUri / "refresh"
-  private val ResyncWait: FiniteDuration = 3.seconds
+  private val RefreshBaseUri: Uri = ApiBaseUri / "refresh"
 
   // Set up logging
   private def setupLogger(level: LogLevelDesc): IO[Logger[IO]] = IO:
@@ -123,9 +122,7 @@ object MainApp:
 
   // This will run until canceled.
   private def reSync(clientId: ClientId): IO[Unit] =
-    fetchClient.get(RefreshBaseUri / clientId.toString)(_ => IO.unit) >>
-      IO.sleep(ResyncWait) >>
-      reSync(clientId)
+    fetchClient.get(RefreshBaseUri / clientId.toString)(_ => IO.unit)
 
   // Log in from cookie and switch to staff role
   private def enforceStaffRole(ssoClient: SSOClient[IO]): IO[Option[UserVault]] =

--- a/modules/web/client/src/main/scala/observe/ui/model/RootModel.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/RootModel.scala
@@ -8,6 +8,8 @@ import cats.derived.*
 import cats.syntax.option.*
 import eu.timepit.refined.cats.given
 import eu.timepit.refined.types.string.NonEmptyString
+import japgolly.scalajs.react.ReactCats.*
+import japgolly.scalajs.react.Reusability
 import lucuma.ui.sso.UserVault
 import monocle.Focus
 import monocle.Lens
@@ -44,6 +46,8 @@ object RootModelData:
   val userSelectionMessage: Lens[RootModelData, Option[NonEmptyString]]           =
     Focus[RootModelData](_.userSelectionMessage)
   val log: Lens[RootModelData, List[NonEmptyString]]                              = Focus[RootModelData](_.log)
+
+  given Reusability[RootModelData] = Reusability.byEq
 
 case class RootModel(environment: Environment, data: RootModelData) derives Eq:
   export data.*

--- a/modules/web/client/src/main/scala/observe/ui/model/enums/SyncStatus.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/enums/SyncStatus.scala
@@ -3,5 +3,10 @@
 
 package observe.ui.model.enums
 
+import japgolly.scalajs.react.Reusability
+
 enum SyncStatus:
   case Synced, OutOfSync
+
+object SyncStatus:
+  given Reusability[SyncStatus] = Reusability.by_==

--- a/modules/web/client/src/main/scala/observe/ui/model/reusability.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/reusability.scala
@@ -28,5 +28,4 @@ object reusability:
   given Reusability[RunningStep]                           = Reusability.byEq
   given Reusability[NodAndShuffleStatus]                   = Reusability.byEq
   given Reusability[ExecutionState]                        = Reusability.byEq
-  given Reusability[RootModelData]                         = Reusability.byEq
   given Reusability[Environment]                           = Reusability.byEq


### PR DESCRIPTION
In this new mechanism, just by setting `syncState` to `OutOfSync` will trigger an infinite process that will request a refresh every 3 seconds. This will continue until state is received through the web socket, which sets `syncState` to `Synced` and cancels the reSync loop.

Furthermore, state propagation was broken in the previous PR. This fixes it.