### PR TITLE
Instrument unification

### DIFF
--- a/modules/engine/src/test/scala/observe/engine/StepSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/StepSuite.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.effect.Ref
 import cats.implicits.*
 import fs2.Stream
+import lucuma.core.enums.Instrument.GmosSouth
 import lucuma.core.model.sequence.Atom
 import munit.CatsEffectSuite
 import observe.common.test.*
@@ -18,7 +19,6 @@ import observe.model.ActionType
 import observe.model.ClientId
 import observe.model.SequenceState
 import observe.model.StepState
-import observe.model.enums.Instrument.GmosS
 import observe.model.enums.Resource
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -108,7 +108,7 @@ class StepSuite extends CatsEffectSuite {
    * Emulates Instrument configuration in the real world.
    */
   val configureInst: Action[IO] = fromF[IO](
-    ActionType.Configure(GmosS),
+    ActionType.Configure(GmosSouth),
     for {
       _ <- L.info("System: Start Instrument configuration")
       _ <- IO.sleep(new FiniteDuration(150, MILLISECONDS))

--- a/modules/engine/src/test/scala/observe/engine/packageSpec.scala
+++ b/modules/engine/src/test/scala/observe/engine/packageSpec.scala
@@ -10,6 +10,7 @@ import cats.effect.std.Semaphore
 import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosLong
 import fs2.Stream
+import lucuma.core.enums.Instrument.GmosSouth
 import lucuma.core.model.OrcidId
 import lucuma.core.model.OrcidProfile
 import lucuma.core.model.StandardRole
@@ -26,7 +27,6 @@ import observe.model.ClientId
 import observe.model.Observation
 import observe.model.SequenceState
 import observe.model.StepState
-import observe.model.enums.Instrument.GmosS
 import observe.model.enums.Resource.TCS
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -68,7 +68,7 @@ class packageSpec extends munit.CatsEffectSuite {
   /**
    * Emulates Instrument configuration in the real world.
    */
-  val configureInst: Action[IO] = fromF[IO](ActionType.Configure(GmosS),
+  val configureInst: Action[IO] = fromF[IO](ActionType.Configure(GmosSouth),
                                             for {
                                               _ <- IO(Thread.sleep(200))
                                             } yield Result.OK(DummyResult)

--- a/modules/model/shared/src/main/scala/observe/model/ActionType.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ActionType.scala
@@ -5,15 +5,16 @@ package observe.model
 
 import cats.Eq
 import cats.syntax.all.*
+import lucuma.core.enums.Instrument
 import observe.model.enums.Resource
 
 sealed trait ActionType extends Product with Serializable
 
 object ActionType {
 
-  case object Observe                       extends ActionType
-  case object Undefined                     extends ActionType // Used in tests
-  final case class Configure(sys: Resource) extends ActionType
+  case object Observe                                    extends ActionType
+  case object Undefined                                  extends ActionType // Used in tests
+  final case class Configure(sys: Resource | Instrument) extends ActionType
 
   given Eq[ActionType] =
     Eq.instance {

--- a/modules/model/shared/src/main/scala/observe/model/ExecutionState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ExecutionState.scala
@@ -7,7 +7,9 @@ import cats.Eq
 import cats.derived.*
 import io.circe.Decoder
 import io.circe.Encoder
+import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.Step
+import lucuma.core.util.Enumerated
 import monocle.Focus
 import monocle.Lens
 import observe.model.enums.ActionStatus
@@ -20,7 +22,7 @@ case class ExecutionState(
   sequenceState:   SequenceState,
   runningStepId:   Option[Step.Id],
   nsState:         Option[NsRunningState],
-  configStatus:    List[(Resource, ActionStatus)],
+  configStatus:    Map[Resource | Instrument, ActionStatus],
   systemOverrides: SystemOverrides,
   breakpoints:     Set[Step.Id] = Set.empty
 ) derives Eq,
@@ -28,11 +30,11 @@ case class ExecutionState(
       Decoder
 
 object ExecutionState:
-  val sequenceState: Lens[ExecutionState, SequenceState]                 = Focus[ExecutionState](_.sequenceState)
-  val runningStepId: Lens[ExecutionState, Option[Step.Id]]               = Focus[ExecutionState](_.runningStepId)
-  val nsState: Lens[ExecutionState, Option[NsRunningState]]              = Focus[ExecutionState](_.nsState)
-  val configStatus: Lens[ExecutionState, List[(Resource, ActionStatus)]] =
+  val sequenceState: Lens[ExecutionState, SequenceState]                           = Focus[ExecutionState](_.sequenceState)
+  val runningStepId: Lens[ExecutionState, Option[Step.Id]]                         = Focus[ExecutionState](_.runningStepId)
+  val nsState: Lens[ExecutionState, Option[NsRunningState]]                        = Focus[ExecutionState](_.nsState)
+  val configStatus: Lens[ExecutionState, Map[Resource | Instrument, ActionStatus]] =
     Focus[ExecutionState](_.configStatus)
-  val breakpoints: Lens[ExecutionState, Set[Step.Id]]                    = Focus[ExecutionState](_.breakpoints)
-  val systemOverrides: Lens[ExecutionState, SystemOverrides]             =
+  val systemOverrides: Lens[ExecutionState, SystemOverrides]                       =
     Focus[ExecutionState](_.systemOverrides)
+  val breakpoints: Lens[ExecutionState, Set[Step.Id]]                              = Focus[ExecutionState](_.breakpoints)

--- a/modules/model/shared/src/main/scala/observe/model/Notification.scala
+++ b/modules/model/shared/src/main/scala/observe/model/Notification.scala
@@ -6,7 +6,7 @@ package observe.model
 import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
-import observe.model.enums.Instrument
+import lucuma.core.enums.Instrument
 import observe.model.enums.Resource
 
 enum Notification derives Eq:

--- a/modules/model/shared/src/main/scala/observe/model/SequenceMetadata.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceMetadata.scala
@@ -5,7 +5,7 @@ package observe.model
 
 import cats.Eq
 import cats.derived.*
-import observe.model.enums.Instrument
+import lucuma.core.enums.Instrument
 
 /** Metadata about the sequence required on the exit point */
 case class SequenceMetadata(instrument: Instrument, observer: Option[Observer], name: String)

--- a/modules/model/shared/src/main/scala/observe/model/SequencesQueue.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequencesQueue.scala
@@ -4,11 +4,11 @@
 package observe.model
 
 import cats.*
+import lucuma.core.enums.Instrument
 import monocle.Focus
 import monocle.Getter
 import monocle.Traversal
 import monocle.function.Each.*
-import observe.model.enums.Instrument
 
 import scala.collection.immutable.SortedMap
 

--- a/modules/model/shared/src/main/scala/observe/model/SingleActionOp.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SingleActionOp.scala
@@ -5,22 +5,24 @@ package observe.model
 
 import cats.Eq
 import cats.syntax.all.*
+import lucuma.core.enums.Instrument
 import observe.model.enums.Resource
 
 sealed trait SingleActionOp extends Product with Serializable {
   val sid: Observation.Id
   val stepId: StepId
-  val resource: Resource
+  val resource: Resource | Instrument
 }
 
 object SingleActionOp {
-  case class Started(sid: Observation.Id, stepId: StepId, resource: Resource) extends SingleActionOp
-  case class Completed(sid: Observation.Id, stepId: StepId, resource: Resource)
+  case class Started(sid: Observation.Id, stepId: StepId, resource: Resource | Instrument)
+      extends SingleActionOp
+  case class Completed(sid: Observation.Id, stepId: StepId, resource: Resource | Instrument)
       extends SingleActionOp
   case class Error(
     sid:      Observation.Id,
     stepId:   StepId,
-    resource: Resource,
+    resource: Resource | Instrument,
     msg:      String
   ) extends SingleActionOp
 

--- a/modules/model/shared/src/main/scala/observe/model/Step.scala
+++ b/modules/model/shared/src/main/scala/observe/model/Step.scala
@@ -5,6 +5,7 @@ package observe.model
 
 import cats.*
 import cats.syntax.all.*
+import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.gmos.DynamicConfig
 import lucuma.core.util.Enumerated
@@ -108,8 +109,8 @@ object Step {
       }
     }
 
-  def configStatus: Lens[Step, List[(Resource, ActionStatus)]] =
-    Lens[Step, List[(Resource, ActionStatus)]] {
+  def configStatus: Lens[Step, List[(Resource | Instrument, ActionStatus)]] =
+    Lens[Step, List[(Resource | Instrument, ActionStatus)]] {
       case s: StandardStep      => s.configStatus
       case s: NodAndShuffleStep => s.configStatus
     } { n =>
@@ -198,7 +199,7 @@ final case class StandardStep(
   override val breakpoint: Boolean,
   override val skip:       Boolean,
   override val fileId:     Option[ImageFileId],
-  configStatus:            List[(Resource, ActionStatus)],
+  configStatus:            List[(Resource | Instrument, ActionStatus)],
   observeStatus:           ActionStatus
 ) extends Step
 
@@ -227,7 +228,7 @@ final case class NodAndShuffleStep(
   override val breakpoint: Boolean,
   override val skip:       Boolean,
   override val fileId:     Option[ImageFileId],
-  configStatus:            List[(Resource, ActionStatus)],
+  configStatus:            List[(Resource | Instrument, ActionStatus)],
   nsStatus:                NodAndShuffleStatus,
   pendingObserveCmd:       Option[NodAndShuffleStep.PendingObserveCmd]
 ) extends Step

--- a/modules/model/shared/src/main/scala/observe/model/client.scala
+++ b/modules/model/shared/src/main/scala/observe/model/client.scala
@@ -11,6 +11,7 @@ import io.circe.Encoder
 import io.circe.KeyDecoder
 import io.circe.KeyEncoder
 import io.circe.syntax.*
+import lucuma.core.enums.Instrument
 import lucuma.core.model.Observation
 import lucuma.core.util.Enumerated
 import observe.model.Conditions
@@ -20,6 +21,7 @@ import observe.model.SequenceView
 import observe.model.SequencesQueue
 import observe.model.StepId
 import observe.model.enums.Resource
+import observe.model.given
 
 sealed trait ClientEvent derives Eq
 
@@ -32,7 +34,7 @@ extension (v: SequencesQueue[SequenceView])
 
 extension (q: SequenceView)
   def executionState: ExecutionState =
-    ExecutionState(q.status, q.runningStep.flatMap(_.id), None, Nil, q.systemOverrides)
+    ExecutionState(q.status, q.runningStep.flatMap(_.id), None, Map.empty, q.systemOverrides)
 
 object ClientEvent:
   enum SingleActionState(val tag: String) derives Eq, Enumerated:
@@ -56,7 +58,7 @@ object ClientEvent:
   case class SingleActionEvent(
     obsId:    Observation.Id,
     stepId:   StepId,
-    resource: Resource,
+    resource: Resource | Instrument,
     event:    SingleActionState,
     error:    Option[String]
   ) extends ClientEvent

--- a/modules/model/shared/src/main/scala/observe/model/enums/Resource.scala
+++ b/modules/model/shared/src/main/scala/observe/model/enums/Resource.scala
@@ -3,106 +3,28 @@
 
 package observe.model.enums
 
-import cats.Show
 import cats.data.NonEmptyList
 import cats.syntax.option.*
-import lucuma.core.enums.{Instrument => CoreInstrument}
+import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
 /** A Observe resource represents any system that can be only used by one single agent. */
-sealed abstract class Resource(val tag: String, val ordinal: Int, val label: String)
-    extends Product
-    with Serializable {
-  def isInstrument: Boolean = false
-}
+enum Resource(val label: String) derives Enumerated:
+  def tag: String = label
 
-object Resource {
-
-  case object P1     extends Resource("P1", 1, "P1")
-  case object OI     extends Resource("OI", 2, "OI")
-  case object TCS    extends Resource("TCS", 3, "TCS")
-  case object Gcal   extends Resource("Gcal", 4, "Gcal")
-  case object Gems   extends Resource("Gems", 5, "Gems")
-  case object Altair extends Resource("Altair", 6, "Altair")
+  case P1     extends Resource("P1")
+  case OI     extends Resource("OI")
+  case TCS    extends Resource("TCS")
+  case Gcal   extends Resource("Gcal")
+  case Gems   extends Resource("Gems")
+  case Altair extends Resource("Altair")
 
   // Mount and science fold cannot be controlled independently. Maybe in the future.
   // For now, I replaced them with TCS
-  //  case object Mount extends Resource
-  //  case object ScienceFold extends Resource
-  given Show[Resource] =
-    Show.show(_.label)
+  //  case Mount extends Resource
+  //  case ScienceFold extends Resource
 
-  val common: List[Resource] = List(TCS, Gcal)
+object Resource:
+  val Common: List[Resource] = List(TCS, Gcal)
 
-  /** @group Typeclass Instances */
-  given Enumerated[Resource] =
-    Enumerated.from(Instrument.allResources.head, Instrument.allResources.tail: _*).withTag(_.tag)
-}
-
-sealed abstract class Instrument(tag: String, ordinal: Int, label: String)
-    extends Resource(tag, ordinal, label) {
-  override def isInstrument: Boolean = true
-
-  def underlying: CoreInstrument = this match
-    // case Instrument.F2    => CoreInstrument.Flamingos2
-    // case Instrument.Ghost => CoreInstrument.Ghost
-    case Instrument.GmosS => CoreInstrument.GmosSouth
-    case Instrument.GmosN => CoreInstrument.GmosNorth
-    // case Instrument.Gnirs => CoreInstrument.Gnirs
-    // case Instrument.Gpi   => CoreInstrument.Gpi
-    // case Instrument.Gsaoi => CoreInstrument.Gsaoi
-    // case Instrument.Niri  => CoreInstrument.Niri
-    // case Instrument.Nifs  => CoreInstrument.Nifs
-}
-
-object Instrument {
-  def fromCoreInstrument(i: CoreInstrument): Option[Instrument] =
-    i match
-      // case CoreInstrument.Flamingos2 => F2
-      // case CoreInstrument.Ghost      => Ghost
-      case CoreInstrument.GmosSouth => GmosS.some
-      case CoreInstrument.GmosNorth => GmosN.some
-      // case CoreInstrument.Gnirs      => Gnirs
-      // case CoreInstrument.Gpi        => Gpi
-      // case CoreInstrument.Gsaoi      => Gsaoi
-      // case CoreInstrument.Niri       => Niri
-      // case CoreInstrument.Nifs       => Nifs
-      case _                        => none
-
-//  case object F2    extends Instrument("F2", 11, "Flamingos2")
-//  case object Ghost extends Instrument("Ghost", 12, "GHOST")
-  case object GmosS extends Instrument("GmosS", 13, "GMOS-S")
-  case object GmosN extends Instrument("GmosN", 14, "GMOS-N")
-//  case object Gnirs extends Instrument("Gnirs", 15, "GNIRS")
-//  case object Gpi   extends Instrument("Gpi", 16, "GPI")
-//  case object Gsaoi extends Instrument("Gsaoi", 17, "GSAOI")
-//  case object Niri  extends Instrument("Niri", 18, "NIRI")
-//  case object Nifs  extends Instrument("Nifs", 19, "NIFS")
-
-  given Show[Instrument] =
-    Show.show(_.label)
-
-  val gsInstruments: NonEmptyList[Instrument] =
-    NonEmptyList.of(GmosS)
-//    NonEmptyList.of(F2, Ghost, GmosS, Gpi, Gsaoi)
-
-  val gnInstruments: NonEmptyList[Instrument] =
-    NonEmptyList.of(GmosN)
-//    NonEmptyList.of(GmosN, Gnirs, Niri, Nifs)
-
-  val all: NonEmptyList[Instrument] =
-    gsInstruments.concatNel(gnInstruments)
-
-  val allResources: NonEmptyList[Resource] =
-    NonEmptyList.of(Resource.P1,
-                    Resource.OI,
-                    Resource.TCS,
-                    Resource.Gcal,
-                    Resource.Gems,
-                    Resource.Altair
-    ) ::: Instrument.all
-
-  /** @group Typeclass Instances */
-  given Enumerated[Instrument] =
-    Enumerated.from(all.head, all.tail: _*).withTag(_.tag)
-}
+  given Display[Resource] = Display.byShortName(_.label)

--- a/modules/model/shared/src/main/scala/observe/model/events.scala
+++ b/modules/model/shared/src/main/scala/observe/model/events.scala
@@ -6,6 +6,7 @@ package observe.model.events
 import cats.*
 import cats.derived.*
 import cats.syntax.all.*
+import lucuma.core.enums.Instrument
 import lucuma.core.model.User
 import observe.model.*
 import observe.model.dhs.ImageFileId

--- a/modules/model/shared/src/main/scala/observe/model/operations.scala
+++ b/modules/model/shared/src/main/scala/observe/model/operations.scala
@@ -3,7 +3,7 @@
 
 package observe.model
 
-import observe.model.enums.Instrument
+import lucuma.core.enums.Instrument
 
 object operations:
   enum OperationLevel:
@@ -123,8 +123,8 @@ object operations:
 
   private val instrumentOperations: Map[Instrument, SupportedOperations] = Map(
     // Instrument.F2     -> F2SupportedOperations,
-    Instrument.GmosS -> GmosSupportedOperations,
-    Instrument.GmosN -> GmosSupportedOperations
+    Instrument.GmosSouth -> GmosSupportedOperations,
+    Instrument.GmosNorth -> GmosSupportedOperations
     // Instrument.Gnirs -> GnirsSupportedOperations,
     // Instrument.Niri   -> NiriSupportedOperations,
     // Instrument.Nifs   -> NifsSupportedOperations,

--- a/modules/model/shared/src/main/scala/observe/model/package.scala
+++ b/modules/model/shared/src/main/scala/observe/model/package.scala
@@ -1,43 +1,68 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package observe
+package observe.model
 
 import cats.*
-import observe.model.enums.Instrument
+import cats.syntax.all.*
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.KeyDecoder
+import io.circe.KeyEncoder
+import io.circe.syntax.*
+import lucuma.core.enums.Instrument
+import lucuma.core.util.Enumerated
+import observe.model.enums.Resource
 import squants.time.Time
 import squants.time.TimeUnit
 
 import java.util.UUID
 
-package object model {
-  type StepId          = lucuma.core.model.sequence.Step.Id
-  type ObservationName = String
-  type TargetName      = String
+type StepId          = lucuma.core.model.sequence.Step.Id
+type ObservationName = String
+type TargetName      = String
 
-  val UnknownTargetName = "None"
+val UnknownTargetName = "None"
 
-  val CalibrationQueueName: String = "Calibration Queue"
-  val CalibrationQueueId: QueueId  =
-    QueueId(UUID.fromString("7156fa7e-48a6-49d1-a267-dbf3bbaa7577"))
+val CalibrationQueueName: String = "Calibration Queue"
+val CalibrationQueueId: QueueId  =
+  QueueId(UUID.fromString("7156fa7e-48a6-49d1-a267-dbf3bbaa7577"))
 
-  given Eq[TimeUnit] =
-    Eq.by(_.symbol)
+given Eq[TimeUnit] =
+  Eq.by(_.symbol)
 
-  given Eq[Time] =
-    Eq.by(_.toMilliseconds)
+given Eq[Time] =
+  Eq.by(_.toMilliseconds)
 
-  extension (i: Instrument) {
-    def hasOI: Boolean = i match {
+extension (i: Instrument)
+  def hasOI: Boolean = i match
 //      case Instrument.F2    => true
-      case Instrument.GmosS => true
-      case Instrument.GmosN => true
+    case Instrument.GmosSouth => true
+    case Instrument.GmosNorth => true
+    case _                    => false
 //      case Instrument.Nifs  => true
 //      case Instrument.Niri  => true
 //      case Instrument.Gnirs => true
 //      case Instrument.Gsaoi => false
 //      case Instrument.Gpi   => true
 //      case Instrument.Ghost => false
-    }
-  }
-}
+
+// Resources come before Instruments
+given Order[Resource | Instrument] = Order.from:
+  case (a: Resource, b: Resource)     => Order[Resource].compare(a, b)
+  case (a: Instrument, b: Instrument) => Order[Instrument].compare(a, b)
+  case (a: Resource, b: Instrument)   => -1
+  case (a: Instrument, b: Resource)   => 1
+
+given Encoder[Resource | Instrument] = Encoder.instance:
+  case r: Resource   => r.asJson
+  case i: Instrument => i.asJson
+given Decoder[Resource | Instrument] =
+  Decoder[Resource].widen.or:
+    Decoder[Instrument].widen
+
+given KeyEncoder[Resource | Instrument] = KeyEncoder.instance:
+  case r: Resource   => r.tag
+  case i: Instrument => i.tag
+given KeyDecoder[Resource | Instrument] = KeyDecoder.instance: tag =>
+  Enumerated[Resource].fromTag(tag).orElse(Enumerated[Instrument].fromTag(tag))

--- a/modules/model/shared/src/test/scala/observe/model/ModelSuite.scala
+++ b/modules/model/shared/src/test/scala/observe/model/ModelSuite.scala
@@ -23,7 +23,6 @@ class ModelSuite extends munit.DisciplineSuite {
   checkAll("Order[Resource]", OrderTests[Resource].order)
   checkAll("Eq[Resource]", EqTests[Resource].eqv)
   checkAll("Eq[List]", EqTests[List[(Resource, ActionStatus)]].eqv)
-  checkAll("Eq[Instrument]", EqTests[Instrument].eqv)
   checkAll("Eq[Operator]", EqTests[Operator].eqv)
   checkAll("Eq[StepState]", EqTests[StepState].eqv)
   checkAll("Eq[ActionStatus]", EqTests[ActionStatus].eqv)

--- a/modules/model/shared/src/test/scala/observe/model/ObserveModelArbitraries.scala
+++ b/modules/model/shared/src/test/scala/observe/model/ObserveModelArbitraries.scala
@@ -9,6 +9,7 @@ import lucuma.core.arb.newTypeArbitrary
 import lucuma.core.arb.newTypeCogen
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
 import lucuma.core.math.arb.ArbRefined.given
@@ -215,7 +216,7 @@ trait ObserveModelArbitraries {
     }
 
   given Cogen[SingleActionOp.Started] =
-    Cogen[(Observation.Id, StepId, Resource)]
+    Cogen[(Observation.Id, StepId, Resource | Instrument)]
       .contramap(x => (x.sid, x.stepId, x.resource))
 
   given Arbitrary[SingleActionOp.Completed] =
@@ -228,7 +229,7 @@ trait ObserveModelArbitraries {
     }
 
   given Cogen[SingleActionOp.Completed] =
-    Cogen[(Observation.Id, StepId, Resource)]
+    Cogen[(Observation.Id, StepId, Resource | Instrument)]
       .contramap(x => (x.sid, x.stepId, x.resource))
 
   given Arbitrary[SingleActionOp.Error] =
@@ -242,7 +243,7 @@ trait ObserveModelArbitraries {
     }
 
   given Cogen[SingleActionOp.Error] =
-    Cogen[(Observation.Id, StepId, Resource, String)]
+    Cogen[(Observation.Id, StepId, Resource | Instrument, String)]
       .contramap(x => (x.sid, x.stepId, x.resource, x.msg))
 
   given Arbitrary[SingleActionOp] = Arbitrary[SingleActionOp] {

--- a/modules/model/shared/src/test/scala/observe/model/SequenceEventsArbitraries.scala
+++ b/modules/model/shared/src/test/scala/observe/model/SequenceEventsArbitraries.scala
@@ -4,6 +4,7 @@
 package observe.model
 
 import lucuma.core.arb.ArbTime.*
+import lucuma.core.enums.Instrument
 import lucuma.core.model.User
 import lucuma.core.model.arb.ArbUser.*
 import lucuma.core.util.arb.ArbEnumerated.*

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbNodAndShuffleStep.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbNodAndShuffleStep.scala
@@ -3,6 +3,7 @@
 
 package observe.model.arb
 
+import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.arb.ArbStepConfig.*
 import lucuma.core.model.sequence.gmos.DynamicConfig
@@ -20,6 +21,7 @@ import observe.model.arb.ArbDhsTypes.given
 import observe.model.arb.ArbGmosParameters.given
 import observe.model.arb.ArbNsRunningState.given
 import observe.model.arb.ArbStepState.given
+import observe.model.arb.ArbSystem.given
 import observe.model.enums.ActionStatus
 import observe.model.enums.Resource
 import org.scalacheck.Arbitrary
@@ -85,7 +87,7 @@ trait ArbNodAndShuffleStep {
         Boolean,
         Boolean,
         Option[dhs.ImageFileId],
-        List[(Resource, ActionStatus)],
+        List[(Resource | Instrument, ActionStatus)],
         NodAndShuffleStatus
       )
     ].contramap(s =>

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbNotification.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbNotification.scala
@@ -3,6 +3,7 @@
 
 package observe.model.arb
 
+import lucuma.core.enums.Instrument
 import lucuma.core.util.arb.ArbEnumerated.*
 import lucuma.core.util.arb.ArbGid.*
 import lucuma.core.util.arb.ArbUid.*
@@ -10,7 +11,6 @@ import observe.model.Notification
 import observe.model.Notification.*
 import observe.model.Observation
 import observe.model.StepId
-import observe.model.enums.Instrument
 import observe.model.enums.Resource
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.*

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbStandardStep.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbStandardStep.scala
@@ -3,6 +3,7 @@
 
 package observe.model.arb
 
+import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.arb.ArbStepConfig.*
 import lucuma.core.model.sequence.gmos.DynamicConfig
@@ -12,6 +13,7 @@ import lucuma.core.util.arb.ArbUid.*
 import observe.model.*
 import observe.model.arb.ArbDhsTypes.given
 import observe.model.arb.ArbStepState.given
+import observe.model.arb.ArbSystem.given
 import observe.model.enums.*
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.*
@@ -30,15 +32,16 @@ trait ArbStandardStep {
       f  <- arbitrary[Option[dhs.ImageFileId]]
       cs <- arbitrary[List[(Resource, ActionStatus)]]
       os <- arbitrary[ActionStatus]
-    } yield new StandardStep(id = id,
-                             instConfig = d,
-                             stepConfig = t,
-                             status = s,
-                             breakpoint = b,
-                             skip = k,
-                             fileId = f,
-                             configStatus = cs,
-                             observeStatus = os
+    } yield new StandardStep(
+      id = id,
+      instConfig = d,
+      stepConfig = t,
+      status = s,
+      breakpoint = b,
+      skip = k,
+      fileId = f,
+      configStatus = cs,
+      observeStatus = os
     )
   }
 
@@ -52,7 +55,7 @@ trait ArbStandardStep {
         Boolean,
         Boolean,
         Option[dhs.ImageFileId],
-        List[(Resource, ActionStatus)],
+        List[(Resource | Instrument, ActionStatus)],
         ActionStatus
       )
     ].contramap(s =>

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbSystem.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbSystem.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.model.arb
+
+import cats.syntax.all.*
+import lucuma.core.enums.Instrument
+import lucuma.core.util.arb.ArbEnumerated.given
+import observe.model.enums.Resource
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbSystem:
+  given Arbitrary[Resource | Instrument] = Arbitrary:
+    Gen.oneOf(arbitrary[Resource], arbitrary[Instrument])
+  given Cogen[Resource | Instrument]     = Cogen[Either[Resource, Instrument]].contramap:
+    case r: Resource   => r.asLeft
+    case i: Instrument => i.asRight
+
+object ArbSystem extends ArbSystem

--- a/modules/model/shared/src/test/scala/observe/model/arb/package.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/package.scala
@@ -23,3 +23,4 @@ package object arb:
       with ArbObservationProgress
       with ArbUserPrompt
       with ArbLength
+      with ArbSystem

--- a/modules/server_new/src/main/scala/observe/server/ExecutionQueue.scala
+++ b/modules/server_new/src/main/scala/observe/server/ExecutionQueue.scala
@@ -4,12 +4,12 @@
 package observe.server
 
 import cats.Eq
+import lucuma.core.enums.Instrument
 import monocle.Focus
 import monocle.Lens
 import observe.model.BatchCommandState
 import observe.model.Observation
 import observe.model.SequenceState
-import observe.model.enums.Instrument
 import observe.model.enums.Resource
 import observe.server.ExecutionQueue.SequenceInQueue
 
@@ -24,7 +24,7 @@ object ExecutionQueue {
     obsId:      Observation.Id,
     instrument: Instrument,
     state:      SequenceState,
-    resources:  Set[Resource]
+    resources:  Set[Resource | Instrument]
   )
 
   def init(name: String): ExecutionQueue =

--- a/modules/server_new/src/main/scala/observe/server/InstrumentGuide.scala
+++ b/modules/server_new/src/main/scala/observe/server/InstrumentGuide.scala
@@ -3,7 +3,7 @@
 
 package observe.server
 
-import observe.model.enums.Instrument
+import lucuma.core.enums.Instrument
 import squants.space.Length
 
 trait InstrumentGuide {

--- a/modules/server_new/src/main/scala/observe/server/InstrumentSystem.scala
+++ b/modules/server_new/src/main/scala/observe/server/InstrumentSystem.scala
@@ -5,9 +5,9 @@ package observe.server
 
 import cats.data.Kleisli
 import fs2.Stream
+import lucuma.core.enums.Instrument
 import lucuma.core.util.TimeSpan
 import observe.model.dhs.ImageFileId
-import observe.model.enums.Instrument
 import observe.model.enums.ObserveCommandResult
 import observe.server.keywords.KeywordsClient
 

--- a/modules/server_new/src/main/scala/observe/server/ObserveActions.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveActions.scala
@@ -128,12 +128,12 @@ trait ObserveActions {
       _ <- env.headers(env.ctx).traverse(_.sendBefore(env.obsId, fileId))
       _ <-
         info(
-          s"Start ${env.inst.resource.show} observation ${env.obsId} with label $fileId"
+          s"Start ${env.inst.resource.longName} observation ${env.obsId} with label $fileId"
         )
       r <- env.inst.observe(fileId)
       _ <-
         info(
-          s"Completed ${env.inst.resource.show} observation ${env.obsId} with label $fileId"
+          s"Completed ${env.inst.resource.longName} observation ${env.obsId} with label $fileId"
         )
     } yield r
 

--- a/modules/server_new/src/main/scala/observe/server/Response.scala
+++ b/modules/server_new/src/main/scala/observe/server/Response.scala
@@ -3,6 +3,7 @@
 
 package observe.server
 
+import lucuma.core.enums.Instrument
 import observe.engine.Result.RetVal
 import observe.model.dhs.ImageFileId
 import observe.model.enums.Resource
@@ -11,7 +12,7 @@ sealed trait Response extends RetVal with Product with Serializable
 
 object Response {
 
-  final case class Configured(resource: Resource) extends Response
+  final case class Configured(resource: Resource | Instrument) extends Response
 
   final case class Observed(fileId: ImageFileId) extends Response
 

--- a/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
@@ -5,6 +5,7 @@ package observe.server
 
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
 import lucuma.core.model.User

--- a/modules/server_new/src/main/scala/observe/server/StepType.scala
+++ b/modules/server_new/src/main/scala/observe/server/StepType.scala
@@ -5,8 +5,8 @@ package observe.server
 
 import cats.*
 import cats.syntax.all.*
+import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.StepConfig
-import observe.model.enums.Instrument
 
 sealed trait StepType extends Product with Serializable {
   def instrument: Instrument

--- a/modules/server_new/src/main/scala/observe/server/System.scala
+++ b/modules/server_new/src/main/scala/observe/server/System.scala
@@ -3,10 +3,11 @@
 
 package observe.server
 
+import lucuma.core.enums.Instrument
 import observe.model.enums.Resource
 
 trait System[F[_]] {
-  val resource: Resource
+  val resource: Resource | Instrument
 
   /**
    * Called to configure a system

--- a/modules/server_new/src/main/scala/observe/server/altair/Altair.scala
+++ b/modules/server_new/src/main/scala/observe/server/altair/Altair.scala
@@ -6,8 +6,8 @@ package observe.server.altair
 import cats.ApplicativeThrow
 import cats.Eq
 import cats.effect.Sync
+import lucuma.core.enums.Instrument
 import observe.common.ObsQueriesGQL.ObsQuery.Data.Observation
-import observe.model.enums.Instrument
 import observe.model.enums.Resource
 import observe.server.altair.AltairController.*
 import observe.server.gems.GemsController.GemsConfig

--- a/modules/server_new/src/main/scala/observe/server/altair/AltairController.scala
+++ b/modules/server_new/src/main/scala/observe/server/altair/AltairController.scala
@@ -6,7 +6,7 @@ package observe.server.altair
 import cats.Eq
 import cats.Show
 import cats.syntax.all.*
-import observe.model.enums.Instrument
+import lucuma.core.enums.Instrument
 import observe.server.tcs.Gaos.GuideCapabilities
 import observe.server.tcs.Gaos.PauseConditionSet
 import observe.server.tcs.Gaos.ResumeConditionSet

--- a/modules/server_new/src/main/scala/observe/server/altair/AltairControllerDisabled.scala
+++ b/modules/server_new/src/main/scala/observe/server/altair/AltairControllerDisabled.scala
@@ -5,7 +5,7 @@ package observe.server.altair
 
 import cats.Applicative
 import cats.syntax.all.*
-import observe.model.enums.Instrument
+import lucuma.core.enums.Instrument
 import observe.server.altair.AltairController.AltairPauseResume
 import observe.server.overrideLogMessage
 import observe.server.tcs.Gaos

--- a/modules/server_new/src/main/scala/observe/server/altair/AltairControllerEpics.scala
+++ b/modules/server_new/src/main/scala/observe/server/altair/AltairControllerEpics.scala
@@ -5,21 +5,17 @@ package observe.server.altair
 
 import cats.Eq
 import cats.*
-import cats.*
 import cats.effect.Async
 import cats.effect.Sync
 import cats.syntax.all.*
-import cats.syntax.all.*
 import edu.gemini.epics.acm.CarStateGEM5
 import edu.gemini.observe.server.altair.LgsSfoControl
+import lucuma.core.enums.Instrument
 import lucuma.core.util.TimeSpan
 import monocle.Focus
 import mouse.boolean.*
-import mouse.boolean.*
 import observe.model.enums.ApplyCommandResult
-import observe.model.enums.Instrument
 import observe.server.ObserveFailure
-import observe.server.altair.AltairController.*
 import observe.server.altair.AltairController.*
 import observe.server.tcs.FOCAL_PLANE_SCALE
 import observe.server.tcs.Gaos.PauseCondition.GaosGuideOff
@@ -29,7 +25,6 @@ import observe.server.tcs.Gaos.ResumeCondition.GaosGuideOn
 import observe.server.tcs.Gaos.ResumeCondition.OiOn
 import observe.server.tcs.Gaos.ResumeCondition.P1On
 import observe.server.tcs.Gaos.*
-import observe.server.tcs.Gaos.*
 import observe.server.tcs.TcsController.FocalPlaneOffset
 import observe.server.tcs.TcsEpics
 import org.typelevel.log4cats.Logger
@@ -37,7 +32,6 @@ import squants.Length
 import squants.Time
 import squants.space.Arcseconds
 import squants.space.Millimeters
-import squants.time.TimeConversions.*
 import squants.time.TimeConversions.*
 
 import java.time.LocalDate

--- a/modules/server_new/src/main/scala/observe/server/altair/AltairControllerSim.scala
+++ b/modules/server_new/src/main/scala/observe/server/altair/AltairControllerSim.scala
@@ -5,7 +5,7 @@ package observe.server.altair
 
 import cats.Applicative
 import cats.syntax.all.*
-import observe.model.enums.Instrument
+import lucuma.core.enums.Instrument
 import observe.server.altair.AltairController.AltairPauseResume
 import observe.server.tcs.Gaos.GuideCapabilities
 import observe.server.tcs.Gaos.PauseConditionSet

--- a/modules/server_new/src/main/scala/observe/server/gmos/Gmos.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/Gmos.scala
@@ -13,6 +13,7 @@ import lucuma.core.enums.GmosAdc
 import lucuma.core.enums.GmosEOffsetting
 import lucuma.core.enums.GmosGratingOrder
 import lucuma.core.enums.GmosRoi
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.MosPreImaging
 import lucuma.core.enums.ObserveClass
 import lucuma.core.math.Wavelength
@@ -27,7 +28,6 @@ import monocle.Getter
 import observe.model.GmosParameters.*
 import observe.model.dhs.ImageFileId
 import observe.model.enums.Guiding
-import observe.model.enums.Instrument
 import observe.model.enums.NodAndShuffleStage
 import observe.model.enums.NodAndShuffleStage.*
 import observe.model.enums.ObserveCommandResult

--- a/modules/server_new/src/main/scala/observe/server/gmos/GmosNorth.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/GmosNorth.scala
@@ -8,6 +8,7 @@ import cats.effect.Ref
 import cats.effect.Temporal
 import cats.syntax.all.*
 import lucuma.core.enums.GmosRoi
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.LightSinkName
 import lucuma.core.enums.MosPreImaging
 import lucuma.core.enums.ObserveClass
@@ -19,7 +20,6 @@ import lucuma.core.model.sequence.gmos.GmosNodAndShuffle
 import lucuma.core.model.sequence.gmos.StaticConfig
 import lucuma.core.util.TimeSpan
 import monocle.Getter
-import observe.model.enums.Instrument
 import observe.server.InstrumentSpecifics
 import observe.server.ObserveFailure
 import observe.server.StepType
@@ -47,7 +47,7 @@ final case class GmosNorth[F[_]: Temporal: Logger] private (
       nsCmdR,
       cfg
     ) {
-  override val resource: Instrument      = Instrument.GmosN
+  override val resource: Instrument      = Instrument.GmosNorth
   override val dhsInstrumentName: String = "GMOS-N"
   override val dhsClient: DhsClient[F]   = dhsClientProvider.dhsClient(dhsInstrumentName)
 
@@ -98,7 +98,7 @@ object GmosNorth {
     dhsClientProvider,
     nsCmdR,
     Gmos.buildConfig[F, GmosSite.North.type, StaticConfig.GmosNorth, DynamicConfig.GmosNorth](
-      Instrument.GmosS,
+      Instrument.GmosSouth,
       stepType,
       staticCfg,
       dynamicCfg
@@ -118,7 +118,7 @@ object GmosNorth {
     GmosObsKeywordsReader(staticConfig, dynamicConfig)
 
   object specifics extends InstrumentSpecifics[StaticConfig.GmosNorth, DynamicConfig.GmosNorth] {
-    override val instrument: Instrument = Instrument.GmosN
+    override val instrument: Instrument = Instrument.GmosNorth
 
     override def calcStepType(
       stepConfig:   StepConfig,

--- a/modules/server_new/src/main/scala/observe/server/gmos/GmosSouth.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/GmosSouth.scala
@@ -8,6 +8,7 @@ import cats.effect.Ref
 import cats.effect.Temporal
 import cats.syntax.all.*
 import lucuma.core.enums.GmosRoi
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.LightSinkName
 import lucuma.core.enums.MosPreImaging
 import lucuma.core.enums.ObserveClass
@@ -19,7 +20,6 @@ import lucuma.core.model.sequence.gmos.GmosNodAndShuffle
 import lucuma.core.model.sequence.gmos.StaticConfig
 import lucuma.core.util.TimeSpan
 import monocle.Getter
-import observe.model.enums.Instrument
 import observe.server.InstrumentSpecifics
 import observe.server.ObserveFailure
 import observe.server.StepType
@@ -47,7 +47,7 @@ final case class GmosSouth[F[_]: Temporal: Logger](
       nsCmdR,
       cfg
     ) {
-  override val resource: Instrument      = Instrument.GmosS
+  override val resource: Instrument      = Instrument.GmosSouth
   override val dhsInstrumentName: String = "GMOS-S"
   override val dhsClient: DhsClient[F]   = dhsClientProvider.dhsClient(dhsInstrumentName)
 
@@ -98,7 +98,7 @@ object GmosSouth {
     dhsClientProvider,
     nsCmdR,
     Gmos.buildConfig[F, GmosSite.South.type, StaticConfig.GmosSouth, DynamicConfig.GmosSouth](
-      Instrument.GmosS,
+      Instrument.GmosSouth,
       stepType,
       staticCfg,
       dynamicCfg
@@ -118,7 +118,7 @@ object GmosSouth {
     GmosObsKeywordsReader(staticConfig, dynamicConfig)
 
   object specifics extends InstrumentSpecifics[StaticConfig.GmosSouth, DynamicConfig.GmosSouth] {
-    override val instrument: Instrument = Instrument.GmosS
+    override val instrument: Instrument = Instrument.GmosSouth
 
     override def calcStepType(
       stepConfig:   StepConfig,

--- a/modules/server_new/src/main/scala/observe/server/gmos/GmosStepsView.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/GmosStepsView.scala
@@ -4,6 +4,7 @@
 package observe.server.gmos
 
 import cats.syntax.all.*
+import lucuma.core.enums.Instrument
 import mouse.all.*
 import observe.engine
 import observe.model.NodAndShuffleStep.PendingObserveCmd
@@ -17,7 +18,7 @@ final class GmosStepsView[F[_]] extends StepsView[F] {
   override def stepView(
     stepg:         SequenceGen.StepGen[F],
     step:          engine.Step[F],
-    altCfgStatus:  List[(Resource, ActionStatus)],
+    altCfgStatus:  List[(Resource | Instrument, ActionStatus)],
     pendingObsCmd: Option[PendingObserveCmd]
   ): Step = {
     val nodAndShuffle: Option[GmosController.Config.NsConfig.NodAndShuffle] = stepg.genData match {

--- a/modules/server_new/src/main/scala/observe/server/package.scala
+++ b/modules/server_new/src/main/scala/observe/server/package.scala
@@ -17,6 +17,7 @@ import cats.effect.std.Queue
 import cats.syntax.all.*
 import clue.ErrorPolicy
 import fs2.Stream
+import lucuma.core.enums.Instrument
 import lucuma.core.util.TimeSpan
 import lucuma.schemas.ObservationDB.Scalars.VisitId
 import monocle.Focus
@@ -75,8 +76,8 @@ package object server {
     def instrumentLoaded[F[_]](
       instrument: Instrument
     ): Lens[EngineState[F], Option[SequenceData[F]]] = instrument match {
-      case Instrument.GmosS => EngineState.selectedGmosSouth
-      case Instrument.GmosN => EngineState.selectedGmosNorth
+      case Instrument.GmosSouth => EngineState.selectedGmosSouth
+      case Instrument.GmosNorth => EngineState.selectedGmosNorth
     }
 
     def atSequence[F[_]](sid: Observation.Id): Optional[EngineState[F], SequenceData[F]] =

--- a/modules/server_new/src/main/scala/observe/server/tcs/TcsControllerEpicsCommon.scala
+++ b/modules/server_new/src/main/scala/observe/server/tcs/TcsControllerEpicsCommon.scala
@@ -8,6 +8,7 @@ import cats.data.*
 import cats.effect.Async
 import cats.effect.Sync
 import cats.syntax.all.*
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.LightSinkName
 import lucuma.core.enums.Site
 import lucuma.core.math.Wavelength
@@ -862,7 +863,7 @@ object TcsControllerEpicsCommon {
 
   def oiSelectionName(i: Instrument): Option[String] = i match {
 //    case Instrument.F2                                        => "F2".some
-    case Instrument.GmosS | Instrument.GmosN => "GMOS".some
+    case Instrument.GmosSouth | Instrument.GmosNorth => "GMOS".some
 //    case Instrument.Gnirs                                     => "GNIRS".some
 //    case Instrument.Niri                                      => "NIRI".some
 //    case Instrument.Nifs                                      => "NIFS".some

--- a/modules/server_new/src/main/scala/observe/server/tcs/TcsSettleTimeCalculator.scala
+++ b/modules/server_new/src/main/scala/observe/server/tcs/TcsSettleTimeCalculator.scala
@@ -6,8 +6,8 @@ package observe.server.tcs
 import cats.Order
 import cats.data.NonEmptySet
 import cats.syntax.all.*
+import lucuma.core.enums.Instrument
 import mouse.boolean.*
-import observe.model.enums.Instrument
 import observe.server.tcs.TcsController.InstrumentOffset
 import observe.server.tcs.TcsController.Subsystem
 import squants.Ratio
@@ -45,8 +45,8 @@ object TcsSettleTimeCalculator {
   )
 
   val oiwfsSettleTimeCalculators: Map[Instrument, SettleTimeCalculator] = Map(
-    Instrument.GmosN -> constantSettleTime(1.seconds),
-    Instrument.GmosS -> constantSettleTime(1.seconds)
+    Instrument.GmosNorth -> constantSettleTime(1.seconds),
+    Instrument.GmosSouth -> constantSettleTime(1.seconds)
 //    Instrument.F2    -> constantSettleTime(1.seconds),
 //    Instrument.Nifs  -> constantSettleTime(4.seconds),
 //    Instrument.Niri  -> constantSettleTime(4.seconds),

--- a/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
@@ -8,6 +8,7 @@ import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosLong
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.*
 import lucuma.core.math.Offset
 import lucuma.core.model.ConstraintSet
@@ -39,7 +40,6 @@ import observe.model.StepState
 import observe.model.SystemOverrides
 import observe.model.UserPrompt
 import observe.model.dhs.DataId
-import observe.model.enums.Instrument
 import observe.model.enums.Resource
 import observe.model.enums.Resource.Gcal
 import observe.model.enums.Resource.TCS
@@ -115,9 +115,10 @@ class ObserveEngineSuite extends TestCommon {
   test("ObserveEngine setObserver should set observer's name") {
     val observer = Observer("Joe")
     val s0       = ODBSequencesLoader
-      .loadSequenceEndo[IO](None,
-                            sequence(seqObsId1),
-                            EngineState.instrumentLoaded(Instrument.GmosN)
+      .loadSequenceEndo[IO](
+        None,
+        sequence(seqObsId1),
+        EngineState.instrumentLoaded(Instrument.GmosNorth)
       )
       .apply(EngineState.default[IO])
     (for {
@@ -136,13 +137,13 @@ class ObserveEngineSuite extends TestCommon {
     val s0 = (
       ODBSequencesLoader.loadSequenceEndo[IO](
         None,
-        sequenceWithResources(seqObsId1, Instrument.GmosN, Set(Instrument.GmosN, TCS)),
-        EngineState.instrumentLoaded(Instrument.GmosN)
+        sequenceWithResources(seqObsId1, Instrument.GmosNorth, Set(Instrument.GmosNorth, TCS)),
+        EngineState.instrumentLoaded(Instrument.GmosNorth)
       ) >>>
         ODBSequencesLoader.loadSequenceEndo[IO](
           None,
-          sequenceWithResources(seqObsId2, Instrument.GmosS, Set(Instrument.GmosS, TCS)),
-          EngineState.instrumentLoaded(Instrument.GmosS)
+          sequenceWithResources(seqObsId2, Instrument.GmosSouth, Set(Instrument.GmosSouth, TCS)),
+          EngineState.instrumentLoaded(Instrument.GmosSouth)
         ) >>>
         EngineState
           .sequenceStateIndex[IO](seqObsId1)
@@ -166,13 +167,13 @@ class ObserveEngineSuite extends TestCommon {
     val s0 = (
       ODBSequencesLoader.loadSequenceEndo[IO](
         None,
-        sequenceWithResources(seqObsId1, Instrument.GmosN, Set(Instrument.GmosN, TCS)),
-        EngineState.instrumentLoaded(Instrument.GmosN)
+        sequenceWithResources(seqObsId1, Instrument.GmosNorth, Set(Instrument.GmosNorth, TCS)),
+        EngineState.instrumentLoaded(Instrument.GmosNorth)
       ) >>>
         ODBSequencesLoader.loadSequenceEndo[IO](
           None,
-          sequenceWithResources(seqObsId2, Instrument.GmosS, Set(Instrument.GmosS)),
-          EngineState.instrumentLoaded(Instrument.GmosS)
+          sequenceWithResources(seqObsId2, Instrument.GmosSouth, Set(Instrument.GmosSouth)),
+          EngineState.instrumentLoaded(Instrument.GmosSouth)
         ) >>>
         EngineState
           .sequenceStateIndex[IO](seqObsId1)
@@ -203,8 +204,8 @@ class ObserveEngineSuite extends TestCommon {
     val s0 = ODBSequencesLoader
       .loadSequenceEndo[IO](
         None,
-        sequenceWithResources(seqObsId1, Instrument.GmosN, Set(Instrument.GmosN, TCS)),
-        EngineState.instrumentLoaded(Instrument.GmosN)
+        sequenceWithResources(seqObsId1, Instrument.GmosNorth, Set(Instrument.GmosNorth, TCS)),
+        EngineState.instrumentLoaded(Instrument.GmosNorth)
       )
       .apply(EngineState.default[IO])
 
@@ -234,8 +235,8 @@ class ObserveEngineSuite extends TestCommon {
   test("ObserveEngine should not run a system configuration if sequence is running") {
     val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](
       None,
-      sequenceWithResources(seqObsId1, Instrument.GmosN, Set(Instrument.GmosN, TCS)),
-      EngineState.instrumentLoaded(Instrument.GmosN)
+      sequenceWithResources(seqObsId1, Instrument.GmosNorth, Set(Instrument.GmosNorth, TCS)),
+      EngineState.instrumentLoaded(Instrument.GmosNorth)
     ) >>>
       EngineState
         .sequenceStateIndex[IO](seqObsId1)
@@ -267,13 +268,13 @@ class ObserveEngineSuite extends TestCommon {
   test("ObserveEngine should not run a system configuration if system is in use") {
     val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](
       None,
-      sequenceWithResources(seqObsId1, Instrument.GmosN, Set(Instrument.GmosN, TCS)),
-      EngineState.instrumentLoaded(Instrument.GmosN)
+      sequenceWithResources(seqObsId1, Instrument.GmosNorth, Set(Instrument.GmosNorth, TCS)),
+      EngineState.instrumentLoaded(Instrument.GmosNorth)
     ) >>>
       ODBSequencesLoader.loadSequenceEndo[IO](
         None,
-        sequenceWithResources(seqObsId2, Instrument.GmosS, Set(Instrument.GmosS, TCS)),
-        EngineState.instrumentLoaded(Instrument.GmosS)
+        sequenceWithResources(seqObsId2, Instrument.GmosSouth, Set(Instrument.GmosSouth, TCS)),
+        EngineState.instrumentLoaded(Instrument.GmosSouth)
       ) >>>
       EngineState
         .sequenceStateIndex[IO](seqObsId1)
@@ -310,13 +311,13 @@ class ObserveEngineSuite extends TestCommon {
   ) {
     val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](
       None,
-      sequenceWithResources(seqObsId1, Instrument.GmosN, Set(Instrument.GmosN, TCS)),
-      EngineState.instrumentLoaded(Instrument.GmosN)
+      sequenceWithResources(seqObsId1, Instrument.GmosNorth, Set(Instrument.GmosNorth, TCS)),
+      EngineState.instrumentLoaded(Instrument.GmosNorth)
     ) >>>
       ODBSequencesLoader.loadSequenceEndo[IO](
         None,
-        sequenceWithResources(seqObsId2, Instrument.GmosS, Set(Instrument.GmosN, Gcal)),
-        EngineState.instrumentLoaded(Instrument.GmosS)
+        sequenceWithResources(seqObsId2, Instrument.GmosSouth, Set(Instrument.GmosNorth, Gcal)),
+        EngineState.instrumentLoaded(Instrument.GmosSouth)
       ) >>>
       EngineState
         .sequenceStateIndex[IO](seqObsId1)
@@ -348,9 +349,10 @@ class ObserveEngineSuite extends TestCommon {
 
   test("ObserveEngine startFrom should start a sequence from an arbitrary step") {
     val s0        = ODBSequencesLoader
-      .loadSequenceEndo[IO](None,
-                            sequenceNSteps(seqObsId1, 5),
-                            EngineState.instrumentLoaded(Instrument.GmosN)
+      .loadSequenceEndo[IO](
+        None,
+        sequenceNSteps(seqObsId1, 5),
+        EngineState.instrumentLoaded(Instrument.GmosNorth)
       )
       .apply(EngineState.default[IO])
     val runStepId = stepId(3)
@@ -382,13 +384,13 @@ class ObserveEngineSuite extends TestCommon {
   test("ObserveEngine startFrom should not start the sequence if there is a resource conflict") {
     val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](
       None,
-      sequenceWithResources(seqObsId1, Instrument.GmosN, Set(Instrument.GmosN, TCS)),
-      EngineState.instrumentLoaded(Instrument.GmosN)
+      sequenceWithResources(seqObsId1, Instrument.GmosNorth, Set(Instrument.GmosNorth, TCS)),
+      EngineState.instrumentLoaded(Instrument.GmosNorth)
     ) >>>
       ODBSequencesLoader.loadSequenceEndo[IO](
         None,
-        sequenceWithResources(seqObsId2, Instrument.GmosS, Set(Instrument.GmosS, TCS)),
-        EngineState.instrumentLoaded(Instrument.GmosS)
+        sequenceWithResources(seqObsId2, Instrument.GmosSouth, Set(Instrument.GmosSouth, TCS)),
+        EngineState.instrumentLoaded(Instrument.GmosSouth)
       ) >>>
       EngineState
         .sequenceStateIndex[IO](seqObsId1)
@@ -836,7 +838,7 @@ class ObserveEngineSuite extends TestCommon {
 //   }
 
   private val testConditionsSequence: SequenceGen[IO] = {
-    val resources: Set[Resource] = Set(Instrument.GmosN, TCS)
+    val resources: Set[Resource | Instrument] = Set(Instrument.GmosNorth, TCS)
 
     val obsTypes: NonEmptyList[(ObserveClass, StepConfig)] = NonEmptyList(
       (ObserveClass.ProgramCal, StepConfig.Dark),
@@ -894,7 +896,7 @@ class ObserveEngineSuite extends TestCommon {
           )
         )
       ),
-      instrument = Instrument.GmosN,
+      instrument = Instrument.GmosNorth,
       staticCfg1,
       atomId1,
       steps = stepList.map { step =>
@@ -920,9 +922,10 @@ class ObserveEngineSuite extends TestCommon {
 
     val seq = testConditionsSequence
 
-    val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](None,
-                                                      seq,
-                                                      EngineState.instrumentLoaded(Instrument.GmosN)
+    val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](
+      None,
+      seq,
+      EngineState.instrumentLoaded(Instrument.GmosNorth)
     ) >>>
       EngineState.conditions.andThen(Conditions.iq).replace(ImageQuality.PointTwo.some) >>>
       EngineState.conditions.andThen(Conditions.wv).replace(WaterVapor.Median.some) >>>
@@ -953,9 +956,10 @@ class ObserveEngineSuite extends TestCommon {
   test("ObserveEngine start should not start the sequence if it fails the conditions check") {
     val seq = testConditionsSequence
 
-    val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](None,
-                                                      seq,
-                                                      EngineState.instrumentLoaded(Instrument.GmosN)
+    val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](
+      None,
+      seq,
+      EngineState.instrumentLoaded(Instrument.GmosNorth)
     ) >>>
       EngineState.conditions.andThen(Conditions.iq).replace(ImageQuality.OnePointZero.some) >>>
       EngineState.conditions.andThen(Conditions.wv).replace(WaterVapor.Dry.some) >>>
@@ -1000,9 +1004,10 @@ class ObserveEngineSuite extends TestCommon {
 
     val seq = testConditionsSequence
 
-    val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](None,
-                                                      seq,
-                                                      EngineState.instrumentLoaded(Instrument.GmosN)
+    val s0 = (ODBSequencesLoader.loadSequenceEndo[IO](
+      None,
+      seq,
+      EngineState.instrumentLoaded(Instrument.GmosNorth)
     ) >>>
       EngineState.conditions.andThen(Conditions.iq).replace(ImageQuality.OnePointZero.some) >>>
       EngineState.conditions.andThen(Conditions.wv).replace(WaterVapor.Dry.some) >>>

--- a/modules/server_new/src/test/scala/observe/server/ObserveServerArbitraries.scala
+++ b/modules/server_new/src/test/scala/observe/server/ObserveServerArbitraries.scala
@@ -3,13 +3,14 @@
 
 package observe.server
 
+import lucuma.core.enums.Instrument
 import lucuma.core.util.arb.ArbEnumerated.*
 import lucuma.core.util.arb.ArbGid.*
 import observe.model.BatchCommandState
 import observe.model.Observation
 import observe.model.ObserveModelArbitraries.given
 import observe.model.SequenceState
-import observe.model.enums.Instrument
+import observe.model.arb.ArbSystem.given
 import observe.model.enums.Resource
 import observe.server.ExecutionQueue.SequenceInQueue
 import org.scalacheck.Arbitrary
@@ -26,12 +27,12 @@ trait ObserveServerArbitraries {
       o <- arbitrary[Observation.Id]
       i <- arbitrary[Instrument]
       s <- arbitrary[SequenceState]
-      r <- arbitrary[Set[Resource]]
+      r <- arbitrary[Set[Resource | Instrument]]
     } yield SequenceInQueue(o, i, s, r)
   }
 
   given Cogen[SequenceInQueue] =
-    Cogen[(Observation.Id, Instrument, SequenceState, List[Resource])]
+    Cogen[(Observation.Id, Instrument, SequenceState, List[Resource | Instrument])]
       .contramap(x => (x.obsId, x.instrument, x.state, x.resources.toList))
 
   given Arbitrary[ExecutionQueue] = Arbitrary {

--- a/modules/server_new/src/test/scala/observe/server/SeqTranslateSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/SeqTranslateSuite.scala
@@ -8,6 +8,7 @@ import cats.data.NonEmptyList
 import cats.effect.*
 import cats.syntax.all.*
 import fs2.Stream
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.Site
 import lucuma.core.util.TimeSpan
 import observe.common.test.*
@@ -18,7 +19,6 @@ import observe.model.ActionType
 import observe.model.Conditions
 import observe.model.SequenceState
 import observe.model.dhs.*
-import observe.model.enums.Instrument
 import observe.server.Response.Observed
 import observe.server.SequenceGen.StepStatusGen
 import observe.server.TestCommon.*
@@ -42,7 +42,7 @@ class SeqTranslateSuite extends TestCommon {
       SequenceGen.PendingStepGen(
         stepId(1),
         Monoid.empty[DataId],
-        Set(Instrument.GmosN),
+        Set(Instrument.GmosNorth),
         _ => InstrumentSystem.Uncontrollable,
         SequenceGen.StepActionsGen(Map.empty,
                                    (_, _) => List(observeActions(Action.ActionState.Idle))
@@ -56,7 +56,7 @@ class SeqTranslateSuite extends TestCommon {
 
   private val baseState: EngineState[IO] =
     (ODBSequencesLoader
-      .loadSequenceEndo[IO](None, seqg, EngineState.instrumentLoaded(Instrument.GmosN)) >>>
+      .loadSequenceEndo[IO](None, seqg, EngineState.instrumentLoaded(Instrument.GmosNorth)) >>>
       EngineState
         .sequenceStateIndex[IO](seqObsId1)
         .andThen(Sequence.State.status[IO])

--- a/modules/server_new/src/test/scala/observe/server/StepsViewNSSpec.scala
+++ b/modules/server_new/src/test/scala/observe/server/StepsViewNSSpec.scala
@@ -7,6 +7,7 @@ import cats.Id
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.syntax.eq.*
+import lucuma.core.enums.Instrument
 import observe.engine.*
 import observe.model.enums.*
 import observe.server.TestCommon.*
@@ -20,18 +21,20 @@ class StepsViewNSSuite extends munit.FunSuite {
   }
 
   test("running after the observe and configure") {
-    val executions: List[ParallelActions[Id]] = List(NonEmptyList.one(running(Resource.TCS)),
-                                                     NonEmptyList.one(observePartial),
-                                                     NonEmptyList.one(done(Instrument.GmosN))
+    val executions: List[ParallelActions[Id]] = List(
+      NonEmptyList.one(running(Resource.TCS)),
+      NonEmptyList.one(observePartial),
+      NonEmptyList.one(done(Instrument.GmosNorth))
     )
     assert(StepsView.observeStatus(executions) === ActionStatus.Running)
   }
 
   test("running after the observe/configure/continue/complete") {
-    val executions: List[ParallelActions[Id]] = List(NonEmptyList.one(running(Resource.TCS)),
-                                                     NonEmptyList.one(observePartial),
-                                                     NonEmptyList.one(done(Instrument.GmosN)),
-                                                     NonEmptyList.one(observed)
+    val executions: List[ParallelActions[Id]] = List(
+      NonEmptyList.one(running(Resource.TCS)),
+      NonEmptyList.one(observePartial),
+      NonEmptyList.one(done(Instrument.GmosNorth)),
+      NonEmptyList.one(observed)
     )
     assert(StepsView.observeStatus(executions) === ActionStatus.Running)
   }

--- a/modules/server_new/src/test/scala/observe/server/tcs/TcsControllerEpicsCommonSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/tcs/TcsControllerEpicsCommonSuite.scala
@@ -10,6 +10,7 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import edu.gemini.observe.server.tcs.BinaryOnOff
 import edu.gemini.observe.server.tcs.BinaryYesNo
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.LightSinkName.Gmos
 import lucuma.core.enums.Site
 import lucuma.core.math.Wavelength
@@ -18,7 +19,6 @@ import observe.model.M1GuideConfig
 import observe.model.M2GuideConfig
 import observe.model.TelescopeGuideConfig
 import observe.model.enums.ComaOption
-import observe.model.enums.Instrument
 import observe.model.enums.M1Source
 import observe.model.enums.MountGuideOption
 import observe.model.enums.TipTiltSource
@@ -83,7 +83,7 @@ class TcsControllerEpicsCommonSuite extends munit.FunSuite {
       OIConfig(GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff))
     ),
     AGConfig(LightPath(Sky, Gmos), None),
-    DummyInstrument(Instrument.GmosS, 1.millimeters.some)
+    DummyInstrument(Instrument.GmosSouth, 1.millimeters.some)
   )
 
   test("TcsControllerEpicsCommon should not pause guiding if it is not necessary") {
@@ -322,7 +322,7 @@ class TcsControllerEpicsCommonSuite extends munit.FunSuite {
                 )
               ) >>>
             BasicTcsConfig.instLensGS
-              .replace(DummyInstrument(Instrument.GmosS, threshold.some))
+              .replace(DummyInstrument(Instrument.GmosSouth, threshold.some))
         )(baseConfig)
       )
     )
@@ -352,7 +352,7 @@ class TcsControllerEpicsCommonSuite extends munit.FunSuite {
                 )
               ) >>>
             BasicTcsConfig.instLensGS
-              .replace(DummyInstrument(Instrument.GmosS, threshold.some))
+              .replace(DummyInstrument(Instrument.GmosSouth, threshold.some))
         )(baseConfig)
       )
     )
@@ -383,7 +383,7 @@ class TcsControllerEpicsCommonSuite extends munit.FunSuite {
                 )
               ) >>>
             BasicTcsConfig.instLensGS
-              .replace(DummyInstrument(Instrument.GmosS, threshold.some))
+              .replace(DummyInstrument(Instrument.GmosSouth, threshold.some))
         )(baseConfig)
       )
     )

--- a/modules/web/client/src/main/scala/observe/ui/components/Home.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/Home.scala
@@ -31,6 +31,7 @@ import observe.model.SequenceState
 import observe.model.SystemOverrides
 import observe.model.enums.ActionStatus
 import observe.model.enums.Resource
+import observe.model.given
 import observe.queries.ObsQueriesGQL
 import observe.ui.DefaultErrorPolicy
 import observe.ui.ObserveStyles
@@ -96,7 +97,7 @@ object Home:
           )
       // TODO: This will actually come from the observe server.
       .useStateView(
-        ExecutionState(SequenceState.Idle, none, none, List.empty, SystemOverrides.AllEnabled)
+        ExecutionState(SequenceState.Idle, none, none, Map.empty, SystemOverrides.AllEnabled)
       )
       .useEffectWithDepsBy((_, _, _, _, config, _) => config)((_, _, _, _, _, executionState) =>
         config =>
@@ -125,7 +126,7 @@ object Home:
           val configState = List(
             (Resource.TCS, ActionStatus.Completed),
             (Resource.Gcal, ActionStatus.Running),
-            (observe.model.enums.Instrument.GmosN, ActionStatus.Pending)
+            (Instrument.GmosNorth, ActionStatus.Pending)
           )
 
           val initialBreakpoints: Set[Step.Id] =
@@ -141,12 +142,13 @@ object Home:
 
           // TODO Verify it is correct the use of systemOverrides
           executionState.set(
-            ExecutionState(sequenceState,
-                           executingStepId,
-                           none,
-                           configState,
-                           executionState.get.systemOverrides,
-                           initialBreakpoints
+            ExecutionState(
+              sequenceState,
+              executingStepId,
+              none,
+              configState.toMap,
+              executionState.get.systemOverrides,
+              initialBreakpoints
             )
           )
       )

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
@@ -10,7 +10,6 @@ import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Step
 import lucuma.react.common.*
 import observe.model.SequenceState
-import observe.model.enums.{Instrument => ObserveInstrument}
 import observe.model.operations.*
 import observe.ui.components.sequence.ControlButtons
 import observe.ui.model.TabOperations
@@ -32,18 +31,15 @@ object StepControlButtons:
   private type Props = StepControlButtons
 
   protected val component = ScalaFnComponent[Props]: props =>
-    ObserveInstrument
-      .fromCoreInstrument(props.instrument)
-      .map: instrument =>
-        ControlButtons(
-          props.obsId,
-          instrument.operations(
-            OperationLevel.Observation,
-            props.isObservePaused,
-            props.isMultiLevel
-          ),
-          props.sequenceState,
-          props.stepId,
-          props.isObservePaused,
-          props.tabOperations
-        ): VdomNode
+    ControlButtons(
+      props.obsId,
+      props.instrument.operations(
+        OperationLevel.Observation,
+        props.isObservePaused,
+        props.isMultiLevel
+      ),
+      props.sequenceState,
+      props.stepId,
+      props.isObservePaused,
+      props.tabOperations
+    ): VdomNode

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepProgressCell.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepProgressCell.scala
@@ -30,7 +30,7 @@ case class StepProgressCell(
   obsId:         Observation.Id,
   tabOperations: TabOperations,
   sequenceState: SequenceState,
-  configStatus:  List[(Resource, ActionStatus)],
+  configStatus:  Map[Resource | Instrument, ActionStatus],
   selectedStep:  Option[Step.Id],
   isPreview:     Boolean
 ) extends ReactFnProps(StepProgressCell.component):
@@ -112,7 +112,7 @@ object StepProgressCell:
       SubsystemControls(
         props.obsId,
         props.stepId,
-        props.configStatus.map(_._1),
+        props.configStatus.map(_._1).toList,
         TabOperations.resourceRunRequested.get(props.tabOperations),
         props.clientMode
       ),

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/SubsystemControls.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/SubsystemControls.scala
@@ -3,10 +3,11 @@
 
 package observe.ui.components.sequence.steps
 
-import cats.Order.*
+import cats.Order.given
 import cats.syntax.all.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.enums.Instrument
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Step
 import lucuma.core.syntax.display.*
@@ -15,6 +16,7 @@ import lucuma.react.fa.FontAwesomeIcon
 import lucuma.react.floatingui.syntax.*
 import lucuma.react.primereact.*
 import observe.model.enums.*
+import observe.model.given
 import observe.ui.Icons
 import observe.ui.ObserveStyles
 import observe.ui.display.given
@@ -29,8 +31,8 @@ import scala.collection.immutable.SortedMap
 case class SubsystemControls(
   obsId:          Observation.Id,
   stepId:         Step.Id,
-  resources:      List[Resource],
-  resourcesCalls: SortedMap[Resource, ResourceRunOperation],
+  resources:      List[Resource | Instrument],
+  resourcesCalls: SortedMap[Resource | Instrument, ResourceRunOperation],
   clientMode:     ClientMode
 ) extends ReactFnProps(SubsystemControls.component)
 
@@ -75,7 +77,8 @@ object SubsystemControls:
 
   private val component = ScalaFnComponent[Props]: props =>
     <.div(ObserveStyles.ConfigButtonStrip)( // (ObserveStyles.notInMobile)(
-      props.resources.sorted
+      props.resources
+        .sorted[Resource | Instrument]
         .map: resource =>
           val resourceState: Option[ResourceRunOperation] = props.resourcesCalls.get(resource)
           val buttonIcon: Option[FontAwesomeIcon]         = determineIcon(resourceState)

--- a/modules/web/client/src/main/scala/observe/ui/display/givens.scala
+++ b/modules/web/client/src/main/scala/observe/ui/display/givens.scala
@@ -4,6 +4,8 @@
 package observe.ui.display
 
 // import cats.syntax.eq.*
+import lucuma.core.enums.Instrument
+import lucuma.core.syntax.display.*
 import lucuma.core.util.Display
 import observe.model.RunningStep
 import observe.model.enums.*
@@ -19,5 +21,16 @@ import observe.model.enums.*
 // given Display[WaterVapor]      = conditionDisplay(_.toInt, _.label)
 
 given Display[Resource] = Display.byShortName(_.label)
+
+given Display[Resource | Instrument] = Display.by(
+  {
+    case r: Resource   => r.shortName
+    case i: Instrument => i.shortName
+  },
+  {
+    case r: Resource   => r.longName
+    case i: Instrument => i.longName
+  }
+)
 
 given Display[RunningStep] = Display.byShortName(u => s"${u.last + 1}/${u.total}")

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/vars.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/vars.scala
@@ -4,13 +4,13 @@
 package observe.web.server.http4s
 
 import cats.syntax.all.*
+import lucuma.core.enums.Instrument
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Step
 import lucuma.core.util.Enumerated
 import observe.model.ClientId
 import observe.model.Observer
 import observe.model.SubsystemEnabled
-import observe.model.enums.Instrument
 import observe.model.enums.Resource
 import observe.model.enums.RunOverride
 import org.http4s.QueryParamDecoder

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
@@ -101,7 +101,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
                   Request[IO](
                     method = Method.POST,
                     uri = Uri.unsafeFromString(
-                      s"/load/GmosS/${obsId.show}/${clientId.value}/observer"
+                      s"/load/GmosSouth/${obsId.show}/${clientId.value}/observer"
                     )
                   )
                 ).value

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
@@ -98,10 +98,11 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
       s      <- commandRoutes(engine)
       wsb    <- WebSocketBuilder2[IO]
       l      <- s(
-                  Request[IO](method = Method.POST,
-                              uri = Uri.unsafeFromString(
-                                s"/load/GmosS/${obsId.show}/${clientId.value}/observer"
-                              )
+                  Request[IO](
+                    method = Method.POST,
+                    uri = Uri.unsafeFromString(
+                      s"/load/GmosS/${obsId.show}/${clientId.value}/observer"
+                    )
                   )
                 ).value
     } yield l.map(_.status)

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
@@ -10,6 +10,7 @@ import cats.syntax.all.*
 import fs2.Stream
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
 import lucuma.core.model.User

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/TestRoutes.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/TestRoutes.scala
@@ -4,11 +4,6 @@
 package observe.web.server.http4s
 
 import cats.effect.IO
-import cats.effect.Ref
-import cats.effect.std.Queue
-import fs2.concurrent.Topic
-import giapi.client.GiapiStatusDb
-import lucuma.core.enums.Site
 import lucuma.core.model.OrcidId
 import lucuma.core.model.OrcidProfile
 import lucuma.core.model.StandardRole
@@ -16,22 +11,16 @@ import lucuma.core.model.StandardUser
 import lucuma.core.model.User
 import lucuma.refined.*
 import lucuma.sso.client.SsoClient.AbstractSsoClient
-import observe.model.config.*
-import observe.model.events.*
-import observe.server.{*, given}
+import observe.server.*
 import org.http4s.*
 import org.http4s.headers.Authorization
-import org.http4s.implicits.*
-import org.http4s.server.websocket.WebSocketBuilder2
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.noop.NoOpLogger
-
-import scala.concurrent.duration.*
 
 trait TestRoutes {
   given logger: Logger[IO] = NoOpLogger.impl[IO]
 
-  private val statusDb = GiapiStatusDb.simulatedDb[IO]
+  // private val statusDb = GiapiStatusDb.simulatedDb[IO]
   // private val config      =
   //   AuthenticationConfig(FiniteDuration(8, HOURS), "token", "abc", useSsl = false, Nil)
   // private val authService = AuthenticationService[IO](Mode.Development, config)


### PR DESCRIPTION
Removes the `Resource.Instrument` sub sum type in favor of the `Instrument` enum from core.

`Resource` can be declared as an `enum` now.

Where necessary, `Resource` type is changed to `Resource | Instrument`.

Maybe we can made an opaque `System` type alias, but there's already a `System` type that encapsulates a `Resource | Instrument`, which may be converted into extension methods. We can evaluate this in a future PR.