### PR TITLE
Disable selection and breakpoint toggle in possibleFuture steps

### DIFF
--- a/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
+++ b/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
@@ -62,6 +62,7 @@ object ObserveStyles:
   val StepRowDone: Css           = Css("ObserveStyles-stepRowDone")
   val StepRowWithBreakpoint: Css = Css("ObserveStyles-stepRowWithBreakpoint")
   val StepRowFirstInAtom: Css    = Css("ObserveStyles-stepRowFirstInAtom")
+  val StepRowPossibleFuture: Css = Css("ObserveStyles-stepRowPossibleFuture")
 
   val ObservationProgressBar: Css = Css("ObserveStyles-observationProgressBar")
   val ControlButtonStrip: Css     = Css("ObserveStyles-controlButtonStrip")

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/ControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/ControlButtons.scala
@@ -60,7 +60,7 @@ object ControlButtons:
     //     case _                                                        => Icons.Stop
 
     // p.connect { proxy =>
-    val isReadingOut = false // proxy().exists(_.stage === ObserveStage.ReadingOut)
+    // val isReadingOut = false // proxy().exists(_.stage === ObserveStage.ReadingOut)
 
     <.div(ObserveStyles.ControlButtonStrip, ^.cls := "p-inputgroup")(
       // ObserveStyles.notInMobile,
@@ -72,27 +72,27 @@ object ControlButtons:
               icon = Icons.Pause.withFixedWidth(), // .withSize(IconSize.LG),
               tooltip = "Pause the current exposure",
               tooltipOptions = DefaultTooltipOptions,
-              disabled = true,
+              disabled = true,                     // props.requestInFlight || props.isObservePaused || isReadingOut
               onClickE = _.stopPropagationCB       // >> requestObsPause(p.obsId, p.stepId)
-            ).withMods(^.disabled := props.requestInFlight || props.isObservePaused || isReadingOut)
+            )
           case StopObservation  =>
             Button(
               clazz = ObserveStyles.StopButton,
               icon = Icons.Stop.withFixedWidth().withSize(IconSize.LG),
               tooltip = "Stop the current exposure early",
               tooltipOptions = DefaultTooltipOptions,
-              disabled = true,
+              disabled = true,               // props.requestInFlight || isReadingOut
               onClickE = _.stopPropagationCB // >> requestStop(p.obsId, p.stepId)
-            ).withMods(^.disabled := props.requestInFlight || isReadingOut)
+            )
           case AbortObservation =>
             Button(
               clazz = ObserveStyles.AbortButton,
               icon = Icons.XMark.withFixedWidth().withSize(IconSize.LG),
               tooltip = "Abort the current exposure",
               tooltipOptions = DefaultTooltipOptions,
-              disabled = true,
+              disabled = true,               // props.requestInFlight || isReadingOut
               onClickE = _.stopPropagationCB // >> requestAbort(p.obsId, p.stepId),
-            ).withMods(^.disabled := props.requestInFlight || isReadingOut)
+            )
           // case ResumeObservation           =>
           //   Popup(
           //     position = PopupPosition.TopRight,

--- a/modules/web/client/src/main/webapp/styles/observe.scss
+++ b/modules/web/client/src/main/webapp/styles/observe.scss
@@ -640,6 +640,10 @@ html {
       // }
     }
 
+    tr.ObserveStyles-stepRowPossibleFuture {
+      opacity: 0.6;
+    }
+
     // .stepWithBreakpoint(@line_color) {
     //   background-image: linear-gradient(to right, @line_color 0px, @line_color);
     //   font-size: smaller !important;


### PR DESCRIPTION
Only nextAtom steps can now be selected or their breakpoint toogled.

Other steps are now shown as disabled.

<img width="396" alt="image" src="https://github.com/gemini-hlsw/observe/assets/1895643/b477a30a-eeb3-4214-bbb8-ddda79e06dba">
