### PR TITLE
Restore functionality to enable/disable subsystems

### DIFF
--- a/modules/model/shared/src/main/scala/observe/model/Environment.scala
+++ b/modules/model/shared/src/main/scala/observe/model/Environment.scala
@@ -11,8 +11,13 @@ import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.refined.given
 import lucuma.core.enums.Site
+import monocle.Focus
+import monocle.Lens
 
-final case class Environment(site: Site, clientId: ClientId, version: Version)
+case class Environment(site: Site, clientId: ClientId, version: Version)
     derives Eq,
       Encoder.AsObject,
       Decoder
+
+object Environment:
+  val clientId: Lens[Environment, ClientId] = Focus[Environment](_.clientId)

--- a/modules/model/shared/src/main/scala/observe/model/ExecutionState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ExecutionState.scala
@@ -17,11 +17,12 @@ import observe.model.enums.Resource
  * This class concentrates all the execution state that is kept in the server.
  */
 case class ExecutionState(
-  sequenceState: SequenceState,
-  runningStepId: Option[Step.Id],
-  nsState:       Option[NsRunningState],
-  configStatus:  List[(Resource, ActionStatus)],
-  breakpoints:   Set[Step.Id] = Set.empty
+  sequenceState:   SequenceState,
+  runningStepId:   Option[Step.Id],
+  nsState:         Option[NsRunningState],
+  configStatus:    List[(Resource, ActionStatus)],
+  systemOverrides: SystemOverrides,
+  breakpoints:     Set[Step.Id] = Set.empty
 ) derives Eq,
       Encoder.AsObject,
       Decoder
@@ -33,3 +34,5 @@ object ExecutionState:
   val configStatus: Lens[ExecutionState, List[(Resource, ActionStatus)]] =
     Focus[ExecutionState](_.configStatus)
   val breakpoints: Lens[ExecutionState, Set[Step.Id]]                    = Focus[ExecutionState](_.breakpoints)
+  val systemOverrides: Lens[ExecutionState, SystemOverrides]             =
+    Focus[ExecutionState](_.systemOverrides)

--- a/modules/model/shared/src/main/scala/observe/model/SequenceView.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceView.scala
@@ -4,19 +4,20 @@
 package observe.model
 
 import cats.*
+import cats.derived.*
 import cats.syntax.all.*
 import monocle.Focus
 import monocle.Traversal
 import monocle.function.Each.*
 
-final case class SequenceView(
+case class SequenceView(
   obsId:           Observation.Id,
   metadata:        SequenceMetadata,
   status:          SequenceState,
   systemOverrides: SystemOverrides,
   steps:           List[Step],
   willStopIn:      Option[Int]
-) {
+) derives Eq {
 
   def progress: Option[RunningStep] =
     steps.zipWithIndex.find(!_._1.isFinished).flatMap { x =>
@@ -33,8 +34,6 @@ final case class SequenceView(
 }
 
 object SequenceView {
-  given Eq[SequenceView] =
-    Eq.by(x => (x.obsId, x.metadata, x.status, x.willStopIn))
 
   val stepT: Traversal[SequenceView, Step] =
     Focus[SequenceView](_.steps).andThen(each[List[Step], Step])

--- a/modules/model/shared/src/main/scala/observe/model/SystemOverrides.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SystemOverrides.scala
@@ -3,40 +3,38 @@
 
 package observe.model
 
-import cats.*
+import cats.Eq
+import cats.derived.*
 
 case class SystemOverrides(
-  isTcsEnabled:        Boolean,
-  isInstrumentEnabled: Boolean,
-  isGcalEnabled:       Boolean,
-  isDhsEnabled:        Boolean
-) {
-  def disableTcs: SystemOverrides = copy(isTcsEnabled = false)
+  isTcsEnabled:        SubsystemEnabled,
+  isInstrumentEnabled: SubsystemEnabled,
+  isGcalEnabled:       SubsystemEnabled,
+  isDhsEnabled:        SubsystemEnabled
+) derives Eq {
+  def disableTcs: SystemOverrides = copy(isTcsEnabled = SubsystemEnabled.Disabled)
 
-  def enableTcs: SystemOverrides = copy(isTcsEnabled = true)
+  def enableTcs: SystemOverrides = copy(isTcsEnabled = SubsystemEnabled.Enabled)
 
-  def disableInstrument: SystemOverrides = copy(isInstrumentEnabled = false)
+  def disableInstrument: SystemOverrides = copy(isInstrumentEnabled = SubsystemEnabled.Disabled)
 
-  def enableInstrument: SystemOverrides = copy(isInstrumentEnabled = true)
+  def enableInstrument: SystemOverrides = copy(isInstrumentEnabled = SubsystemEnabled.Enabled)
 
-  def disableGcal: SystemOverrides = copy(isGcalEnabled = false)
+  def disableGcal: SystemOverrides = copy(isGcalEnabled = SubsystemEnabled.Disabled)
 
-  def enableGcal: SystemOverrides = copy(isGcalEnabled = true)
+  def enableGcal: SystemOverrides = copy(isGcalEnabled = SubsystemEnabled.Enabled)
 
-  def disableDhs: SystemOverrides = copy(isDhsEnabled = false)
+  def disableDhs: SystemOverrides = copy(isDhsEnabled = SubsystemEnabled.Disabled)
 
-  def enableDhs: SystemOverrides = copy(isDhsEnabled = true)
+  def enableDhs: SystemOverrides = copy(isDhsEnabled = SubsystemEnabled.Enabled)
 }
 
 object SystemOverrides {
   val AllEnabled: SystemOverrides = SystemOverrides(
-    isTcsEnabled = true,
-    isInstrumentEnabled = true,
-    isGcalEnabled = true,
-    isDhsEnabled = true
+    isTcsEnabled = SubsystemEnabled.Enabled,
+    isInstrumentEnabled = SubsystemEnabled.Enabled,
+    isGcalEnabled = SubsystemEnabled.Enabled,
+    isDhsEnabled = SubsystemEnabled.Enabled
   )
-
-  given Eq[SystemOverrides] =
-    Eq.by(x => (x.isTcsEnabled, x.isInstrumentEnabled, x.isGcalEnabled, x.isDhsEnabled))
 
 }

--- a/modules/model/shared/src/main/scala/observe/model/client.scala
+++ b/modules/model/shared/src/main/scala/observe/model/client.scala
@@ -32,7 +32,7 @@ extension (v: SequencesQueue[SequenceView])
 
 extension (q: SequenceView)
   def executionState: ExecutionState =
-    ExecutionState(q.status, q.runningStep.flatMap(_.id), None, Nil)
+    ExecutionState(q.status, q.runningStep.flatMap(_.id), None, Nil, q.systemOverrides)
 
 object ClientEvent:
   enum SingleActionState(val tag: String) derives Eq, Enumerated:

--- a/modules/model/shared/src/main/scala/observe/model/events.scala
+++ b/modules/model/shared/src/main/scala/observe/model/events.scala
@@ -139,6 +139,7 @@ extension (e: ObserveEvent)
     case ConditionsUpdated(v)    => ClientEvent.ObserveState(v.sequencesState, v.conditions).some
     case SequenceRefreshed(v, _) => ClientEvent.ObserveState(v.sequencesState, v.conditions).some
     case ObserverUpdated(v)      => ClientEvent.ObserveState(v.sequencesState, v.conditions).some
+    case OverridesUpdated(v)     => ClientEvent.ObserveState(v.sequencesState, v.conditions).some
     case SingleActionEvent(v)    =>
       v match {
         case SingleActionOp.Started(sid, stepId, resource)    =>

--- a/modules/model/shared/src/main/scala/observe/model/newTypes.scala
+++ b/modules/model/shared/src/main/scala/observe/model/newTypes.scala
@@ -25,3 +25,10 @@ type Operator = Operator.Type
 
 object ImageFileId extends NewType[String]
 type ImageFileId = ImageFileId.Type
+
+object SubsystemEnabled extends NewType[Boolean] {
+  val Enabled  = SubsystemEnabled(true)
+  val Disabled = SubsystemEnabled(false)
+}
+
+type SubsystemEnabled = SubsystemEnabled.Type

--- a/modules/model/shared/src/test/scala/observe/model/ObserveModelArbitraries.scala
+++ b/modules/model/shared/src/test/scala/observe/model/ObserveModelArbitraries.scala
@@ -61,6 +61,9 @@ trait ObserveModelArbitraries {
   given Arbitrary[QueueId] = newTypeArbitrary(QueueId)
   given Cogen[QueueId]     = newTypeCogen(QueueId)
 
+  given Arbitrary[SubsystemEnabled] = newTypeArbitrary(SubsystemEnabled)
+  given Cogen[SubsystemEnabled]     = newTypeCogen(SubsystemEnabled)
+
   given Arbitrary[ActionType] = Arbitrary[ActionType] {
     for {
       c <- arbitrary[Resource].map(ActionType.Configure.apply)
@@ -96,10 +99,10 @@ trait ObserveModelArbitraries {
 
   given Arbitrary[SystemOverrides] = Arbitrary[SystemOverrides] {
     for {
-      tcs  <- arbitrary[Boolean]
-      inst <- arbitrary[Boolean]
-      gcal <- arbitrary[Boolean]
-      dhs  <- arbitrary[Boolean]
+      tcs  <- arbitrary[SubsystemEnabled]
+      inst <- arbitrary[SubsystemEnabled]
+      gcal <- arbitrary[SubsystemEnabled]
+      dhs  <- arbitrary[SubsystemEnabled]
     } yield SystemOverrides(tcs, inst, gcal, dhs)
   }
 
@@ -129,7 +132,7 @@ trait ObserveModelArbitraries {
     Cogen[(Instrument, Option[Observer], String)].contramap(s => (s.instrument, s.observer, s.name))
 
   given Cogen[SystemOverrides] =
-    Cogen[(Boolean, Boolean, Boolean, Boolean)].contramap(x =>
+    Cogen[(SubsystemEnabled, SubsystemEnabled, SubsystemEnabled, SubsystemEnabled)].contramap(x =>
       (x.isTcsEnabled, x.isInstrumentEnabled, x.isGcalEnabled, x.isDhsEnabled)
     )
 

--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -111,27 +111,31 @@ trait ObserveEngine[F[_]] {
 
   // Systems overrides
   def setTcsEnabled(
-    seqId:   Observation.Id,
-    user:    User,
-    enabled: SubsystemEnabled
+    seqId:    Observation.Id,
+    user:     User,
+    enabled:  SubsystemEnabled,
+    clientId: ClientId
   ): F[Unit]
 
   def setGcalEnabled(
-    seqId:   Observation.Id,
-    user:    User,
-    enabled: SubsystemEnabled
+    seqId:    Observation.Id,
+    user:     User,
+    enabled:  SubsystemEnabled,
+    clientId: ClientId
   ): F[Unit]
 
   def setInstrumentEnabled(
-    seqId:   Observation.Id,
-    user:    User,
-    enabled: SubsystemEnabled
+    seqId:    Observation.Id,
+    user:     User,
+    enabled:  SubsystemEnabled,
+    clientId: ClientId
   ): F[Unit]
 
   def setDhsEnabled(
-    seqId:   Observation.Id,
-    user:    User,
-    enabled: SubsystemEnabled
+    seqId:    Observation.Id,
+    user:     User,
+    enabled:  SubsystemEnabled,
+    clientId: ClientId
   ): F[Unit]
 
   def selectSequence(
@@ -148,13 +152,13 @@ trait ObserveEngine[F[_]] {
 
   def setConditions(conditions: Conditions, user: User): F[Unit]
 
-  def setImageQuality(iq: ImageQuality, user: User): F[Unit]
+  def setImageQuality(iq: ImageQuality, user: User, clientId: ClientId): F[Unit]
 
-  def setWaterVapor(wv: WaterVapor, user: User): F[Unit]
+  def setWaterVapor(wv: WaterVapor, user: User, clientId: ClientId): F[Unit]
 
-  def setSkyBackground(sb: SkyBackground, user: User): F[Unit]
+  def setSkyBackground(sb: SkyBackground, user: User, clientId: ClientId): F[Unit]
 
-  def setCloudExtinction(cc: CloudExtinction, user: User): F[Unit]
+  def setCloudExtinction(cc: CloudExtinction, user: User, clientId: ClientId): F[Unit]
 
   def setSkipMark(
     seqId:    Observation.Id,
@@ -718,6 +722,13 @@ object ObserveEngine {
     private def logDebugEvent(msg: String): F[Unit] =
       Event.logDebugMsgF[F, EngineState[F], SeqEvent](msg).flatMap(executeEngine.offer)
 
+    private def logDebugEvent(msg: String, user: User, clientId: ClientId): F[Unit] =
+      Event
+        .logDebugMsgF[F, EngineState[F], SeqEvent](
+          s"$msg, by ${user.displayName} from client $clientId"
+        )
+        .flatMap(executeEngine.offer)
+
     override def clearLoadedSequences(user: User): F[Unit] =
       logDebugEvent("ObserveEngine: Updating loaded sequences") *>
         executeEngine.offer(
@@ -751,8 +762,8 @@ object ObserveEngine {
         )
       )
 
-    override def setImageQuality(iq: ImageQuality, user: User): F[Unit] =
-      logDebugEvent(s"ObserveEngine: Setting image quality to $iq") *>
+    override def setImageQuality(iq: ImageQuality, user: User, clientId: ClientId): F[Unit] =
+      logDebugEvent(s"ObserveEngine: Setting image quality to $iq", user, clientId) *>
         executeEngine.offer(
           Event.modifyState[F, EngineState[F], SeqEvent](
             (EngineState.conditions[F].andThen(Conditions.iq).replace(iq.some) >>> refreshSequences)
@@ -761,8 +772,8 @@ object ObserveEngine {
           )
         )
 
-    override def setWaterVapor(wv: WaterVapor, user: User): F[Unit] =
-      logDebugEvent(s"ObserveEngine: Setting water vapor to $wv") *>
+    override def setWaterVapor(wv: WaterVapor, user: User, clientId: ClientId): F[Unit] =
+      logDebugEvent(s"ObserveEngine: Setting water vapor to $wv", user, clientId) *>
         executeEngine.offer(
           Event.modifyState[F, EngineState[F], SeqEvent](
             (EngineState.conditions[F].andThen(Conditions.wv).replace(wv.some) >>> refreshSequences)
@@ -771,8 +782,8 @@ object ObserveEngine {
           )
         )
 
-    override def setSkyBackground(sb: SkyBackground, user: User): F[Unit] =
-      logDebugEvent(s"ObserveEngine: Setting sky background to $sb") *>
+    override def setSkyBackground(sb: SkyBackground, user: User, clientId: ClientId): F[Unit] =
+      logDebugEvent(s"ObserveEngine: Setting sky background to $sb", user, clientId) *>
         executeEngine.offer(
           Event.modifyState[F, EngineState[F], SeqEvent](
             (EngineState.conditions[F].andThen(Conditions.sb).replace(sb.some) >>> refreshSequences)
@@ -782,9 +793,10 @@ object ObserveEngine {
         )
 
     override def setCloudExtinction(
-      ce:   CloudExtinction,
-      user: User
-    ): F[Unit] = logDebugEvent(s"ObserveEngine: Setting cloud cover to $ce") *>
+      ce:       CloudExtinction,
+      user:     User,
+      clientId: ClientId
+    ): F[Unit] = logDebugEvent(s"ObserveEngine: Setting cloud cover to $ce", user, clientId) *>
       executeEngine.offer(
         Event.modifyState[F, EngineState[F], SeqEvent](
           (EngineState.conditions[F].andThen(Conditions.ce).replace(ce.some) >>> refreshSequences)
@@ -803,7 +815,7 @@ object ObserveEngine {
 //      setObserver(seqId, user, observer) *>
 //        executeEngine.offer(Event.skip[F, EngineState[F], SeqEvent](seqId, user, stepId, v))
 //
-    override def requestRefresh(clientId: ClientId): F[Unit]              =
+    override def requestRefresh(clientId: ClientId): F[Unit]                                  =
       executeEngine.offer(Event.poll(clientId))
 
     private def seqQueueRefreshStream: Stream[F, Either[ObserveFailure, EventType[F]]] =
@@ -1373,10 +1385,13 @@ object ObserveEngine {
       event:    SeqEvent,
       seqId:    Observation.Id,
       user:     User,
-      enabled:  SubsystemEnabled
+      enabled:  SubsystemEnabled,
+      clientId: ClientId
     ): F[Unit] =
       logDebugEvent(
-        s"ObserveEngine: Setting $resource enabled flag to '$enabled' for sequence '$seqId' by ${user.id}"
+        s"ObserveEngine: Setting $resource enabled flag to '$enabled' for sequence '$seqId'",
+        user,
+        clientId
       ) *>
         executeEngine.offer(
           Event.modifyState[F, EngineState[F], SeqEvent](
@@ -1389,55 +1404,64 @@ object ObserveEngine {
           )
         )
     override def setTcsEnabled(
-      seqId:   Observation.Id,
-      user:    User,
-      enabled: SubsystemEnabled
+      seqId:    Observation.Id,
+      user:     User,
+      enabled:  SubsystemEnabled,
+      clientId: ClientId
     ): F[Unit] =
       toggleOverride(Resource.TCS.label,
                      (enabled, x) => if (enabled.value) x.enableTcs else x.disableTcs,
                      SetTcsEnabled(seqId, user.some, enabled),
                      seqId,
                      user,
-                     enabled
+                     enabled,
+                     clientId
       )
 
     override def setGcalEnabled(
-      seqId:   Observation.Id,
-      user:    User,
-      enabled: SubsystemEnabled
+      seqId:    Observation.Id,
+      user:     User,
+      enabled:  SubsystemEnabled,
+      clientId: ClientId
     ): F[Unit] =
       toggleOverride(Resource.Gcal.label,
                      (enabled, x) => if (enabled.value) x.enableGcal else x.disableGcal,
                      SetGcalEnabled(seqId, user.some, enabled),
                      seqId,
                      user,
-                     enabled
+                     enabled,
+                     clientId
       )
 
     override def setInstrumentEnabled(
-      seqId:   Observation.Id,
-      user:    User,
-      enabled: SubsystemEnabled
+      seqId:    Observation.Id,
+      user:     User,
+      enabled:  SubsystemEnabled,
+      clientId: ClientId
     ): F[Unit] =
-      toggleOverride("Instrument",
-                     (enabled, x) => if (enabled.value) x.enableInstrument else x.disableInstrument,
-                     SetInstrumentEnabled(seqId, user.some, enabled),
-                     seqId,
-                     user,
-                     enabled
+      toggleOverride(
+        "Instrument",
+        (enabled, x) => if (enabled.value) x.enableInstrument else x.disableInstrument,
+        SetInstrumentEnabled(seqId, user.some, enabled),
+        seqId,
+        user,
+        enabled,
+        clientId
       )
 
     override def setDhsEnabled(
-      seqId:   Observation.Id,
-      user:    User,
-      enabled: SubsystemEnabled
+      seqId:    Observation.Id,
+      user:     User,
+      enabled:  SubsystemEnabled,
+      clientId: ClientId
     ): F[Unit] =
       toggleOverride("DHS",
                      (enabled, x) => if (enabled.value) x.enableDhs else x.disableDhs,
                      SetDhsEnabled(seqId, user.some, enabled),
                      seqId,
                      user,
-                     enabled
+                     enabled,
+                     clientId: ClientId
       )
 
   }

--- a/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
@@ -16,68 +16,67 @@ import observe.model.Observer
 import observe.model.Operator
 import observe.model.QueueId
 import observe.model.StepId
+import observe.model.SubsystemEnabled
 import observe.model.UserPrompt
 import observe.model.enums.*
 
 sealed trait SeqEvent extends Product with Serializable
 
 object SeqEvent {
-  final case class SetOperator(name: Operator, user: Option[User])             extends SeqEvent
-  final case class SetObserver(id: Observation.Id, user: Option[User], name: Observer)
+  case class SetOperator(name: Operator, user: Option[User])                      extends SeqEvent
+  case class SetObserver(id: Observation.Id, user: Option[User], name: Observer)  extends SeqEvent
+  case class SetTcsEnabled(id: Observation.Id, user: Option[User], enabled: SubsystemEnabled)
       extends SeqEvent
-  final case class SetTcsEnabled(id: Observation.Id, user: Option[User], enabled: Boolean)
+  case class SetGcalEnabled(id: Observation.Id, user: Option[User], enabled: SubsystemEnabled)
       extends SeqEvent
-  final case class SetGcalEnabled(id: Observation.Id, user: Option[User], enabled: Boolean)
-      extends SeqEvent
-  final case class SetInstrumentEnabled(
+  case class SetInstrumentEnabled(
     id:      Observation.Id,
     user:    Option[User],
-    enabled: Boolean
+    enabled: SubsystemEnabled
   ) extends SeqEvent
-  final case class SetDhsEnabled(id: Observation.Id, user: Option[User], enabled: Boolean)
+  case class SetDhsEnabled(id: Observation.Id, user: Option[User], enabled: SubsystemEnabled)
       extends SeqEvent
-  final case class SetConditions(conditions: Conditions, user: Option[User])   extends SeqEvent
-  final case class LoadSequence(sid: Observation.Id)                           extends SeqEvent
-  final case class UnloadSequence(id: Observation.Id)                          extends SeqEvent
-  final case class AddLoadedSequence(
+  case class SetConditions(conditions: Conditions, user: Option[User])            extends SeqEvent
+  case class LoadSequence(sid: Observation.Id)                                    extends SeqEvent
+  case class UnloadSequence(id: Observation.Id)                                   extends SeqEvent
+  case class AddLoadedSequence(
     instrument: Instrument,
     obsId:      Observation.Id,
     user:       User,
     clientId:   ClientId
   ) extends SeqEvent
-  final case class ClearLoadedSequences(user: Option[User])                    extends SeqEvent
-  final case class SetImageQuality(iq: ImageQuality, user: Option[User])       extends SeqEvent
-  final case class SetWaterVapor(wv: WaterVapor, user: Option[User])           extends SeqEvent
-  final case class SetSkyBackground(wv: SkyBackground, user: Option[User])     extends SeqEvent
-  final case class SetCloudCover(cc: CloudExtinction, user: Option[User])      extends SeqEvent
-  final case class NotifyUser(memo: Notification, clientID: ClientId)          extends SeqEvent
-  final case class RequestConfirmation(prompt: UserPrompt, cid: ClientId)      extends SeqEvent
-  final case class StartQueue(
+  case class ClearLoadedSequences(user: Option[User])                             extends SeqEvent
+  case class SetImageQuality(iq: ImageQuality, user: Option[User])                extends SeqEvent
+  case class SetWaterVapor(wv: WaterVapor, user: Option[User])                    extends SeqEvent
+  case class SetSkyBackground(wv: SkyBackground, user: Option[User])              extends SeqEvent
+  case class SetCloudCover(cc: CloudExtinction, user: Option[User])               extends SeqEvent
+  case class NotifyUser(memo: Notification, clientID: ClientId)                   extends SeqEvent
+  case class RequestConfirmation(prompt: UserPrompt, cid: ClientId)               extends SeqEvent
+  case class StartQueue(
     qid:         QueueId,
     clientID:    ClientId,
     startedSeqs: List[(Observation.Id, StepId)]
   ) extends SeqEvent
-  final case class StopQueue(qid: QueueId, clientID: ClientId)                 extends SeqEvent
-  final case class UpdateQueueAdd(qid: QueueId, seqs: List[Observation.Id])    extends SeqEvent
-  final case class UpdateQueueRemove(
+  case class StopQueue(qid: QueueId, clientID: ClientId)                          extends SeqEvent
+  case class UpdateQueueAdd(qid: QueueId, seqs: List[Observation.Id])             extends SeqEvent
+  case class UpdateQueueRemove(
     qid:         QueueId,
     seqs:        List[Observation.Id],
     pos:         List[Int],
     startedSeqs: List[(Observation.Id, StepId)]
   ) extends SeqEvent
-  final case class UpdateQueueMoved(qid: QueueId, cid: ClientId, oid: Observation.Id, pos: Int)
+  case class UpdateQueueMoved(qid: QueueId, cid: ClientId, oid: Observation.Id, pos: Int)
       extends SeqEvent
-  final case class UpdateQueueClear(qid: QueueId)                              extends SeqEvent
-  final case class StartSysConfig(obsId: Observation.Id, stepId: StepId, res: Resource)
-      extends SeqEvent
-  final case class Busy(obsId: Observation.Id, cid: ClientId)                  extends SeqEvent
-  final case class SequenceStart(sid: Observation.Id, stepId: StepId)          extends SeqEvent
-  final case class SequencesStart(startedSeqs: List[(Observation.Id, StepId)]) extends SeqEvent
-  final case class ResourceBusy(
+  case class UpdateQueueClear(qid: QueueId)                                       extends SeqEvent
+  case class StartSysConfig(obsId: Observation.Id, stepId: StepId, res: Resource) extends SeqEvent
+  case class Busy(obsId: Observation.Id, cid: ClientId)                           extends SeqEvent
+  case class SequenceStart(sid: Observation.Id, stepId: StepId)                   extends SeqEvent
+  case class SequencesStart(startedSeqs: List[(Observation.Id, StepId)])          extends SeqEvent
+  case class ResourceBusy(
     obsId:    Observation.Id,
     stepId:   StepId,
     res:      Resource,
     clientID: ClientId
   ) extends SeqEvent
-  case object NullSeqEvent                                                     extends SeqEvent
+  case object NullSeqEvent                                                        extends SeqEvent
 }

--- a/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
@@ -777,27 +777,27 @@ object SeqTranslate {
 //    private val gnirsDisabled: GnirsController[F]           = new GnirsControllerDisabled[F]
 
     def tcsSouth(overrides: SystemOverrides): TcsSouthController[F] =
-      if (overrides.isTcsEnabled) systems.tcsSouth
+      if (overrides.isTcsEnabled.value) systems.tcsSouth
       else tcsSouthDisabled
 
     def tcsNorth(overrides: SystemOverrides): TcsNorthController[F] =
-      if (overrides.isTcsEnabled) systems.tcsNorth
+      if (overrides.isTcsEnabled.value) systems.tcsNorth
       else tcsNorthDisabled
 
     def gems(overrides: SystemOverrides): GemsController[F] =
-      if (overrides.isTcsEnabled) systems.gems
+      if (overrides.isTcsEnabled.value) systems.gems
       else gemsDisabled
 
     def altair(overrides: SystemOverrides): AltairController[F] =
-      if (overrides.isTcsEnabled) systems.altair
+      if (overrides.isTcsEnabled.value) systems.altair
       else altairDisabled
 
     def dhs(overrides: SystemOverrides): DhsClientProvider[F] =
-      if (overrides.isDhsEnabled) systems.dhs
+      if (overrides.isDhsEnabled.value) systems.dhs
       else dhsDisabled
 
     def gcal(overrides: SystemOverrides): GcalController[F] =
-      if (overrides.isGcalEnabled) systems.gcal
+      if (overrides.isGcalEnabled.value) systems.gcal
       else gcalDisabled
 
 //    def flamingos2(overrides: SystemOverrides): Flamingos2Controller[F] =
@@ -805,11 +805,11 @@ object SeqTranslate {
 //      else flamingos2Disabled
 
     def gmosNorth(overrides: SystemOverrides): GmosNorthController[F] =
-      if (overrides.isInstrumentEnabled) systems.gmosNorth
+      if (overrides.isInstrumentEnabled.value) systems.gmosNorth
       else gmosNorthDisabled
 
     def gmosSouth(overrides: SystemOverrides): GmosSouthController[F] =
-      if (overrides.isInstrumentEnabled) systems.gmosSouth
+      if (overrides.isInstrumentEnabled.value) systems.gmosSouth
       else gmosSouthDisabled
 
 //    def gsaoi(overrides: SystemOverrides): GsaoiController[F] =

--- a/modules/server_new/src/main/scala/observe/server/SequenceData.scala
+++ b/modules/server_new/src/main/scala/observe/server/SequenceData.scala
@@ -31,4 +31,6 @@ object SequenceData {
 
   def visitId[F[_]]: Lens[SequenceData[F], Option[VisitId]] = Focus[SequenceData[F]](_.visitId)
 
+  def overrides[F[_]]: Lens[SequenceData[F], SystemOverrides] = Focus[SequenceData[F]](_.overrides)
+
 }

--- a/modules/server_new/src/main/scala/observe/server/package.scala
+++ b/modules/server_new/src/main/scala/observe/server/package.scala
@@ -37,7 +37,6 @@ import squants.Length
 import squants.space.Angle
 
 import server.InstrumentSystem.ElapsedTime
-import server.InstrumentSystem.ElapsedTime
 
 package object server {
 

--- a/modules/server_new/src/test/scala/observe/server/EpicsUtilSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/EpicsUtilSuite.scala
@@ -12,8 +12,6 @@ import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledThreadPoolExecutor
-import java.util.concurrent.TimeUnit.MILLISECONDS
-import scala.concurrent.duration.FiniteDuration
 
 class EpicsUtilSuite extends munit.CatsEffectSuite {
 

--- a/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
@@ -30,6 +30,7 @@ import observe.engine.EventResult
 import observe.engine.EventResult.Outcome
 import observe.engine.Sequence
 import observe.engine.user
+import observe.model.ClientId
 import observe.model.Conditions
 import observe.model.Observer
 import observe.model.Operator
@@ -46,9 +47,13 @@ import observe.model.enums.RunOverride
 import observe.server.SeqEvent.RequestConfirmation
 import observe.server.SequenceGen.StepStatusGen
 
+import java.util.UUID
+
 class ObserveEngineSuite extends TestCommon {
 
   import TestCommon.*
+
+  val clientId = ClientId(UUID.randomUUID())
 
   test("ObserveEngine setOperator should set operator's name") {
     val operator = Operator("Joe")
@@ -67,7 +72,7 @@ class ObserveEngineSuite extends TestCommon {
 
     (for {
       oe <- observeEngine
-      sf <- advanceN(oe, s0, oe.setImageQuality(iq, user), 2)
+      sf <- advanceN(oe, s0, oe.setImageQuality(iq, user, clientId), 2)
     } yield sf.flatMap(EngineState.conditions.andThen(Conditions.iq).get).exists { op =>
       op === iq
     }).assert
@@ -79,7 +84,7 @@ class ObserveEngineSuite extends TestCommon {
     val s0 = EngineState.default[IO]
     (for {
       oe <- observeEngine
-      sf <- advanceN(oe, s0, oe.setWaterVapor(wv, user), 2)
+      sf <- advanceN(oe, s0, oe.setWaterVapor(wv, user, clientId), 2)
     } yield sf.flatMap(EngineState.conditions.andThen(Conditions.wv).get).exists { op =>
       op === wv
     }).assert
@@ -90,7 +95,7 @@ class ObserveEngineSuite extends TestCommon {
     val s0 = EngineState.default[IO]
     (for {
       oe <- observeEngine
-      sf <- advanceN(oe, s0, oe.setCloudExtinction(ce, user), 2)
+      sf <- advanceN(oe, s0, oe.setCloudExtinction(ce, user, clientId), 2)
     } yield sf.flatMap(EngineState.conditions.andThen(Conditions.ce).get).exists { op =>
       op === ce
     }).assert
@@ -101,7 +106,7 @@ class ObserveEngineSuite extends TestCommon {
     val s0 = EngineState.default[IO]
     (for {
       oe <- observeEngine
-      sf <- advanceN(oe, s0, oe.setSkyBackground(sb, user), 2)
+      sf <- advanceN(oe, s0, oe.setSkyBackground(sb, user, clientId), 2)
     } yield sf.flatMap(EngineState.conditions.andThen(Conditions.sb).get).exists { op =>
       op === sb
     }).assert

--- a/modules/server_new/src/test/scala/observe/server/StepsViewSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/StepsViewSuite.scala
@@ -17,7 +17,10 @@ import observe.model.enums.Resource.TCS
 import observe.model.enums.*
 import observe.server.TestCommon.*
 
+import java.util.UUID
+
 class StepsViewSuite extends TestCommon {
+  val clientId = ClientId(UUID.randomUUID())
 
   test("StepsView configStatus should build empty without tasks") {
     assert(StepsView.configStatus(Nil).isEmpty)
@@ -177,7 +180,7 @@ class StepsViewSuite extends TestCommon {
 
     (for {
       oe <- observeEngine
-      sf <- advanceN(oe, s0, oe.setImageQuality(iq, user), 2)
+      sf <- advanceN(oe, s0, oe.setImageQuality(iq, user, clientId), 2)
     } yield sf.flatMap(EngineState.conditions.andThen(Conditions.iq).get).exists { op =>
       op === iq
     }).assert
@@ -188,7 +191,7 @@ class StepsViewSuite extends TestCommon {
     val s0 = EngineState.default[IO]
     (for {
       oe <- observeEngine
-      sf <- advanceN(oe, s0, oe.setWaterVapor(wv, user), 2)
+      sf <- advanceN(oe, s0, oe.setWaterVapor(wv, user, clientId), 2)
     } yield sf.flatMap(EngineState.conditions.andThen(Conditions.wv).get).exists { op =>
       op === wv
     }).assert
@@ -199,7 +202,7 @@ class StepsViewSuite extends TestCommon {
     val s0 = EngineState.default[IO]
     (for {
       oe <- observeEngine
-      sf <- advanceN(oe, s0, oe.setCloudExtinction(ce, user), 2)
+      sf <- advanceN(oe, s0, oe.setCloudExtinction(ce, user, clientId), 2)
     } yield sf.flatMap(EngineState.conditions.andThen(Conditions.ce).get).exists { op =>
       op === ce
     }).assert
@@ -210,7 +213,7 @@ class StepsViewSuite extends TestCommon {
     val s0 = EngineState.default[IO]
     for {
       oe <- observeEngine
-      sf <- advanceN(oe, s0, oe.setSkyBackground(sb, user), 2)
+      sf <- advanceN(oe, s0, oe.setSkyBackground(sb, user, clientId), 2)
     } yield sf.flatMap(EngineState.conditions.andThen(Conditions.sb).get).exists { op =>
       op === sb
     }

--- a/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
@@ -23,6 +23,7 @@ import observe.ui.services.ConfigApi
 
 case class ConfigPanel(
   operator:   Option[Operator],
+  clientId:   ClientId,
   conditions: View[Conditions]
 ) extends ReactFnProps(ConfigPanel.component)
 
@@ -39,22 +40,22 @@ object ConfigPanel:
       val iq: View[Option[ImageQuality]] =
         props.conditions
           .zoom(Conditions.iq)
-          .withOnMod(_.map(configApi.setImageQuality).orEmpty.runAsync)
+          .withOnMod(_.map(configApi.setImageQuality(props.clientId, _)).orEmpty.runAsync)
 
       val ce: View[Option[CloudExtinction]] =
         props.conditions
           .zoom(Conditions.ce)
-          .withOnMod(_.map(configApi.setCloudExtinction).orEmpty.runAsync)
+          .withOnMod(_.map(configApi.setCloudExtinction(props.clientId, _)).orEmpty.runAsync)
 
       val wv: View[Option[WaterVapor]] =
         props.conditions
           .zoom(Conditions.wv)
-          .withOnMod(_.map(configApi.setWaterVapor).orEmpty.runAsync)
+          .withOnMod(_.map(configApi.setWaterVapor(props.clientId, _)).orEmpty.runAsync)
 
       val sb: View[Option[SkyBackground]] =
         props.conditions
           .zoom(Conditions.sb)
-          .withOnMod(_.map(configApi.setSkyBackground).orEmpty.runAsync)
+          .withOnMod(_.map(configApi.setSkyBackground(props.clientId, _)).orEmpty.runAsync)
 
       <.div(ObserveStyles.ConfigSection)(
         <.div(ObserveStyles.ObserverArea)(

--- a/modules/web/client/src/main/scala/observe/ui/components/Home.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/Home.scala
@@ -28,6 +28,7 @@ import lucuma.ui.syntax.all.*
 import observe.model.ExecutionState
 import observe.model.Observer
 import observe.model.SequenceState
+import observe.model.SystemOverrides
 import observe.model.enums.ActionStatus
 import observe.model.enums.Resource
 import observe.queries.ObsQueriesGQL
@@ -95,7 +96,7 @@ object Home:
           )
       // TODO: This will actually come from the observe server.
       .useStateView(
-        ExecutionState(SequenceState.Idle, none, none, List.empty)
+        ExecutionState(SequenceState.Idle, none, none, List.empty, SystemOverrides.AllEnabled)
       )
       .useEffectWithDepsBy((_, _, _, _, config, _) => config)((_, _, _, _, _, executionState) =>
         config =>
@@ -138,8 +139,15 @@ object Home:
                     getBreakPoints(executionConfig.science)
               .orEmpty
 
+          // TODO Verify it is correct the use of systemOverrides
           executionState.set(
-            ExecutionState(sequenceState, executingStepId, none, configState, initialBreakpoints)
+            ExecutionState(sequenceState,
+                           executingStepId,
+                           none,
+                           configState,
+                           executionState.get.systemOverrides,
+                           initialBreakpoints
+            )
           )
       )
       .render: (props, ctx, observations, selectedObsId, config, executionState) =>

--- a/modules/web/client/src/main/scala/observe/ui/components/Routing.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/Routing.scala
@@ -27,6 +27,7 @@ object Routing:
             <.div(
               ConfigPanel(
                 rootModel.get.operator,
+                rootModel.zoom(RootModel.clientId).get,
                 rootModel.zoom(RootModel.conditions)
               )
             )

--- a/modules/web/client/src/main/scala/observe/ui/model/RootModel.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/RootModel.scala
@@ -54,11 +54,13 @@ case class RootModel(environment: Environment, data: RootModelData) derives Eq:
 
 object RootModel:
   private val data: Lens[RootModel, RootModelData]                            = Focus[RootModel](_.data)
+  private val environment: Lens[RootModel, Environment]                       = Focus[RootModel](_.environment)
   val userVault: Lens[RootModel, Option[UserVault]]                           = data.andThen(RootModelData.userVault)
   val sequenceExecution: Lens[RootModel, Map[Observation.Id, ExecutionState]] =
     data.andThen(RootModelData.sequenceExecution)
   val conditions: Lens[RootModel, Conditions]                                 = data.andThen(RootModelData.conditions)
   val operator: Lens[RootModel, Option[Operator]]                             = data.andThen(RootModelData.operator)
+  val clientId: Lens[RootModel, ClientId]                                     = environment.andThen(Environment.clientId)
   val userSelectionMessage: Lens[RootModel, Option[NonEmptyString]]           =
     data.andThen(RootModelData.userSelectionMessage)
   val log: Lens[RootModel, List[NonEmptyString]]                              = data.andThen(RootModelData.log)

--- a/modules/web/client/src/main/scala/observe/ui/services/ConfigApi.scala
+++ b/modules/web/client/src/main/scala/observe/ui/services/ConfigApi.scala
@@ -17,11 +17,11 @@ trait ConfigApi[F[_]: MonadThrow]:
   protected val NotAuthorized: F[Unit] =
     MonadThrow[F].raiseError(new RuntimeException("Not authorized"))
 
-  def setImageQuality(iq:    ImageQuality): F[Unit]    = NotAuthorized
-  def setCloudExtinction(ce: CloudExtinction): F[Unit] = NotAuthorized
-  def setWaterVapor(wv:      WaterVapor): F[Unit]      = NotAuthorized
-  def setSkyBackground(sb:   SkyBackground): F[Unit]   = NotAuthorized
-  def refresh(clientId:      ClientId): F[Unit]        = NotAuthorized
+  def setImageQuality(clientId:    ClientId, iq: ImageQuality): F[Unit]    = NotAuthorized
+  def setCloudExtinction(clientId: ClientId, ce: CloudExtinction): F[Unit] = NotAuthorized
+  def setWaterVapor(clientId:      ClientId, wv: WaterVapor): F[Unit]      = NotAuthorized
+  def setSkyBackground(clientId:   ClientId, sb: SkyBackground): F[Unit]   = NotAuthorized
+  def refresh(clientId:            ClientId): F[Unit] = NotAuthorized
 
   def isBlocked: Boolean = false
 

--- a/modules/web/client/src/main/scala/observe/ui/services/ConfigApiImpl.scala
+++ b/modules/web/client/src/main/scala/observe/ui/services/ConfigApiImpl.scala
@@ -50,10 +50,14 @@ case class ConfigApiImpl(
         apiStatus.async.set(ApiStatus.Idle)
     )
 
-  override def setImageQuality(iq:    ImageQuality): IO[Unit]    = request("iq", iq)
-  override def setCloudExtinction(ce: CloudExtinction): IO[Unit] = request("ce", ce)
-  override def setWaterVapor(wv:      WaterVapor): IO[Unit]      = request("wv", wv)
-  override def setSkyBackground(sb:   SkyBackground): IO[Unit]   = request("sb", sb)
-  override def refresh(clientId:      ClientId): IO[Unit]        = request("refresh", clientId)
+  override def setImageQuality(clientId: ClientId, iq: ImageQuality): IO[Unit]       =
+    request(s"${clientId.value}/iq", iq)
+  override def setCloudExtinction(clientId: ClientId, ce: CloudExtinction): IO[Unit] =
+    request(s"${clientId.value}/ce", ce)
+  override def setWaterVapor(clientId: ClientId, wv: WaterVapor): IO[Unit]           =
+    request(s"${clientId.value}/wv", wv)
+  override def setSkyBackground(clientId: ClientId, sb: SkyBackground): IO[Unit]     =
+    request(s"${clientId.value}/sb", sb)
+  override def refresh(clientId: ClientId): IO[Unit] = request(s"${clientId.value}/refresh", ())
 
   override def isBlocked: Boolean = apiStatus.get == ApiStatus.Busy

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
@@ -132,49 +132,49 @@ class ObserveCommandRoutes[F[_]: Async: Compression](
     case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "tcsEnabled" /
         SubsystemEnabledVar(tcsEnabled) =>
       ssoClient.require(req) { user =>
-        oe.setTcsEnabled(obsId, user, tcsEnabled) *>
+        oe.setTcsEnabled(obsId, user, tcsEnabled, clientId) *>
           NoContent()
       }
 
     case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "gcalEnabled" /
         SubsystemEnabledVar(gcalEnabled) =>
       ssoClient.require(req) { user =>
-        oe.setGcalEnabled(obsId, user, gcalEnabled) *>
+        oe.setGcalEnabled(obsId, user, gcalEnabled, clientId) *>
           NoContent()
       }
 
     case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "instrumentEnabled" /
         SubsystemEnabledVar(instEnabled) =>
       ssoClient.require(req) { user =>
-        oe.setInstrumentEnabled(obsId, user, instEnabled) *>
+        oe.setInstrumentEnabled(obsId, user, instEnabled, clientId) *>
           NoContent()
       }
 
     case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "dhsEnabled" /
         SubsystemEnabledVar(dhsEnabled) =>
       ssoClient.require(req) { user =>
-        oe.setDhsEnabled(obsId, user, dhsEnabled) *>
+        oe.setDhsEnabled(obsId, user, dhsEnabled, clientId) *>
           NoContent()
       }
 
     case req @ POST -> Root / ClientIDVar(clientId) / "iq" =>
       ssoClient.require(req) { u =>
-        req.decode[ImageQuality](iq => oe.setImageQuality(iq, u) *> NoContent())
+        req.decode[ImageQuality](iq => oe.setImageQuality(iq, u, clientId) *> NoContent())
       }
 
     case req @ POST -> Root / ClientIDVar(clientId) / "wv" =>
       ssoClient.require(req) { u =>
-        req.decode[WaterVapor](wv => oe.setWaterVapor(wv, u) *> NoContent())
+        req.decode[WaterVapor](wv => oe.setWaterVapor(wv, u, clientId) *> NoContent())
       }
 
     case req @ POST -> Root / ClientIDVar(clientId) / "sb" =>
       ssoClient.require(req) { u =>
-        req.decode[SkyBackground](sb => oe.setSkyBackground(sb, u) *> NoContent())
+        req.decode[SkyBackground](sb => oe.setSkyBackground(sb, u, clientId) *> NoContent())
       }
 
     case req @ POST -> Root / ClientIDVar(clientId) / "ce" =>
       ssoClient.require(req) { u =>
-        req.decode[CloudExtinction](ce => oe.setCloudExtinction(ce, u) *> NoContent())
+        req.decode[CloudExtinction](ce => oe.setCloudExtinction(ce, u, clientId) *> NoContent())
       }
 
     case req @ POST -> Root / "load" / InstrumentVar(i) / ObsIdVar(obsId) /

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
@@ -129,45 +129,56 @@ class ObserveCommandRoutes[F[_]: Async: Compression](
     //   se.setObserver(inputQueue, obsId, user, obs) *>
     //     Ok(s"Set observer name to '${obs.value}' for sequence $obsId")
     //
-    // case POST -> Root / ObsId(obsId) / "tcsEnabled" / BooleanVar(tcsEnabled) as user =>
-    //   se.setTcsEnabled(inputQueue, obsId, user, tcsEnabled) *>
-    //     Ok(s"Set TCS enable flag to '$tcsEnabled' for sequence $obsId")
-    //
-    // case POST -> Root / ObsId(obsId) / "gcalEnabled" / BooleanVar(gcalEnabled) as user =>
-    //   se.setGcalEnabled(inputQueue, obsId, user, gcalEnabled) *>
-    //     Ok(s"Set GCAL enable flag to '$gcalEnabled' for sequence $obsId")
-    //
-    // case POST -> Root / ObsId(obsId) / "instEnabled" / BooleanVar(instEnabled) as user =>
-    //   se.setInstrumentEnabled(inputQueue, obsId, user, instEnabled) *>
-    //     Ok(s"Set instrument enable flag to '$instEnabled' for sequence $obsId")
-    //
-    // case POST -> Root / ObsId(obsId) / "dhsEnabled" / BooleanVar(dhsEnabled) as user =>
-    //   se.setDhsEnabled(inputQueue, obsId, user, dhsEnabled) *>
-    //     Ok(s"Set DHS enable flag to '$dhsEnabled' for sequence $obsId")
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "tcsEnabled" /
+        SubsystemEnabledVar(tcsEnabled) =>
+      ssoClient.require(req) { user =>
+        oe.setTcsEnabled(obsId, user, tcsEnabled) *>
+          NoContent()
+      }
 
-    case req @ POST -> Root / "iq" =>
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "gcalEnabled" /
+        SubsystemEnabledVar(gcalEnabled) =>
+      ssoClient.require(req) { user =>
+        oe.setGcalEnabled(obsId, user, gcalEnabled) *>
+          NoContent()
+      }
+
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "instrumentEnabled" /
+        SubsystemEnabledVar(instEnabled) =>
+      ssoClient.require(req) { user =>
+        oe.setInstrumentEnabled(obsId, user, instEnabled) *>
+          NoContent()
+      }
+
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "dhsEnabled" /
+        SubsystemEnabledVar(dhsEnabled) =>
+      ssoClient.require(req) { user =>
+        oe.setDhsEnabled(obsId, user, dhsEnabled) *>
+          NoContent()
+      }
+
+    case req @ POST -> Root / ClientIDVar(clientId) / "iq" =>
       ssoClient.require(req) { u =>
         req.decode[ImageQuality](iq => oe.setImageQuality(iq, u) *> NoContent())
       }
 
-    case req @ POST -> Root / "wv" =>
+    case req @ POST -> Root / ClientIDVar(clientId) / "wv" =>
       ssoClient.require(req) { u =>
         req.decode[WaterVapor](wv => oe.setWaterVapor(wv, u) *> NoContent())
       }
 
-    case req @ POST -> Root / "sb" =>
+    case req @ POST -> Root / ClientIDVar(clientId) / "sb" =>
       ssoClient.require(req) { u =>
         req.decode[SkyBackground](sb => oe.setSkyBackground(sb, u) *> NoContent())
       }
 
-    case req @ POST -> Root / "ce" =>
+    case req @ POST -> Root / ClientIDVar(clientId) / "ce" =>
       ssoClient.require(req) { u =>
         req.decode[CloudExtinction](ce => oe.setCloudExtinction(ce, u) *> NoContent())
       }
 
-    case req @ POST -> Root / "load" / InstrumentVar(i) / ObsIdVar(obsId) / ObserverVar(
-          observer
-        ) / ClientIDVar(clientId) =>
+    case req @ POST -> Root / "load" / InstrumentVar(i) / ObsIdVar(obsId) /
+        ClientIDVar(clientId) / ObserverVar(observer) =>
       ssoClient.require(req) { user =>
         oe.selectSequence(i, obsId, observer, user, clientId) *> NoContent()
       }
@@ -213,7 +224,7 @@ class ObserveCommandRoutes[F[_]: Async: Compression](
     // }
     //
     // val refreshCommand: HttpRoutes[F] = HttpRoutes.of[F] {
-    case GET -> Root / "refresh" / ClientIDVar(clientId) =>
+    case GET -> Root / ClientIDVar(clientId) / "refresh" =>
       oe.requestRefresh(clientId) *> NoContent()
 
     case req @ POST -> Root / "resetconditions" =>

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/vars.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/vars.scala
@@ -9,45 +9,54 @@ import lucuma.core.model.sequence.Step
 import lucuma.core.util.Enumerated
 import observe.model.ClientId
 import observe.model.Observer
+import observe.model.SubsystemEnabled
 import observe.model.enums.Instrument
 import observe.model.enums.Resource
 import observe.model.enums.RunOverride
 import org.http4s.QueryParamDecoder
 import org.http4s.dsl.impl.OptionalQueryParamDecoderMatcher
 
-object ClientIDVar {
+object ClientIDVar:
   def unapply(str: String): Option[ClientId] =
     Either.catchNonFatal(ClientId(java.util.UUID.fromString(str))).toOption
-}
 
-trait EnumeratedVar[A: Enumerated] {
+trait EnumeratedVar[A: Enumerated]:
   def unapply(str: String): Option[A] =
     Enumerated[A].fromTag(str)
-}
 
 object InstrumentVar extends EnumeratedVar[Instrument]
 object ResourceVar   extends EnumeratedVar[Resource]
 
-object ObsIdVar {
+object ObsIdVar:
   def unapply(str: String): Option[Observation.Id] =
     Observation.Id.parse(str)
-}
 
-object StepIdVar {
+object StepIdVar:
   def unapply(str: String): Option[Step.Id] =
     Step.Id.parse(str)
-}
 
-object ObserverVar {
+object ObserverVar:
   def unapply(str: String): Option[Observer] =
     Observer(str).some
-}
 
 private given QueryParamDecoder[RunOverride] =
-  QueryParamDecoder[Boolean].map {
+  QueryParamDecoder[Boolean].map:
     case true => RunOverride.Override
     case _    => RunOverride.Default
-  }
 
 object OptionalRunOverride
     extends OptionalQueryParamDecoderMatcher[RunOverride]("overrideTargetCheck")
+
+object BooleanVar:
+  def unapply(str: String): Option[Boolean] =
+    str.toLowerCase match
+      case "true"  => Some(true)
+      case "false" => Some(false)
+      case _       => None
+
+object SubsystemEnabledVar:
+  def unapply(str: String): Option[SubsystemEnabled] =
+    str.toLowerCase match
+      case "true"  => SubsystemEnabled.Enabled.some
+      case "false" => SubsystemEnabled.Disabled.some
+      case _       => none

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
@@ -42,7 +42,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
       s      <- commandRoutes(engine)
       wsb    <- WebSocketBuilder2[IO]
       l      <- s(
-                  Request[IO](method = Method.POST, uri = uri"/wv")
+                  Request[IO](method = Method.POST, uri = Uri.unsafeFromString(s"/${clientId.value}/wv"))
                     .withEntity((WaterVapor.Wet: WaterVapor).asJson)
                 ).value
       b      <- l.traverse(_.as[String])
@@ -56,7 +56,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
       s      <- commandRoutes(engine)
       wsb    <- WebSocketBuilder2[IO]
       l      <- s(
-                  Request[IO](method = Method.POST, uri = uri"/iq")
+                  Request[IO](method = Method.POST, uri = Uri.unsafeFromString(s"/${clientId.value}/iq"))
                     .withEntity((ImageQuality.PointTwo: ImageQuality).asJson)
                 ).value
       b      <- l.traverse(_.as[String])
@@ -70,7 +70,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
       s      <- commandRoutes(engine)
       wsb    <- WebSocketBuilder2[IO]
       l      <- s(
-                  Request[IO](method = Method.POST, uri = uri"/sb")
+                  Request[IO](method = Method.POST, uri = Uri.unsafeFromString(s"/${clientId.value}/sb"))
                     .withEntity((SkyBackground.Darkest: SkyBackground).asJson)
                 ).value
       b      <- l.traverse(_.as[String])
@@ -84,7 +84,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
       s      <- commandRoutes(engine)
       wsb    <- WebSocketBuilder2[IO]
       l      <- s(
-                  Request[IO](method = Method.POST, uri = uri"/ce")
+                  Request[IO](method = Method.POST, uri = Uri.unsafeFromString(s"/${clientId.value}/ce"))
                     .withEntity((CloudExtinction.PointFive: CloudExtinction).asJson)
                 ).value
       b      <- l.traverse(_.as[String])
@@ -100,7 +100,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
       l      <- s(
                   Request[IO](method = Method.POST,
                               uri = Uri.unsafeFromString(
-                                s"/load/GmosS/${obsId.show}/observer/${clientId.value}"
+                                s"/load/GmosS/${obsId.show}/${clientId.value}/observer"
                               )
                   )
                 ).value
@@ -117,6 +117,70 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
                   Request[IO](method = Method.POST,
                               uri = Uri.unsafeFromString(
                                 s"/${obsId.show}/execute/${stepId.show}/TCS/observer/${clientId.value}"
+                              )
+                  )
+                ).value
+    } yield l.map(_.status)
+    assertIO(r, Some(Status.NoContent))
+  }
+
+  test("disable tcs") {
+    val r = for {
+      engine <- TestObserveEngine.build[IO]
+      s      <- commandRoutes(engine)
+      wsb    <- WebSocketBuilder2[IO]
+      l      <- s(
+                  Request[IO](method = Method.POST,
+                              uri = Uri.unsafeFromString(
+                                s"/${obsId.show}/${clientId.value}/tcsEnabled/false"
+                              )
+                  )
+                ).value
+    } yield l.map(_.status)
+    assertIO(r, Some(Status.NoContent))
+  }
+
+  test("disable gcal") {
+    val r = for {
+      engine <- TestObserveEngine.build[IO]
+      s      <- commandRoutes(engine)
+      wsb    <- WebSocketBuilder2[IO]
+      l      <- s(
+                  Request[IO](method = Method.POST,
+                              uri = Uri.unsafeFromString(
+                                s"/${obsId.show}/${clientId.value}/gcalEnabled/false"
+                              )
+                  )
+                ).value
+    } yield l.map(_.status)
+    assertIO(r, Some(Status.NoContent))
+  }
+
+  test("disable instrument") {
+    val r = for {
+      engine <- TestObserveEngine.build[IO]
+      s      <- commandRoutes(engine)
+      wsb    <- WebSocketBuilder2[IO]
+      l      <- s(
+                  Request[IO](method = Method.POST,
+                              uri = Uri.unsafeFromString(
+                                s"/${obsId.show}/${clientId.value}/instrumentEnabled/false"
+                              )
+                  )
+                ).value
+    } yield l.map(_.status)
+    assertIO(r, Some(Status.NoContent))
+  }
+
+  test("disable dhs") {
+    val r = for {
+      engine <- TestObserveEngine.build[IO]
+      s      <- commandRoutes(engine)
+      wsb    <- WebSocketBuilder2[IO]
+      l      <- s(
+                  Request[IO](method = Method.POST,
+                              uri = Uri.unsafeFromString(
+                                s"/${obsId.show}/${clientId.value}/dhsEnabled/false"
                               )
                   )
                 ).value

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
@@ -18,12 +18,9 @@ import observe.model.Observation.Id
 import observe.model.*
 import observe.model.enums.*
 import observe.server.EngineState
-import observe.server.EventQueue
-import observe.server.EventType
 import observe.server.ObserveEngine
 import observe.server.SeqEvent
 import observe.server.Systems
-import observe.server.keywords.DhsClientDisabled
 import org.typelevel.log4cats.Logger
 
 class TestObserveEngine[F[_]: Sync: Logger](sys: Systems[F]) extends ObserveEngine[F] {
@@ -79,25 +76,25 @@ class TestObserveEngine[F[_]: Sync: Logger](sys: Systems[F]) extends ObserveEngi
   override def setTcsEnabled(
     seqId:   Id,
     user:    User,
-    enabled: Boolean
+    enabled: SubsystemEnabled
   ): F[Unit] = Applicative[F].unit
 
   override def setGcalEnabled(
     seqId:   Id,
     user:    User,
-    enabled: Boolean
+    enabled: SubsystemEnabled
   ): F[Unit] = Applicative[F].unit
 
   override def setInstrumentEnabled(
     seqId:   Id,
     user:    User,
-    enabled: Boolean
+    enabled: SubsystemEnabled
   ): F[Unit] = Applicative[F].unit
 
   override def setDhsEnabled(
     seqId:   Id,
     user:    User,
-    enabled: Boolean
+    enabled: SubsystemEnabled
   ): F[Unit] = Applicative[F].unit
 
   override def selectSequence(

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
@@ -74,27 +74,31 @@ class TestObserveEngine[F[_]: Sync: Logger](sys: Systems[F]) extends ObserveEngi
   ): F[Unit] = Applicative[F].unit
 
   override def setTcsEnabled(
-    seqId:   Id,
-    user:    User,
-    enabled: SubsystemEnabled
+    seqId:    Id,
+    user:     User,
+    enabled:  SubsystemEnabled,
+    clientId: ClientId
   ): F[Unit] = Applicative[F].unit
 
   override def setGcalEnabled(
-    seqId:   Id,
-    user:    User,
-    enabled: SubsystemEnabled
+    seqId:    Id,
+    user:     User,
+    enabled:  SubsystemEnabled,
+    clientId: ClientId
   ): F[Unit] = Applicative[F].unit
 
   override def setInstrumentEnabled(
-    seqId:   Id,
-    user:    User,
-    enabled: SubsystemEnabled
+    seqId:    Id,
+    user:     User,
+    enabled:  SubsystemEnabled,
+    clientId: ClientId
   ): F[Unit] = Applicative[F].unit
 
   override def setDhsEnabled(
-    seqId:   Id,
-    user:    User,
-    enabled: SubsystemEnabled
+    seqId:    Id,
+    user:     User,
+    enabled:  SubsystemEnabled,
+    clientId: ClientId
   ): F[Unit] = Applicative[F].unit
 
   override def selectSequence(
@@ -113,16 +117,16 @@ class TestObserveEngine[F[_]: Sync: Logger](sys: Systems[F]) extends ObserveEngi
   override def setConditions(conditions: Conditions, user: User): F[Unit] =
     Applicative[F].unit
 
-  override def setImageQuality(iq: ImageQuality, user: User): F[Unit] =
+  override def setImageQuality(iq: ImageQuality, user: User, clientId: ClientId): F[Unit] =
     Applicative[F].unit
 
-  override def setWaterVapor(wv: WaterVapor, user: User): F[Unit] =
+  override def setWaterVapor(wv: WaterVapor, user: User, clientId: ClientId): F[Unit] =
     Applicative[F].unit
 
-  override def setSkyBackground(sb: SkyBackground, user: User): F[Unit] =
+  override def setSkyBackground(sb: SkyBackground, user: User, clientId: ClientId): F[Unit] =
     Applicative[F].unit
 
-  override def setCloudExtinction(cc: CloudExtinction, user: User): F[Unit] =
+  override def setCloudExtinction(cc: CloudExtinction, user: User, clientId: ClientId): F[Unit] =
     Applicative[F].unit
 
   override def setSkipMark(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 val sbtLucumaVersion = "0.11.8"
-addSbtPlugin("edu.gemini" % "sbt-lucuma-app"         % sbtLucumaVersion)
-addSbtPlugin("edu.gemini" % "sbt-lucuma-sjs-bundler" % sbtLucumaVersion)
-addSbtPlugin("edu.gemini" % "sbt-lucuma-css"         % sbtLucumaVersion)
+addSbtPlugin("edu.gemini" % "sbt-lucuma-app" % sbtLucumaVersion)
+addSbtPlugin("edu.gemini" % "sbt-lucuma-css" % sbtLucumaVersion)
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.14.0")
 


### PR DESCRIPTION
These were commented on the engine and are now restored
After thinking a bit I think most routes should take a clientId to log which client does what action.
This required some changes on the client code.