### PR TITLE
Show observation header, keep obs details and sequence loaded until a new one is selected

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,6 +33,14 @@ pull_request_rules:
       add:
       - client-clue
       remove: []
+- name: Label client-model PRs
+  conditions:
+  - files~=^modules/web/client-model/
+  actions:
+    label:
+      add:
+      - client-model
+      remove: []
 - name: Label engine PRs
   conditions:
   - files~=^modules/engine/

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val root = tlCrossRootProject.aggregate(
   observe_web_client,
   observe_server,
   observe_model,
+  observe_ui_model,
   observe_engine
 )
 
@@ -105,6 +106,17 @@ lazy val observe_web_server = project
   .dependsOn(observe_server)
   .dependsOn(observe_model.jvm % "compile->compile;test->test")
 
+lazy val observe_ui_model = project
+  .in(file("modules/web/client-model"))
+  .settings(lucumaGlobalSettings: _*)
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    coverageEnabled := false,
+    libraryDependencies ++= Seq(
+      LucumaSchemas.value
+    ) ++ LucumaCore.value ++ Circe.value
+  )
+
 lazy val observe_web_client = project
   .in(file("modules/web/client"))
   .settings(lucumaGlobalSettings: _*)
@@ -132,7 +144,7 @@ lazy val observe_web_client = project
     ),
     buildInfoPackage := "observe.ui"
   )
-  .dependsOn(observe_model.js)
+  .dependsOn(observe_model.js, observe_ui_model)
 
 // List all the modules and their inter dependencies
 lazy val observe_server = project

--- a/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
@@ -1,0 +1,83 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.ui.model
+
+import cats.Eq
+import cats.Order.given
+import cats.derived.*
+import cats.syntax.all.*
+import io.circe.Decoder
+import io.circe.generic.semiauto.*
+import lucuma.core.model.ConstraintSet
+import lucuma.core.model.ObsAttachment
+// import lucuma.core.model.Observation
+import lucuma.core.model.PosAngleConstraint
+import lucuma.core.model.TimingWindow
+import lucuma.core.util.Timestamp
+import lucuma.schemas.decoders.given
+import lucuma.schemas.model.BasicConfiguration
+import lucuma.schemas.model.ObservingMode
+import monocle.Focus
+import org.typelevel.cats.time.*
+
+import java.time.Instant
+import scala.collection.immutable.SortedSet
+
+// This class is only used by the UI, but it's in the shared model project so that it can be used
+// by the UI's clue queries.
+case class ObsSummary(
+  // id:                 Observation.Id,
+  title:              String,
+  constraints:        ConstraintSet,
+  timingWindows:      List[TimingWindow],
+  attachmentIds:      SortedSet[ObsAttachment.Id],
+  observingMode:      Option[ObservingMode],
+  visualizationTime:  Option[Instant],
+  posAngleConstraint: PosAngleConstraint
+) derives Eq:
+  lazy val configurationSummary: Option[String] = observingMode.map(_.toBasicConfiguration) match
+    case Some(BasicConfiguration.GmosNorthLongSlit(grating, _, fpu, _)) =>
+      s"GMOS-N ${grating.shortName} ${fpu.shortName}".some
+    case Some(BasicConfiguration.GmosSouthLongSlit(grating, _, fpu, _)) =>
+      s"GMOS-S ${grating.shortName} ${fpu.shortName}".some
+    case _                                                              =>
+      none
+
+  lazy val constraintsSummary: String =
+    s"${constraints.imageQuality.label} ${constraints.cloudExtinction.label} ${constraints.skyBackground.label} ${constraints.waterVapor.label}"
+
+object ObsSummary:
+  // val id                 = Focus[ObsSummary](_.id)
+  val title              = Focus[ObsSummary](_.title)
+  val constraints        = Focus[ObsSummary](_.constraints)
+  val timingWindows      = Focus[ObsSummary](_.timingWindows)
+  val attachmentIds      = Focus[ObsSummary](_.attachmentIds)
+  val observingMode      = Focus[ObsSummary](_.observingMode)
+  val visualizationTime  = Focus[ObsSummary](_.visualizationTime)
+  val posAngleConstraint = Focus[ObsSummary](_.posAngleConstraint)
+
+  private case class AttachmentIdWrapper(id: ObsAttachment.Id)
+  private object AttachmentIdWrapper:
+    given Decoder[AttachmentIdWrapper] = deriveDecoder
+
+  given Decoder[ObsSummary] = Decoder.instance: c =>
+    for
+      // id                 <- c.get[Observation.Id]("id")
+      title              <- c.get[String]("title")
+      constraints        <- c.get[ConstraintSet]("constraintSet")
+      timingWindows      <- c.get[List[TimingWindow]]("timingWindows")
+      attachmentIds      <- c.get[List[AttachmentIdWrapper]]("obsAttachments")
+      observingMode      <- c.get[Option[ObservingMode]]("observingMode")
+      visualizationTime  <- c.get[Option[Timestamp]]("visualizationTime")
+      posAngleConstraint <- c.get[PosAngleConstraint]("posAngleConstraint")
+    yield ObsSummary(
+      // id,
+      title,
+      constraints,
+      timingWindows,
+      SortedSet.from(attachmentIds.map(_.id)),
+      observingMode,
+      visualizationTime.map(_.toInstant),
+      posAngleConstraint
+    )

--- a/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
@@ -11,7 +11,6 @@ import io.circe.Decoder
 import io.circe.generic.semiauto.*
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ObsAttachment
-// import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.TimingWindow
 import lucuma.core.util.Timestamp
@@ -24,10 +23,7 @@ import org.typelevel.cats.time.*
 import java.time.Instant
 import scala.collection.immutable.SortedSet
 
-// This class is only used by the UI, but it's in the shared model project so that it can be used
-// by the UI's clue queries.
 case class ObsSummary(
-  // id:                 Observation.Id,
   title:              String,
   constraints:        ConstraintSet,
   timingWindows:      List[TimingWindow],
@@ -48,7 +44,6 @@ case class ObsSummary(
     s"${constraints.imageQuality.label} ${constraints.cloudExtinction.label} ${constraints.skyBackground.label} ${constraints.waterVapor.label}"
 
 object ObsSummary:
-  // val id                 = Focus[ObsSummary](_.id)
   val title              = Focus[ObsSummary](_.title)
   val constraints        = Focus[ObsSummary](_.constraints)
   val timingWindows      = Focus[ObsSummary](_.timingWindows)
@@ -63,7 +58,6 @@ object ObsSummary:
 
   given Decoder[ObsSummary] = Decoder.instance: c =>
     for
-      // id                 <- c.get[Observation.Id]("id")
       title              <- c.get[String]("title")
       constraints        <- c.get[ConstraintSet]("constraintSet")
       timingWindows      <- c.get[List[TimingWindow]]("timingWindows")
@@ -72,7 +66,6 @@ object ObsSummary:
       visualizationTime  <- c.get[Option[Timestamp]]("visualizationTime")
       posAngleConstraint <- c.get[PosAngleConstraint]("posAngleConstraint")
     yield ObsSummary(
-      // id,
       title,
       constraints,
       timingWindows,

--- a/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
@@ -48,4 +48,13 @@ object ObsQueriesGQL {
       }
     """
   }
+
+  @GraphQL
+  trait ObservationSummary extends GraphQLOperation[ObservationDB] {
+    val document = s"""
+      query($$obsId: ObservationId!) {
+        observation(observationId: $$obsId) $ObservationSummarySubquery
+      }
+    """
+  }
 }

--- a/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package queries.common
+
+import clue.GraphQLSubquery
+import observe.ui.model.ObsSummary
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.odb.*
+import clue.annotation.GraphQL
+
+@GraphQL
+object ObservationSummarySubquery
+    extends GraphQLSubquery.Typed[ObservationDB, ObsSummary]("Observation"):
+
+  override val subquery: String = s"""
+        {
+          id
+          title
+          visualizationTime
+          posAngleConstraint $PosAngleConstraintSubquery
+          constraintSet $ConstraintSetSubquery
+          timingWindows $TimingWindowSubquery
+          obsAttachments {
+            id
+          }
+          observingMode $ObservingModeSubquery
+        }
+      """

--- a/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package queries.common
+package observe.queries
 
 import clue.GraphQLSubquery
 import observe.ui.model.ObsSummary

--- a/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
+++ b/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
@@ -6,7 +6,6 @@ package observe.ui
 import lucuma.react.common.style.Css
 
 object ObserveStyles:
-
   val LoginTitle: Css = Css("ObserveStyles-login-title")
 
   val Centered: Css       = Css("ObserveStyles-centered")
@@ -103,3 +102,7 @@ object ObserveStyles:
   val ConfigButton: Css      = Css("ObserveStyles-configButton")
 
   val SyncingPanel: Css = Css("ObserveStyles-syncingPanel")
+
+  val ObsSummary: Css        = Css("ObserveStyles-obsSummary")
+  val ObsSummaryTitle: Css   = Css("ObserveStyles-obsSummary-title")
+  val ObsSummaryDetails: Css = Css("ObserveStyles-obsSummary-details")

--- a/modules/web/client/src/main/scala/observe/ui/components/Home.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/Home.scala
@@ -34,6 +34,7 @@ import observe.ui.DefaultErrorPolicy
 import observe.ui.ObserveStyles
 import observe.ui.components.queue.SessionQueue
 import observe.ui.model.AppContext
+import observe.ui.model.LoadedObservation
 import observe.ui.model.ResourceRunOperation
 import observe.ui.model.RootModel
 import observe.ui.model.SessionQueueRow
@@ -41,7 +42,6 @@ import observe.ui.model.TabOperations
 import observe.ui.model.enums.ClientMode
 import observe.ui.model.enums.ObsClass
 import observe.ui.services.SequenceApi
-import observe.ui.model.LoadedObservation
 
 import scala.collection.immutable.SortedMap
 
@@ -182,31 +182,35 @@ object Home:
               ,
               SplitterPanel():
                 (observations.toOption, selectedObsId).mapN: (obsRows, obsId) =>
-                  props.rootModel.get.nighttimeObservation.toPot
-                    .flatMap(_.config)
-                    .renderPot:
-                      case InstrumentExecutionConfig.GmosNorth(config) =>
-                        GmosNorthSequenceTables(
-                          clientMode,
-                          obsId,
-                          config,
-                          executionState.get,
-                          tabOperations(config),
-                          isPreview = false,
-                          flipBreakPoint
-                        ) // TODO isPreview
-                          .withKey(obsId.toString)
-                      case InstrumentExecutionConfig.GmosSouth(config) =>
-                        GmosSouthSequenceTables(
-                          clientMode,
-                          obsId,
-                          config,
-                          executionState.get,
-                          tabOperations(config),
-                          isPreview = false,
-                          flipBreakPoint
+                  <.div(^.height := "100%", ^.key := obsId.toString)(
+                    props.rootModel.get.nighttimeObservation.toPot
+                      .flatMap(_.unPot)
+                      .renderPot: (obsId, summary, config) =>
+                        React.Fragment(
+                          ObsHeader(obsId, summary),
+                          config match
+                            case InstrumentExecutionConfig.GmosNorth(config) =>
+                              GmosNorthSequenceTables(
+                                clientMode,
+                                obsId,
+                                config,
+                                executionState.get,
+                                tabOperations(config),
+                                isPreview = false,
+                                flipBreakPoint
+                              )
+                            case InstrumentExecutionConfig.GmosSouth(config) =>
+                              GmosSouthSequenceTables(
+                                clientMode,
+                                obsId,
+                                config,
+                                executionState.get,
+                                tabOperations(config),
+                                isPreview = false,
+                                flipBreakPoint
+                              )
                         )
-                          .withKey(obsId.toString)
+                  )
             ),
             Accordion(tabs =
               List(

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -62,6 +62,7 @@ import typings.loglevel.mod.LogLevelDesc
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
+import observe.ui.components.services.ObservationSyncer
 
 object MainApp:
   private val ConfigFile: Uri       = uri"/environments.conf.json"
@@ -328,6 +329,7 @@ object MainApp:
                   onHide = Callback.empty,
                   clazz = ObserveStyles.SyncingPanel
                 )(SolarProgress()),
+                ObservationSyncer(rootModel.zoom(RootModel.nighttimeObservation)),
                 router(rootModel)
               )
             )

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -38,6 +38,7 @@ import lucuma.ui.syntax.pot.*
 import observe.model.Environment
 import observe.model.events.client.ClientEvent
 import observe.ui.ObserveStyles
+import observe.ui.components.services.ObservationSyncer
 import observe.ui.model.AppConfig
 import observe.ui.model.AppContext
 import observe.ui.model.RootModel
@@ -62,7 +63,6 @@ import typings.loglevel.mod.LogLevelDesc
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
-import observe.ui.components.services.ObservationSyncer
 
 object MainApp:
   private val ConfigFile: Uri       = uri"/environments.conf.json"

--- a/modules/web/client/src/main/scala/observe/ui/components/ObsHeader.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ObsHeader.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.ui.components
+
+import lucuma.react.common.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import observe.ui.model.ObsSummary
+
+case class ObsHeader(
+  observation: ObsSummary
+) extends ReactFnProps(ObsHeader.component)
+
+object ObsHeader:
+  private type Props = ObsHeader
+
+  val component = ScalaFnComponent[Props](props => <.div)

--- a/modules/web/client/src/main/scala/observe/ui/components/ObsHeader.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ObsHeader.scala
@@ -3,16 +3,27 @@
 
 package observe.ui.components
 
-import lucuma.react.common.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.common.*
+import observe.model.Observation
+import observe.ui.ObserveStyles
 import observe.ui.model.ObsSummary
 
 case class ObsHeader(
+  obsId:       Observation.Id,
   observation: ObsSummary
 ) extends ReactFnProps(ObsHeader.component)
 
 object ObsHeader:
   private type Props = ObsHeader
 
-  val component = ScalaFnComponent[Props](props => <.div)
+  val component =
+    ScalaFnComponent[Props]: props =>
+      <.div(ObserveStyles.ObsSummary)(
+        <.div(ObserveStyles.ObsSummaryTitle)(s"${props.observation.title} [${props.obsId}]"),
+        <.div(ObserveStyles.ObsSummaryDetails)(
+          <.span(props.observation.configurationSummary),
+          <.span(props.observation.constraintsSummary)
+        )
+      )

--- a/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
@@ -4,7 +4,6 @@
 package observe.ui.components.queue
 
 import cats.syntax.all.*
-import crystal.react.View
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Observation
@@ -25,8 +24,11 @@ import observe.ui.display.given
 import observe.ui.model.SessionQueueRow
 import observe.ui.model.enums.ObsClass
 
-case class SessionQueue(queue: List[SessionQueueRow], selectedObsId: View[Option[Observation.Id]])
-    extends ReactFnProps(SessionQueue.component)
+case class SessionQueue(
+  queue:            List[SessionQueueRow],
+  selectedObsId:    Option[Observation.Id],
+  setSelectedObsId: Observation.Id => Callback
+) extends ReactFnProps(SessionQueue.component)
 
 object SessionQueue:
   private type Props = SessionQueue
@@ -203,7 +205,7 @@ object SessionQueue:
   private val component =
     ScalaFnComponent
       .withHooks[Props]
-      .useMemoBy(props => props.selectedObsId.get)(_ => columns(_))
+      .useMemoBy(props => props.selectedObsId)(_ => columns(_))
       .useReactTableBy: (props, cols) =>
         TableOptions(
           cols,
@@ -219,8 +221,8 @@ object SessionQueue:
             tableMod = ObserveStyles.ObserveTable |+| ObserveStyles.SessionTable,
             rowMod = row =>
               TagMod(
-                rowClass( /*row.index.toInt,*/ row.original, props.selectedObsId.get),
-                ^.onClick --> props.selectedObsId.set(row.original.obsId.some)
+                rowClass( /*row.index.toInt,*/ row.original, props.selectedObsId),
+                ^.onClick --> props.setSelectedObsId(row.original.obsId)
               ),
             overscan = 5
           )

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.ui.components.services
+
+import cats.syntax.all.*
+import crystal.react.*
+import observe.ui.model.LoadedObservation
+import lucuma.react.common.ReactFnProps
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.ui.reusability.given
+import lucuma.schemas.odb.SequenceSQL
+import cats.effect.IO
+import observe.ui.model.AppContext
+import observe.ui.DefaultErrorPolicy
+
+// Renderless component that reloads observation summaries and sequences when observations are selected.
+case class ObservationSyncer(nighttimeObservation: View[Option[LoadedObservation]])
+    extends ReactFnProps(ObservationSyncer.component)
+
+object ObservationSyncer:
+  private type Props = ObservationSyncer
+
+  private val component =
+    ScalaFnComponent
+      .withHooks[Props]
+      .useContext(AppContext.ctx)
+      .useEffectWithDepsBy((props, _) => props.nighttimeObservation.get.map(_.obsId)):
+        (props, ctx) =>
+          _.map: obsId =>
+            import ctx.given
+
+            // TODO We will have to requery under certain conditions:
+            // - After step is executed/paused/aborted.
+            // - If sequence changes... How do we know this??? Update: Shane will add a hash to the API
+            SequenceSQL
+              .SequenceQuery[IO]
+              .query(obsId)
+              .map(_.observation.map(_.execution.config))
+              .attempt
+              .map:
+                _.flatMap:
+                  _.toRight:
+                    Exception(s"Execution Configuration not defined for observation [$obsId]")
+              .flatMap: config =>
+                props.nighttimeObservation.async.mod(_.map(_.withConfig(config)))
+          .orEmpty
+      .render: _ =>
+        EmptyVdom

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
@@ -3,17 +3,18 @@
 
 package observe.ui.components.services
 
+import cats.effect.IO
 import cats.syntax.all.*
 import crystal.react.*
-import observe.ui.model.LoadedObservation
-import lucuma.react.common.ReactFnProps
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
-import lucuma.ui.reusability.given
+import lucuma.react.common.ReactFnProps
 import lucuma.schemas.odb.SequenceSQL
-import cats.effect.IO
-import observe.ui.model.AppContext
+import lucuma.ui.reusability.given
+import observe.queries.ObsQueriesGQL
 import observe.ui.DefaultErrorPolicy
+import observe.ui.model.AppContext
+import observe.ui.model.LoadedObservation
 
 // Renderless component that reloads observation summaries and sequences when observations are selected.
 case class ObservationSyncer(nighttimeObservation: View[Option[LoadedObservation]])
@@ -31,20 +32,39 @@ object ObservationSyncer:
           _.map: obsId =>
             import ctx.given
 
+            val fetchSummary =
+              ObsQueriesGQL
+                .ObservationSummary[IO]
+                .query(obsId)
+                .map(_.observation)
+                .attempt
+                .map:
+                  _.flatMap:
+                    _.toRight:
+                      Exception(s"Observation [$obsId] not found")
+                .flatMap: obs =>
+                  props.nighttimeObservation.async.mod(_.map(_.withSummary(obs)))
+
             // TODO We will have to requery under certain conditions:
             // - After step is executed/paused/aborted.
             // - If sequence changes... How do we know this??? Update: Shane will add a hash to the API
-            SequenceSQL
-              .SequenceQuery[IO]
-              .query(obsId)
-              .map(_.observation.map(_.execution.config))
-              .attempt
-              .map:
-                _.flatMap:
-                  _.toRight:
-                    Exception(s"Execution Configuration not defined for observation [$obsId]")
-              .flatMap: config =>
-                props.nighttimeObservation.async.mod(_.map(_.withConfig(config)))
+            val fetchSequence =
+              SequenceSQL
+                .SequenceQuery[IO]
+                .query(obsId)
+                .map(_.observation.map(_.execution.config))
+                .attempt
+                .map:
+                  _.flatMap:
+                    _.toRight:
+                      Exception(s"Execution Configuration not defined for observation [$obsId]")
+                .flatMap: config =>
+                  props.nighttimeObservation.async.mod(_.map(_.withConfig(config)))
+
+            (fetchSummary, fetchSequence).tupled.void
+            // List(fetchSequence, fetchSummary).sequence.void
+            // fetchSummary
+            // fetchSequence
           .orEmpty
       .render: _ =>
         EmptyVdom

--- a/modules/web/client/src/main/scala/observe/ui/model/LoadedObservation.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/LoadedObservation.scala
@@ -4,11 +4,11 @@
 package observe.ui.model
 
 import cats.syntax.all.*
-import lucuma.core.model.sequence.InstrumentExecutionConfig
-import lucuma.core.model.Observation
 import crystal.Pot
-import monocle.Lens
+import lucuma.core.model.Observation
+import lucuma.core.model.sequence.InstrumentExecutionConfig
 import monocle.Focus
+import monocle.Lens
 
 case class LoadedObservation private (
   obsId:   Observation.Id,
@@ -23,9 +23,6 @@ case class LoadedObservation private (
 
   def unPot: Pot[(Observation.Id, ObsSummary, InstrumentExecutionConfig)] =
     (summary, config).mapN((s, c) => (obsId, s, c))
-
-  // def whenReady[A](f: (Observation.Id, ObsSummary, InstrumentExecutionConfig) => A): Pot[A] =
-  //   (summary, config).mapN((s, c) => f(obsId, s, c))
 
 object LoadedObservation:
   def apply(obsId: Observation.Id): LoadedObservation = new LoadedObservation(obsId)

--- a/modules/web/client/src/main/scala/observe/ui/model/LoadedObservation.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/LoadedObservation.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.ui.model
+
+import cats.syntax.all.*
+import lucuma.core.model.sequence.InstrumentExecutionConfig
+import lucuma.core.model.Observation
+import crystal.Pot
+import monocle.Lens
+import monocle.Focus
+
+case class LoadedObservation private (
+  obsId:   Observation.Id,
+  summary: Pot[ObsSummary] = Pot.pending,
+  config:  Pot[InstrumentExecutionConfig] = Pot.pending
+):
+  def withSummary(summary: Either[Throwable, ObsSummary]): LoadedObservation =
+    copy(summary = Pot.fromTry(summary.toTry))
+
+  def withConfig(config: Either[Throwable, InstrumentExecutionConfig]): LoadedObservation =
+    copy(config = Pot.fromTry(config.toTry))
+
+  def unPot: Pot[(Observation.Id, ObsSummary, InstrumentExecutionConfig)] =
+    (summary, config).mapN((s, c) => (obsId, s, c))
+
+  // def whenReady[A](f: (Observation.Id, ObsSummary, InstrumentExecutionConfig) => A): Pot[A] =
+  //   (summary, config).mapN((s, c) => f(obsId, s, c))
+
+object LoadedObservation:
+  def apply(obsId: Observation.Id): LoadedObservation = new LoadedObservation(obsId)
+
+  val id: Lens[LoadedObservation, Observation.Id] = Focus[LoadedObservation](_.obsId)

--- a/modules/web/client/src/main/scala/observe/ui/model/RootModel.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/RootModel.scala
@@ -18,6 +18,8 @@ import observe.ui.model.enums.ClientMode
 
 case class RootModelData(
   userVault:            Option[UserVault],
+  nighttimeObservation: Option[LoadedObservation],
+  daytimeObservations:  List[LoadedObservation],
   sequenceExecution:    Map[Observation.Id, ExecutionState],
   conditions:           Conditions,
   observer:             Option[Observer],
@@ -32,6 +34,8 @@ object RootModelData:
     val vault: Option[UserVault] = userVault.toOption.flatten
     RootModelData(
       userVault = vault,
+      nighttimeObservation = none,
+      daytimeObservations = List.empty,
       sequenceExecution = Map.empty,
       conditions = Conditions.Default,
       observer =
@@ -43,6 +47,10 @@ object RootModelData:
     )
 
   val userVault: Lens[RootModelData, Option[UserVault]]                           = Focus[RootModelData](_.userVault)
+  val nighttimeObservation: Lens[RootModelData, Option[LoadedObservation]]        =
+    Focus[RootModelData](_.nighttimeObservation)
+  val daytimeObservations: Lens[RootModelData, List[LoadedObservation]]           =
+    Focus[RootModelData](_.daytimeObservations)
   val sequenceExecution: Lens[RootModelData, Map[Observation.Id, ExecutionState]] =
     Focus[RootModelData](_.sequenceExecution)
   val conditions: Lens[RootModelData, Conditions]                                 = Focus[RootModelData](_.conditions)
@@ -61,6 +69,10 @@ object RootModel:
   private val data: Lens[RootModel, RootModelData]                            = Focus[RootModel](_.data)
   private val environment: Lens[RootModel, Environment]                       = Focus[RootModel](_.environment)
   val userVault: Lens[RootModel, Option[UserVault]]                           = data.andThen(RootModelData.userVault)
+  val nighttimeObservation: Lens[RootModel, Option[LoadedObservation]]        =
+    data.andThen(RootModelData.nighttimeObservation)
+  val daytimeObservations: Lens[RootModel, List[LoadedObservation]]           =
+    data.andThen(RootModelData.daytimeObservations)
   val sequenceExecution: Lens[RootModel, Map[Observation.Id, ExecutionState]] =
     data.andThen(RootModelData.sequenceExecution)
   val conditions: Lens[RootModel, Conditions]                                 = data.andThen(RootModelData.conditions)

--- a/modules/web/client/src/main/webapp/styles/observe.scss
+++ b/modules/web/client/src/main/webapp/styles/observe.scss
@@ -1,4 +1,4 @@
-@use '/lucuma-css/lucuma-ui-common.scss' as lucumaUICommon;
+@use "/lucuma-css/lucuma-ui-common.scss" as lucumaUICommon;
 
 html {
   font-size: 14px;
@@ -68,7 +68,6 @@ html {
     background-color: var(--orange-500);
   }
 }
-
 
 .p-accordion .p-accordion-header:not(.p-disabled) {
   &.ObserveStyles-logArea {
@@ -156,7 +155,7 @@ html {
       height: 60px;
       vertical-align: top;
 
-      td:not(.ObserveStyles-breakpointTableCell){
+      td:not(.ObserveStyles-breakpointTableCell) {
         padding-top: 6px;
       }
     }
@@ -287,13 +286,13 @@ html {
     thead {
       z-index: 1;
 
-      tr>th {
+      tr > th {
         padding: 0.5em 0.75em;
         border: 1px solid var(--surface-border);
       }
     }
 
-    tr>td {
+    tr > td {
       min-width: 20px;
       font-size: small;
       text-overflow: ellipsis;
@@ -309,14 +308,13 @@ html {
   }
 
   &.ObserveStyles-sessionTable {
-    tr>td {
+    tr > td {
       padding-top: 0.5em;
       padding-bottom: 0.5em;
     }
   }
 
   &.ObserveStyles-stepTable {
-
     tr.ObserveStyles-stepRowDone {
       pointer-events: none;
       color: var(--disabled-row-color);
@@ -359,10 +357,9 @@ html {
       @return bottom-line($outer), bottom-thick-line($inner);
     }
 
-
     tr {
       box-shadow: none !important;
-      
+
       td {
         padding-top: 1px;
         padding-bottom: 1px;
@@ -379,7 +376,9 @@ html {
       //
       //
       // SEPARATOR-SEPARATOR-SEPARATOR
-      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+      td:not(.ObserveStyles-breakpointTableCell):not(
+          .ObserveStyles-runningStateTableCell-shown
+        ) {
         box-shadow: bottom-line($separator-color) !important;
       }
 
@@ -392,7 +391,9 @@ html {
         //
         //
         // HOVER-HOVER-HOVER-HOVER-HOVER
-        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+        td:not(.ObserveStyles-breakpointTableCell):not(
+            .ObserveStyles-runningStateTableCell-shown
+          ) {
           box-shadow: top-line($hover-color), bottom-line($hover-color) !important;
         }
       }
@@ -407,7 +408,9 @@ html {
       //
       //
       // SEPARATOR-SEPARATOR-SEPARATOR
-      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+      td:not(.ObserveStyles-breakpointTableCell):not(
+          .ObserveStyles-runningStateTableCell-shown
+        ) {
         box-shadow: top-line($atom-color), bottom-line($separator-color) !important;
       }
 
@@ -420,8 +423,11 @@ html {
         //
         //
         // HOVER-HOVER-HOVER-HOVER-HOVER
-        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-          box-shadow: top-double-line($atom-color, $hover-color), bottom-line($hover-color) !important;
+        td:not(.ObserveStyles-breakpointTableCell):not(
+            .ObserveStyles-runningStateTableCell-shown
+          ) {
+          box-shadow: top-double-line($atom-color, $hover-color),
+            bottom-line($hover-color) !important;
         }
       }
 
@@ -434,7 +440,9 @@ html {
         //
         //
         // BREAKPOINT-BREAKPOINT-BREAKPO
-        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+        td:not(.ObserveStyles-breakpointTableCell):not(
+            .ObserveStyles-runningStateTableCell-shown
+          ) {
           box-shadow: top-line($atom-color), bottom-line($breakpoint-color) !important;
         }
 
@@ -447,8 +455,11 @@ html {
           //
           // HOVER-HOVER-HOVER-HOVER-HOVER
           // BREAKPOINT-BREAKPOINT-BREAKPO
-          td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-            box-shadow: top-double-line($atom-color, $hover-color), bottom-double-line($breakpoint-color, $hover-color) !important;
+          td:not(.ObserveStyles-breakpointTableCell):not(
+              .ObserveStyles-runningStateTableCell-shown
+            ) {
+            box-shadow: top-double-line($atom-color, $hover-color),
+              bottom-double-line($breakpoint-color, $hover-color) !important;
           }
         }
       }
@@ -463,7 +474,9 @@ html {
       //
       //
       // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
-      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+      td:not(.ObserveStyles-breakpointTableCell):not(
+          .ObserveStyles-runningStateTableCell-shown
+        ) {
         box-shadow: bottom-line($atom-color) !important;
       }
 
@@ -476,8 +489,11 @@ html {
         //
         // HOVER-HOVER-HOVER-HOVER-HOVER
         // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
-        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-          box-shadow: top-line($hover-color), bottom-double-line($atom-color, $hover-color) !important;
+        td:not(.ObserveStyles-breakpointTableCell):not(
+            .ObserveStyles-runningStateTableCell-shown
+          ) {
+          box-shadow: top-line($hover-color),
+            bottom-double-line($atom-color, $hover-color) !important;
         }
       }
     }
@@ -491,7 +507,9 @@ html {
       //
       //
       // BREAKPOINT-BREAKPOINT-BREAKPO
-      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+      td:not(.ObserveStyles-breakpointTableCell):not(
+          .ObserveStyles-runningStateTableCell-shown
+        ) {
         box-shadow: bottom-line($breakpoint-color) !important;
       }
 
@@ -504,36 +522,48 @@ html {
         //
         // HOVER-HOVER-HOVER-HOVER-HOV
         // BREAKPOINT-BREAKPOINT-BREAK
-        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-          box-shadow: top-line($hover-color), bottom-double-line($breakpoint-color, $hover-color) !important;
+        td:not(.ObserveStyles-breakpointTableCell):not(
+            .ObserveStyles-runningStateTableCell-shown
+          ) {
+          box-shadow: top-line($hover-color),
+            bottom-double-line($breakpoint-color, $hover-color) !important;
         }
       }
     }
 
-    tr.ObserveStyles-stepRowWithBreakpoint, tr.ObserveStyles-stepRowWithBreakpoint:not(:first-of-type) {
+    tr.ObserveStyles-stepRowWithBreakpoint,
+    tr.ObserveStyles-stepRowWithBreakpoint:not(:first-of-type) {
       // Breakpoint row.
       // BREAKPOINT-BREAKPOINT-BREAKPO
       //
       //
       // ROW CONTENTS
       //
-      // 
+      //
       // SEPARATOR-SEPARATOR-SEPARATOR
-      td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+      td:not(.ObserveStyles-breakpointTableCell):not(
+          .ObserveStyles-runningStateTableCell-shown
+        ) {
         box-shadow: top-line($breakpoint-color), bottom-line($separator-color) !important;
       }
 
-      &:has(+ .ObserveStyles-stepRowWithBreakpoint), &:has(+ .ObserveStyles-stepRowWithBreakpoint):has(+ .ObserveStyles-stepRowFirstInAtom){
+      &:has(+ .ObserveStyles-stepRowWithBreakpoint),
+      &:has(+ .ObserveStyles-stepRowWithBreakpoint):has(
+          + .ObserveStyles-stepRowFirstInAtom
+        ) {
         // Breakpoint row with next row with breakpoint.
         // BREAKPOINT-BREAKPOINT-BREAKPO
         //
         //
         // ROW CONTENTS
         //
-        // 
+        //
         // BREAKPOINT-BREAKPOINT-BREAKPO
-        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-          box-shadow: top-line($breakpoint-color), bottom-line($breakpoint-color) !important;
+        td:not(.ObserveStyles-breakpointTableCell):not(
+            .ObserveStyles-runningStateTableCell-shown
+          ) {
+          box-shadow: top-line($breakpoint-color),
+            bottom-line($breakpoint-color) !important;
         }
       }
 
@@ -546,7 +576,9 @@ html {
         //
         //
         // ATOM-ATOM-ATOM-ATOM-ATOM-ATOM
-        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
+        td:not(.ObserveStyles-breakpointTableCell):not(
+            .ObserveStyles-runningStateTableCell-shown
+          ) {
           box-shadow: top-line($breakpoint-color), bottom-line($atom-color) !important;
         }
       }
@@ -558,10 +590,13 @@ html {
         //
         // ROW CONTENTS
         //
-        // 
+        //
         // HOVER-HOVER-HOVER-HOVER-HOVER
-        td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-          box-shadow: top-double-line($breakpoint-color, $hover-color), bottom-line($hover-color) !important;
+        td:not(.ObserveStyles-breakpointTableCell):not(
+            .ObserveStyles-runningStateTableCell-shown
+          ) {
+          box-shadow: top-double-line($breakpoint-color, $hover-color),
+            bottom-line($hover-color) !important;
         }
 
         &:has(+ .ObserveStyles-stepRowWithBreakpoint) {
@@ -573,8 +608,11 @@ html {
           //
           // HOVER-HOVER-HOVER-HOVER-HOVER
           // BREAKPOINT-BREAKPOINT-BREAKPO
-          td:not(.ObserveStyles-breakpointTableCell):not(.ObserveStyles-runningStateTableCell-shown) {
-            box-shadow: top-double-line($breakpoint-color, $hover-color), bottom-double-line($breakpoint-color, $hover-color) !important;
+          td:not(.ObserveStyles-breakpointTableCell):not(
+              .ObserveStyles-runningStateTableCell-shown
+            ) {
+            box-shadow: top-double-line($breakpoint-color, $hover-color),
+              bottom-double-line($breakpoint-color, $hover-color) !important;
           }
         }
       }
@@ -671,7 +709,6 @@ html {
       padding: 0;
       border: 0;
     }
-
   }
 }
 
@@ -898,5 +935,22 @@ html {
 
   .p-dialog-header {
     text-align: center;
+  }
+}
+
+.ObserveStyles-obsSummary {
+  margin: 15px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  .ObserveStyles-obsSummary-title {
+    font-size: x-large;
+    font-weight: bold;
+  }
+
+  .ObserveStyles-obsSummary-details {
+    display: flex;
+    gap: 3em;
   }
 }


### PR DESCRIPTION
Moves the loaded sequence to the `RootModel`, as well as providing global hooks to update it, as well as the observation details, when a new observation is selected anywhere, freeing the component logic from this task, and avoiding a requery in case of navigating to another tab and back.

I needed to create a model class `ObsSummary` to hold observation details which needed to be referenced from clue queries. Therefore, I had to place it in a new project.

The observation header displays basic information for the moment and it's lacking more stylized... well, styling.