### PR TITLE
Support setting multiple breakpoints and set breakpoints on load

### DIFF
--- a/modules/engine/src/main/scala/observe/engine/Engine.scala
+++ b/modules/engine/src/main/scala/observe/engine/Engine.scala
@@ -346,42 +346,42 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
   private def send(ev: EventType): HandleType[Unit] = Handle.fromStream(Stream(ev))
 
   private def handleUserEvent(ue: UserEventType): HandleType[ResultType] = ue match {
-    case Start(id, _, _)            =>
+    case Start(id, _, _)             =>
       debug(s"Engine: Start requested for sequence $id") *> start(id) *> pure(
         UserCommandResponse(ue, Outcome.Ok, None)
       )
-    case Pause(id, _)               =>
+    case Pause(id, _)                =>
       debug(s"Engine: Pause requested for sequence $id") *> pause(id) *> pure(
         UserCommandResponse(ue, Outcome.Ok, None)
       )
-    case CancelPause(id, _)         =>
+    case CancelPause(id, _)          =>
       debug(s"Engine: Pause canceled for sequence $id") *> cancelPause(id) *> pure(
         UserCommandResponse(ue, Outcome.Ok, None)
       )
-    case Breakpoint(id, _, step, v) =>
+    case Breakpoints(id, _, step, v) =>
       debug(s"Engine: breakpoint changed for sequence $id and step $step to $v") *>
-        modifyS(id)(_.setBreakpoint(step, v)) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
-    case SkipMark(id, _, step, v)   =>
+        modifyS(id)(_.setBreakpoints(step, v)) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
+    case SkipMark(id, _, step, v)    =>
       debug(s"Engine: skip mark changed for sequence $id and step $step to $v") *>
         modifyS(id)(_.setSkipMark(step, v)) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
-    case Poll(_)                    =>
+    case Poll(_)                     =>
       debug("Engine: Polling current state") *> pure(UserCommandResponse(ue, Outcome.Ok, None))
-    case GetState(f)                => getState(f) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
-    case ModifyState(f)             =>
+    case GetState(f)                 => getState(f) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
+    case ModifyState(f)              =>
       summon[Monad[HandleType]].map(f)((r: U) => UserCommandResponse[F, U](ue, Outcome.Ok, Some(r)))
-    case ActionStop(id, f)          =>
+    case ActionStop(id, f)           =>
       debug("Engine: Action stop requested") *> actionStop(id, f) *> pure(
         UserCommandResponse(ue, Outcome.Ok, None)
       )
-    case ActionResume(id, i, cont)  =>
+    case ActionResume(id, i, cont)   =>
       debug("Engine: Action resume requested") *> actionResume(id, i, cont) *> pure(
         UserCommandResponse(ue, Outcome.Ok, None)
       )
-    case LogDebug(msg, _)           => debug(msg) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
-    case LogInfo(msg, _)            => info(msg) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
-    case LogWarning(msg, _)         => warning(msg) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
-    case LogError(msg, _)           => error(msg) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
-    case Pure(v)                    => pure(UserCommandResponse(ue, Outcome.Ok, v.some))
+    case LogDebug(msg, _)            => debug(msg) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
+    case LogInfo(msg, _)             => info(msg) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
+    case LogWarning(msg, _)          => warning(msg) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
+    case LogError(msg, _)            => error(msg) *> pure(UserCommandResponse(ue, Outcome.Ok, None))
+    case Pure(v)                     => pure(UserCommandResponse(ue, Outcome.Ok, v.some))
   }
 
   private def handleSystemEvent(

--- a/modules/engine/src/main/scala/observe/engine/Event.scala
+++ b/modules/engine/src/main/scala/observe/engine/Event.scala
@@ -6,6 +6,7 @@ package observe.engine
 import cats.effect.Sync
 import cats.syntax.all.*
 import fs2.Stream
+import lucuma.core.enums.Breakpoint
 import lucuma.core.model.User
 import observe.engine.SystemEvent.Null
 import observe.model.ClientId
@@ -33,11 +34,11 @@ object Event {
   def cancelPause[F[_], S, U](id: Observation.Id, user: User): Event[F, S, U]               =
     EventUser[F, S, U](CancelPause(id, user.some))
   def breakpoint[F[_], S, U](
-    id:   Observation.Id,
-    user: User,
-    step: StepId,
-    v:    Boolean
-  ): Event[F, S, U] = EventUser[F, S, U](Breakpoint(id, user.some, step, v))
+    id:    Observation.Id,
+    user:  User,
+    steps: List[StepId],
+    v:     Breakpoint
+  ): Event[F, S, U] = EventUser[F, S, U](Breakpoints(id, user.some, steps, v))
   def skip[F[_], S, U](
     id:   Observation.Id,
     user: User,

--- a/modules/engine/src/main/scala/observe/engine/Event.scala
+++ b/modules/engine/src/main/scala/observe/engine/Event.scala
@@ -24,8 +24,8 @@ import UserEvent.*
 sealed trait Event[F[_], S, U] extends Product with Serializable
 
 object Event {
-  final case class EventUser[F[_], S, U](ue: UserEvent[F, S, U]) extends Event[F, S, U]
-  final case class EventSystem[F[_], S, U](se: SystemEvent)      extends Event[F, S, U]
+  case class EventUser[F[_], S, U](ue: UserEvent[F, S, U]) extends Event[F, S, U]
+  case class EventSystem[F[_], S, U](se: SystemEvent)      extends Event[F, S, U]
 
   def start[F[_], S, U](id: Observation.Id, user: User, clientId: ClientId): Event[F, S, U] =
     EventUser[F, S, U](Start[F, S, U](id, user.some, clientId))
@@ -33,7 +33,7 @@ object Event {
     EventUser[F, S, U](Pause(id, user.some))
   def cancelPause[F[_], S, U](id: Observation.Id, user: User): Event[F, S, U]               =
     EventUser[F, S, U](CancelPause(id, user.some))
-  def breakpoint[F[_], S, U](
+  def breakpoints[F[_], S, U](
     id:    Observation.Id,
     user:  User,
     steps: List[StepId],

--- a/modules/engine/src/test/scala/observe/engine/SequenceSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/SequenceSuite.scala
@@ -8,6 +8,7 @@ import cats.data.OptionT
 import cats.effect.IO
 import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosLong
+import lucuma.core.enums.Breakpoint
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.Observation as LObservation
 import observe.common.test.*
@@ -34,7 +35,7 @@ class SequenceSuite extends munit.CatsEffectSuite {
 
   private val executionEngine = Engine.build[IO, TestState, Unit](TestState)
 
-  def simpleStep(id: StepId, breakpoint: Boolean): Step[IO] =
+  def simpleStep(id: StepId, breakpoint: Breakpoint): Step[IO] =
     Step
       .init(
         id = id,
@@ -43,7 +44,7 @@ class SequenceSuite extends munit.CatsEffectSuite {
           NonEmptyList.one(action)         // Execution
         )
       )
-      .copy(breakpoint = Step.BreakpointMark(breakpoint))
+      .copy(breakpoint = breakpoint)
 
   def isFinished(status: SequenceState): Boolean = status match {
     case SequenceState.Idle      => true
@@ -74,8 +75,8 @@ class SequenceSuite extends munit.CatsEffectSuite {
            Sequence.State.init(
              Sequence.sequence(seqId,
                                atomId,
-                               List(simpleStep(stepId(1), breakpoint = false),
-                                    simpleStep(stepId(2), breakpoint = true)
+                               List(simpleStep(stepId(1), Breakpoint.Disabled),
+                                    simpleStep(stepId(2), Breakpoint.Enabled)
                                )
              )
            )
@@ -103,12 +104,13 @@ class SequenceSuite extends munit.CatsEffectSuite {
         sequences = Map(
           (seqId,
            Sequence.State.init(
-             Sequence.sequence(id = seqId,
-                               atomId,
-                               steps = List(simpleStep(stepId(1), breakpoint = false),
-                                            simpleStep(stepId(2), breakpoint = true),
-                                            simpleStep(stepId(3), breakpoint = false)
-                               )
+             Sequence.sequence(
+               id = seqId,
+               atomId,
+               steps = List(simpleStep(stepId(1), Breakpoint.Disabled),
+                            simpleStep(stepId(2), Breakpoint.Enabled),
+                            simpleStep(stepId(3), Breakpoint.Disabled)
+               )
              )
            )
           )
@@ -165,7 +167,7 @@ class SequenceSuite extends munit.CatsEffectSuite {
 
     Step.Zipper(
       id = stepId(1),
-      breakpoint = Step.BreakpointMark(false),
+      breakpoint = Breakpoint.Disabled,
       Step.SkipMark(false),
       pending = pending,
       focus = focus,
@@ -220,8 +222,8 @@ class SequenceSuite extends munit.CatsEffectSuite {
     val seq = Sequence.State.init(
       Sequence.sequence(id = seqId,
                         atomId,
-                        steps = List(simpleStep(stepId(1), breakpoint = false),
-                                     simpleStep(stepId(2), breakpoint = false)
+                        steps = List(simpleStep(stepId(1), Breakpoint.Enabled),
+                                     simpleStep(stepId(2), Breakpoint.Disabled)
                         )
       )
     )

--- a/modules/engine/src/test/scala/observe/engine/StepSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/StepSuite.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.effect.Ref
 import cats.implicits.*
 import fs2.Stream
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument.GmosSouth
 import lucuma.core.model.sequence.Atom
 import munit.CatsEffectSuite
@@ -62,7 +63,7 @@ class StepSuite extends CatsEffectSuite {
 
     Step.Zipper(
       id = stepId(1),
-      breakpoint = Step.BreakpointMark(false),
+      breakpoint = Breakpoint.Disabled,
       skipMark = Step.SkipMark(false),
       pending = pending,
       focus = focus,
@@ -267,7 +268,7 @@ class StepSuite extends CatsEffectSuite {
                pending = Nil,
                focus = Step.Zipper(
                  id = stepId(2),
-                 breakpoint = Step.BreakpointMark(false),
+                 breakpoint = Breakpoint.Disabled,
                  skipMark = Step.SkipMark(false),
                  pending = Nil,
                  focus = Execution(List(observe)),
@@ -321,7 +322,7 @@ class StepSuite extends CatsEffectSuite {
                pending = Nil,
                focus = Step.Zipper(
                  id = stepId(2),
-                 breakpoint = Step.BreakpointMark(false),
+                 breakpoint = Breakpoint.Disabled,
                  skipMark = Step.SkipMark(false),
                  pending = Nil,
                  focus = Execution(List(observe)),
@@ -756,7 +757,7 @@ class StepSuite extends CatsEffectSuite {
       Step
         .Zipper(
           id = stepId(1),
-          breakpoint = Step.BreakpointMark(false),
+          breakpoint = Breakpoint.Disabled,
           skipMark = Step.SkipMark(false),
           pending = Nil,
           focus = Execution(List(action, actionFailed, actionCompleted)),
@@ -773,7 +774,7 @@ class StepSuite extends CatsEffectSuite {
       Step
         .Zipper(
           id = stepId(1),
-          breakpoint = Step.BreakpointMark(false),
+          breakpoint = Breakpoint.Disabled,
           skipMark = Step.SkipMark(false),
           pending = Nil,
           focus = Execution(List(actionCompleted, actionCompleted, actionCompleted)),
@@ -790,7 +791,7 @@ class StepSuite extends CatsEffectSuite {
       Step
         .Zipper(
           id = stepId(1),
-          breakpoint = Step.BreakpointMark(false),
+          breakpoint = Breakpoint.Disabled,
           skipMark = Step.SkipMark(false),
           pending = Nil,
           focus = Execution(List(actionCompleted, action, actionCompleted)),
@@ -807,7 +808,7 @@ class StepSuite extends CatsEffectSuite {
       Step
         .Zipper(
           id = stepId(1),
-          breakpoint = Step.BreakpointMark(false),
+          breakpoint = Breakpoint.Disabled,
           skipMark = Step.SkipMark(false),
           pending = Nil,
           focus = Execution(List(action, action, action)),
@@ -824,7 +825,7 @@ class StepSuite extends CatsEffectSuite {
       Step
         .Zipper(
           id = stepId(1),
-          breakpoint = Step.BreakpointMark(false),
+          breakpoint = Breakpoint.Disabled,
           skipMark = Step.SkipMark(false),
           pending = Nil,
           focus = Execution(List(action, action, action)),

--- a/modules/engine/src/test/scala/observe/engine/packageSpec.scala
+++ b/modules/engine/src/test/scala/observe/engine/packageSpec.scala
@@ -10,6 +10,7 @@ import cats.effect.std.Semaphore
 import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosLong
 import fs2.Stream
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument.GmosSouth
 import lucuma.core.model.OrcidId
 import lucuma.core.model.OrcidProfile
@@ -33,6 +34,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.duration.*
 
 def user =
   StandardUser(
@@ -61,7 +63,7 @@ class packageSpec extends munit.CatsEffectSuite {
    */
   val configureTcs: Action[IO] = fromF[IO](ActionType.Configure(TCS),
                                            for {
-                                             _ <- IO(Thread.sleep(200))
+                                             _ <- IO.sleep(200.milliseconds)
                                            } yield Result.OK(DummyResult)
   )
 
@@ -70,7 +72,7 @@ class packageSpec extends munit.CatsEffectSuite {
    */
   val configureInst: Action[IO] = fromF[IO](ActionType.Configure(GmosSouth),
                                             for {
-                                              _ <- IO(Thread.sleep(200))
+                                              _ <- IO.sleep(200.milliseconds)
                                             } yield Result.OK(DummyResult)
   )
 
@@ -79,13 +81,13 @@ class packageSpec extends munit.CatsEffectSuite {
    */
   val observe: Action[IO] = fromF[IO](ActionType.Observe,
                                       for {
-                                        _ <- IO(Thread.sleep(200))
+                                        _ <- IO.sleep(200.milliseconds)
                                       } yield Result.OK(DummyResult)
   )
 
   val faulty: Action[IO] = fromF[IO](ActionType.Undefined,
                                      for {
-                                       _ <- IO(Thread.sleep(100))
+                                       _ <- IO.sleep(100.milliseconds)
                                      } yield Result.Error("There was an error in this action")
   )
 
@@ -530,7 +532,7 @@ class packageSpec extends munit.CatsEffectSuite {
                  .copy(skipMark = Step.SkipMark(true)),
                Step
                  .init(id = stepId(2), executions = executions)
-                 .copy(skipMark = Step.SkipMark(true), breakpoint = Step.BreakpointMark(true)),
+                 .copy(skipMark = Step.SkipMark(true), breakpoint = Breakpoint.Enabled),
                Step.init(id = stepId(3), executions = executions)
              )
            )
@@ -570,10 +572,10 @@ class packageSpec extends munit.CatsEffectSuite {
                  .copy(skipped = Step.Skipped(true)),
                Step
                  .init(id = stepId(2), executions = executions)
-                 .copy(skipMark = Step.SkipMark(true), breakpoint = Step.BreakpointMark(true)),
+                 .copy(skipMark = Step.SkipMark(true), breakpoint = Breakpoint.Enabled),
                Step
                  .init(id = stepId(3), executions = executions)
-                 .copy(skipMark = Step.SkipMark(true), breakpoint = Step.BreakpointMark(true))
+                 .copy(skipMark = Step.SkipMark(true), breakpoint = Breakpoint.Enabled)
              )
            )
          )
@@ -614,7 +616,7 @@ class packageSpec extends munit.CatsEffectSuite {
                  .copy(skipMark = Step.SkipMark(true)),
                Step
                  .init(id = stepId(3), executions = executions)
-                 .copy(skipMark = Step.SkipMark(true), breakpoint = Step.BreakpointMark(true)),
+                 .copy(skipMark = Step.SkipMark(true), breakpoint = Breakpoint.Enabled),
                Step.init(id = stepId(4), executions = executions)
              )
            )

--- a/modules/model/shared/src/main/scala/observe/model/client.scala
+++ b/modules/model/shared/src/main/scala/observe/model/client.scala
@@ -14,6 +14,7 @@ import io.circe.KeyDecoder
 import io.circe.KeyEncoder
 import io.circe.refined.*
 import io.circe.syntax.*
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument
 import lucuma.core.model.Observation
 import lucuma.core.util.Enumerated
@@ -47,7 +48,7 @@ extension (q: SequenceView)
       None,
       Map.empty,
       q.systemOverrides,
-      q.steps.mapFilter(s => if (s.breakpoint) s.id.some else none).toSet
+      q.steps.mapFilter(s => if (s.breakpoint === Breakpoint.Enabled) s.id.some else none).toSet
     )
 
 object ClientEvent:

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbNodAndShuffleStep.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbNodAndShuffleStep.scala
@@ -3,6 +3,7 @@
 
 package observe.model.arb
 
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.arb.ArbStepConfig.*
@@ -57,7 +58,7 @@ trait ArbNodAndShuffleStep {
       d  <- arbitrary[DynamicConfig]
       t  <- arbitrary[StepConfig]
       s  <- arbitrary[StepState]
-      b  <- arbitrary[Boolean]
+      b  <- arbitrary[Breakpoint]
       k  <- arbitrary[Boolean]
       f  <- arbitrary[Option[dhs.ImageFileId]]
       cs <- arbitrary[List[(Resource, ActionStatus)]]
@@ -84,7 +85,7 @@ trait ArbNodAndShuffleStep {
         DynamicConfig,
         StepConfig,
         StepState,
-        Boolean,
+        Breakpoint,
         Boolean,
         Option[dhs.ImageFileId],
         List[(Resource | Instrument, ActionStatus)],

--- a/modules/model/shared/src/test/scala/observe/model/arb/ArbStandardStep.scala
+++ b/modules/model/shared/src/test/scala/observe/model/arb/ArbStandardStep.scala
@@ -3,6 +3,7 @@
 
 package observe.model.arb
 
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.arb.ArbStepConfig.*
@@ -27,7 +28,7 @@ trait ArbStandardStep {
       d  <- arbitrary[DynamicConfig]
       t  <- arbitrary[StepConfig]
       s  <- arbitrary[StepState]
-      b  <- arbitrary[Boolean]
+      b  <- arbitrary[Breakpoint]
       k  <- arbitrary[Boolean]
       f  <- arbitrary[Option[dhs.ImageFileId]]
       cs <- arbitrary[List[(Resource, ActionStatus)]]
@@ -52,7 +53,7 @@ trait ArbStandardStep {
         DynamicConfig,
         StepConfig,
         StepState,
-        Boolean,
+        Breakpoint,
         Boolean,
         Option[dhs.ImageFileId],
         List[(Resource | Instrument, ActionStatus)],

--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -14,6 +14,7 @@ import cats.effect.kernel.Sync
 import cats.syntax.all.*
 import fs2.Pipe
 import fs2.Stream
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.Instrument
@@ -93,12 +94,12 @@ trait ObserveEngine[F[_]] {
     user:     User
   ): F[Unit]
 
-  def setBreakpoint(
+  def setBreakpoints(
     seqId:    Observation.Id,
     user:     User,
     observer: Observer,
-    stepId:   StepId,
-    v:        Boolean
+    stepId:   List[StepId],
+    v:        Breakpoint
   ): F[Unit]
 
   def setOperator(user: User, name: Operator): F[Unit]
@@ -548,14 +549,14 @@ object ObserveEngine {
     ): F[Unit] = setObserver(seqId, user, observer) *>
       executeEngine.offer(Event.cancelPause[F, EngineState[F], SeqEvent](seqId, user))
 
-    override def setBreakpoint(
+    override def setBreakpoints(
       seqId:    Observation.Id,
       user:     User,
       observer: Observer,
-      stepId:   StepId,
-      v:        Boolean
+      steps:    List[StepId],
+      v:        Breakpoint
     ): F[Unit] = setObserver(seqId, user, observer) *>
-      executeEngine.offer(Event.breakpoint[F, EngineState[F], SeqEvent](seqId, user, stepId, v))
+      executeEngine.offer(Event.breakpoint[F, EngineState[F], SeqEvent](seqId, user, steps, v))
 
     override def setOperator(user: User, name: Operator): F[Unit] =
       logDebugEvent(s"ObserveEngine: Setting Operator name to '$name' by ${user.displayName}") *>
@@ -1772,25 +1773,25 @@ object ObserveEngine {
     ev match {
       case UserCommandResponse(ue, _, uev) =>
         ue match {
-          case UserEvent.Start(id, _, _)        =>
+          case UserEvent.Start(id, _, _)         =>
             val rs = sequences.find(_.obsId === id).flatMap(_.runningStep.flatMap(_.id))
             rs.foldMap(x => Stream.emit(ClientSequenceStart(id, x, svs)))
-          case UserEvent.Pause(_, _)            => Stream.emit(SequencePauseRequested(svs))
-          case UserEvent.CancelPause(id, _)     => Stream.emit(SequencePauseCanceled(id, svs))
-          case UserEvent.Breakpoint(_, _, _, _) => Stream.emit(StepBreakpointChanged(svs))
-          case UserEvent.SkipMark(_, _, _, _)   => Stream.emit(StepSkipMarkChanged(svs))
-          case UserEvent.Poll(cid)              => Stream.emit(SequenceRefreshed(svs, cid))
-          case UserEvent.GetState(_)            => Stream.empty
-          case UserEvent.ModifyState(_)         => modifyStateEvent(uev.getOrElse(NullSeqEvent), svs)
-          case UserEvent.ActionStop(_, _)       => Stream.emit(ActionStopRequested(svs))
-          case UserEvent.LogDebug(_, _)         => Stream.empty
-          case UserEvent.LogInfo(m, ts)         => Stream.emit(ServerLogMessage(ServerLogLevel.INFO, ts, m))
-          case UserEvent.LogWarning(m, ts)      =>
+          case UserEvent.Pause(_, _)             => Stream.emit(SequencePauseRequested(svs))
+          case UserEvent.CancelPause(id, _)      => Stream.emit(SequencePauseCanceled(id, svs))
+          case UserEvent.Breakpoints(_, _, _, _) => Stream.emit(StepBreakpointChanged(svs))
+          case UserEvent.SkipMark(_, _, _, _)    => Stream.emit(StepSkipMarkChanged(svs))
+          case UserEvent.Poll(cid)               => Stream.emit(SequenceRefreshed(svs, cid))
+          case UserEvent.GetState(_)             => Stream.empty
+          case UserEvent.ModifyState(_)          => modifyStateEvent(uev.getOrElse(NullSeqEvent), svs)
+          case UserEvent.ActionStop(_, _)        => Stream.emit(ActionStopRequested(svs))
+          case UserEvent.LogDebug(_, _)          => Stream.empty
+          case UserEvent.LogInfo(m, ts)          => Stream.emit(ServerLogMessage(ServerLogLevel.INFO, ts, m))
+          case UserEvent.LogWarning(m, ts)       =>
             Stream.emit(ServerLogMessage(ServerLogLevel.WARN, ts, m))
-          case UserEvent.LogError(m, ts)        =>
+          case UserEvent.LogError(m, ts)         =>
             Stream.emit(ServerLogMessage(ServerLogLevel.ERROR, ts, m))
-          case UserEvent.ActionResume(_, _, _)  => Stream.emit(SequenceUpdated(svs))
-          case UserEvent.Pure(_)                => Stream.empty
+          case UserEvent.ActionResume(_, _, _)   => Stream.emit(SequenceUpdated(svs))
+          case UserEvent.Pure(_)                 => Stream.empty
         }
       case SystemUpdate(se, _)             =>
         se match {

--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -555,8 +555,10 @@ object ObserveEngine {
       observer: Observer,
       steps:    List[StepId],
       v:        Breakpoint
-    ): F[Unit] = setObserver(seqId, user, observer) *>
-      executeEngine.offer(Event.breakpoint[F, EngineState[F], SeqEvent](seqId, user, steps, v))
+    ): F[Unit] =
+      // Set the observer after the breakpoints are set to do optimistic updates on the UI
+      executeEngine.offer(Event.breakpoints[F, EngineState[F], SeqEvent](seqId, user, steps, v)) *>
+        setObserver(seqId, user, observer)
 
     override def setOperator(user: User, name: Operator): F[Unit] =
       logDebugEvent(s"ObserveEngine: Setting Operator name to '$name' by ${user.displayName}") *>

--- a/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
@@ -155,7 +155,8 @@ object SeqTranslate {
           (ov: SystemOverrides) => instf(ov).observeControl,
           StepActionsGen(configs, rest),
           instConfig = step.instrumentConfig,
-          config = step.stepConfig
+          config = step.stepConfig,
+          breakpoint = step.breakpoint
         )
 
       }

--- a/modules/server_new/src/main/scala/observe/server/SequenceGen.scala
+++ b/modules/server_new/src/main/scala/observe/server/SequenceGen.scala
@@ -5,6 +5,7 @@ package observe.server
 
 import cats.data.NonEmptyList
 import cats.syntax.all.*
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.StepConfig
@@ -29,7 +30,7 @@ import observe.model.enums.Resource
  * It is combined with header parameters to build an engine.Sequence. It allows to rebuild the
  * engine sequence whenever any of those parameters change.
  */
-final case class SequenceGen[F[_]](
+case class SequenceGen[F[_]](
   obsData:    OdbObservation,
   instrument: Instrument,
   staticCfg:  StaticConfig,
@@ -89,7 +90,7 @@ object SequenceGen {
       }
   }
 
-  final case class StepActionsGen[F[_]](
+  case class StepActionsGen[F[_]](
     configs: Map[Resource | Instrument, SystemOverrides => Action[F]],
     post:    (HeaderExtraData, SystemOverrides) => List[ParallelActions[F]]
   ) {
@@ -110,34 +111,35 @@ object SequenceGen {
 
   }
 
-  final case class PendingStepGen[F[_]](
-    override val id:         StepId,
-    override val dataId:     DataId,
-    resources:               Set[Resource | Instrument],
-    obsControl:              SystemOverrides => InstrumentSystem.ObserveControl[F],
-    generator:               StepActionsGen[F],
-    override val genData:    StepStatusGen = StepStatusGen.Null,
-    override val instConfig: DynamicConfig,
-    override val config:     StepConfig
+  case class PendingStepGen[F[_]](
+    id:         StepId,
+    dataId:     DataId,
+    resources:  Set[Resource | Instrument],
+    obsControl: SystemOverrides => InstrumentSystem.ObserveControl[F],
+    generator:  StepActionsGen[F],
+    genData:    StepStatusGen = StepStatusGen.Null,
+    instConfig: DynamicConfig,
+    config:     StepConfig,
+    breakpoint: Breakpoint
   ) extends StepGen[F]
 
-  final case class SkippedStepGen[F[_]](
-    override val id:         StepId,
-    override val dataId:     DataId,
-    override val genData:    StepStatusGen = StepStatusGen.Null,
-    override val instConfig: DynamicConfig,
-    override val config:     StepConfig
+  case class SkippedStepGen[F[_]](
+    id:         StepId,
+    dataId:     DataId,
+    genData:    StepStatusGen = StepStatusGen.Null,
+    instConfig: DynamicConfig,
+    config:     StepConfig
   ) extends StepGen[F]
 
   // Receiving a sequence from the ODB with a completed step without an image file id would be
   // weird, but I still use an Option just in case
-  final case class CompletedStepGen[F[_]](
-    override val id:         StepId,
-    override val dataId:     DataId,
-    fileId:                  Option[ImageFileId],
-    override val genData:    StepStatusGen = StepStatusGen.Null,
-    override val instConfig: DynamicConfig,
-    override val config:     StepConfig
+  case class CompletedStepGen[F[_]](
+    id:         StepId,
+    dataId:     DataId,
+    fileId:     Option[ImageFileId],
+    genData:    StepStatusGen = StepStatusGen.Null,
+    instConfig: DynamicConfig,
+    config:     StepConfig
   ) extends StepGen[F]
 
   def stepIndex[F[_]](

--- a/modules/server_new/src/main/scala/observe/server/StepsView.scala
+++ b/modules/server_new/src/main/scala/observe/server/StepsView.scala
@@ -151,7 +151,7 @@ object StepsView {
         instConfig = stepg.instConfig,
         stepConfig = stepg.config,
         status = status,
-        breakpoint = step.breakpoint.value,
+        breakpoint = step.breakpoint,
         skip = step.skipMark.value,
         configStatus = configStatus,
         observeStatus = observeStatus(step.executions),

--- a/modules/server_new/src/main/scala/observe/server/gmos/GmosStepsView.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/GmosStepsView.scala
@@ -14,7 +14,7 @@ import observe.server.StepsView.*
 import observe.server.*
 import observe.server.gmos.GmosController.Config.*
 
-final class GmosStepsView[F[_]] extends StepsView[F] {
+class GmosStepsView[F[_]] extends StepsView[F] {
   override def stepView(
     stepg:         SequenceGen.StepGen[F],
     step:          engine.Step[F],
@@ -55,7 +55,7 @@ final class GmosStepsView[F[_]] extends StepsView[F] {
           instConfig = stepg.instConfig,
           stepConfig = stepg.config,
           status = status,
-          breakpoint = step.breakpoint.value,
+          breakpoint = step.breakpoint,
           skip = step.skipMark.value,
           configStatus = configStatus,
           nsStatus = NodAndShuffleStatus(

--- a/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
@@ -914,7 +914,8 @@ class ObserveEngineSuite extends TestCommon {
           ),
           StepStatusGen.Null,
           step.instrumentConfig,
-          step.stepConfig
+          step.stepConfig,
+          breakpoint = Breakpoint.Disabled
         )
       }.toList
     )

--- a/modules/server_new/src/test/scala/observe/server/SeqTranslateSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/SeqTranslateSuite.scala
@@ -8,6 +8,7 @@ import cats.data.NonEmptyList
 import cats.effect.*
 import cats.syntax.all.*
 import fs2.Stream
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.Site
 import lucuma.core.util.TimeSpan
@@ -49,7 +50,8 @@ class SeqTranslateSuite extends TestCommon {
         ),
         StepStatusGen.Null,
         dynamicCfg1,
-        stepCfg1
+        stepCfg1,
+        breakpoint = Breakpoint.Disabled
       )
     )
   )

--- a/modules/server_new/src/test/scala/observe/server/TestCommon.scala
+++ b/modules/server_new/src/test/scala/observe/server/TestCommon.scala
@@ -343,7 +343,8 @@ object TestCommon {
         ),
         StepStatusGen.Null,
         dynamicCfg1,
-        stepCfg1
+        stepCfg1,
+        breakpoint = Breakpoint.Disabled
       )
     )
   )
@@ -423,7 +424,8 @@ object TestCommon {
           ),
           StepStatusGen.Null,
           dynamicCfg1,
-          stepCfg1
+          stepCfg1,
+          breakpoint = Breakpoint.Disabled
         )
       )
   )
@@ -494,7 +496,8 @@ object TestCommon {
         ),
         StepStatusGen.Null,
         dynamicCfg1,
-        stepCfg1
+        stepCfg1,
+        breakpoint = Breakpoint.Disabled
       ),
       SequenceGen.PendingStepGen(
         id = stepId(2),
@@ -507,7 +510,8 @@ object TestCommon {
         ),
         StepStatusGen.Null,
         dynamicCfg1,
-        stepCfg1
+        stepCfg1,
+        breakpoint = Breakpoint.Disabled
       )
     )
   )

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/vars.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/vars.scala
@@ -5,6 +5,7 @@ package observe.web.server.http4s
 
 import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Step
@@ -57,16 +58,20 @@ private given QueryParamDecoder[RunOverride] =
 object OptionalRunOverride
     extends OptionalQueryParamDecoderMatcher[RunOverride]("overrideTargetCheck")
 
-object BooleanVar:
-  def unapply(str: String): Option[Boolean] =
+private trait BooleanBasedVar[A]:
+  def unapply(str: String): Option[A] =
     str.toLowerCase match
-      case "true"  => Some(true)
-      case "false" => Some(false)
-      case _       => None
-
-object SubsystemEnabledVar:
-  def unapply(str: String): Option[SubsystemEnabled] =
-    str.toLowerCase match
-      case "true"  => SubsystemEnabled.Enabled.some
-      case "false" => SubsystemEnabled.Disabled.some
+      case "true"  => item(true).some
+      case "false" => item(false).some
       case _       => none
+
+  def item(b: Boolean): A
+
+object BooleanVar extends BooleanBasedVar[Boolean]:
+  def item(b: Boolean) = b
+
+object BreakpointVar extends BooleanBasedVar[Breakpoint]:
+  def item(b: Boolean) = if b then Breakpoint.Enabled else Breakpoint.Disabled
+
+object SubsystemEnabledVar extends BooleanBasedVar[SubsystemEnabled]:
+  def item(b: Boolean) = if b then SubsystemEnabled.Enabled else SubsystemEnabled.Disabled

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
@@ -104,6 +104,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
                       s"/load/GmosSouth/${obsId.show}/${clientId.value}/observer"
                     )
                   )
+                    .withEntity(List.empty[Step.Id].asJson)
                 ).value
     } yield l.map(_.status)
     assertIO(r, Some(Status.NoContent))

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
@@ -104,7 +104,6 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
                       s"/load/GmosSouth/${obsId.show}/${clientId.value}/observer"
                     )
                   )
-                    .withEntity(List.empty[Step.Id].asJson)
                 ).value
     } yield l.map(_.status)
     assertIO(r, Some(Status.NoContent))
@@ -200,6 +199,24 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
     } yield l.map(_.status)
     assertIO(r, Some(Status.NoContent))
 
+  test("set breakpoints"):
+    val r = for {
+      engine <- TestObserveEngine.build[IO]
+      s      <- commandRoutes(engine)
+      wsb    <- WebSocketBuilder2[IO]
+      l      <-
+        s(
+          Request[IO](
+            method = Method.POST,
+            uri = Uri
+              .unsafeFromString(
+                s"/${obsId.show}/${clientId.value}/breakpoints/observer/true"
+              )
+          )
+            .withEntity(List(stepId).asJson)
+        ).value
+    } yield l.map(_.status)
+    assertIO(r, Some(Status.NoContent))
   test("start"):
     val r = for {
       engine <- TestObserveEngine.build[IO]

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
@@ -8,6 +8,7 @@ import cats.effect.Async
 import cats.effect.Sync
 import cats.syntax.all.*
 import fs2.Stream
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.Instrument
@@ -57,12 +58,12 @@ class TestObserveEngine[F[_]: Sync: Logger](sys: Systems[F]) extends ObserveEngi
     user:     User
   ): F[Unit] = Applicative[F].unit
 
-  override def setBreakpoint(
+  override def setBreakpoints(
     seqId:    Id,
     user:     User,
     observer: Observer,
-    stepId:   StepId,
-    v:        Boolean
+    stepId:   List[StepId],
+    v:        Breakpoint
   ): F[Unit] = Applicative[F].unit
 
   override def setOperator(user: User, name: Operator): F[Unit] =


### PR DESCRIPTION
breakpoints are read from the odb on load and it is possible to set multiple breakpoints at once in a separate `breakpoints` route