### PR TITLE
Pause events

### DIFF
--- a/modules/model/shared/src/main/scala/observe/model/events.scala
+++ b/modules/model/shared/src/main/scala/observe/model/events.scala
@@ -138,28 +138,8 @@ case class AlignAndCalibEvent(step: Int) extends ObserveEvent derives Eq
 
 extension (e: ObserveEvent)
   def toClientEvent: Option[(Option[ClientId], ClientEvent)] = (e match {
-    case ConditionsUpdated(v)                                   =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case SequenceRefreshed(v, _)                                =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case ObserverUpdated(v)                                     =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case OverridesUpdated(v)                                    =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case StepBreakpointChanged(v)                               =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case SequenceUpdated(v)                                     =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case StepExecuted(_, v)                                     =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case FileIdStepExecuted(_, v)                               =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case SequenceStart(_, _, v)                                 =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case SequenceCompleted(v)                                   =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
-    case OperatorUpdated(v)                                     =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
+    case a: ObserveModelUpdate                                  =>
+      ClientEvent.ObserveState(a.view.sequencesState, a.view.conditions, a.view.operator).some
     case UserPromptNotification(c @ ChecksOverride(_, _, _), _) =>
       ClientEvent.ChecksOverrideEvent(c).some
     case SingleActionEvent(v)                                   =>
@@ -182,8 +162,6 @@ extension (e: ObserveEvent)
             )
             .some
       }
-    case SequenceLoaded(_, v)                                   =>
-      ClientEvent.ObserveState(v.sequencesState, v.conditions, v.operator).some
     case _                                                      =>
       none
   }).map { u =>

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
@@ -93,32 +93,32 @@ class ObserveCommandRoutes[F[_]: Async: Compression](
     //   se.setSkipMark(inputQueue, obsId, user, obs, stepId, bp) *>
     //     Ok(s"Set skip mark in step $stepId of sequence $obsId")
 
-    case req @ POST -> Root / ObsIdVar(obsId) / StepIdVar(stepId) / ClientIDVar(clientId) / "stop" /
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "stop" /
         ObserverVar(obs) =>
       ssoClient.require(req): user =>
         oe.stopObserve(obsId, obs, user, graceful = false) *> NoContent()
 
-    case req @ POST -> Root / ObsIdVar(obsId) / StepIdVar(stepId) / ClientIDVar(clientId) /
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) /
         "stopGracefully" / ObserverVar(obs) =>
       ssoClient.require(req): user =>
         oe.stopObserve(obsId, obs, user, graceful = true) *> NoContent()
 
-    case req @ POST -> Root / ObsIdVar(obsId) / StepIdVar(stepId) / ClientIDVar(clientId) /
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) /
         "abort" / ObserverVar(obs) =>
       ssoClient.require(req): user =>
         oe.abortObserve(obsId, obs, user) *> NoContent()
 
-    case req @ POST -> Root / ObsIdVar(obsId) / StepIdVar(stepId) / ClientIDVar(clientId) /
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) /
         "pauseObs" / ObserverVar(obs) =>
       ssoClient.require(req): user =>
         oe.pauseObserve(obsId, obs, user, graceful = false) *> NoContent()
 
-    case req @ POST -> Root / ObsIdVar(obsId) / StepIdVar(stepId) / ClientIDVar(clientId) /
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) /
         "pauseObsGracefully" / ObserverVar(obs) =>
       ssoClient.require(req): user =>
         oe.pauseObserve(obsId, obs, user, graceful = true) *> NoContent()
 
-    case req @ POST -> Root / ObsIdVar(obsId) / StepIdVar(stepId) / ClientIDVar(clientId) /
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) /
         "resumeObs" / ObserverVar(obs) =>
       ssoClient.require(req): user =>
         oe.resumeObserve(obsId, obs, user) *> NoContent()

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/ObserveCommandRoutesSuite.scala
@@ -333,7 +333,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
   } */
 
   test("stop sequence"):
-    val uri = Uri.unsafeFromString(s"/${obsId.show}/${stepId.show}/${clientId.value}/stop/observer")
+    val uri = Uri.unsafeFromString(s"/${obsId.show}/${clientId.value}/stop/observer")
     val r   = for
       engine <- TestObserveEngine.build[IO]
       s      <- commandRoutes(engine)
@@ -344,7 +344,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
 
   test("stop sequence gracefully"):
     val uri = Uri.unsafeFromString(
-      s"/${obsId.show}/${stepId.show}/${clientId.value}/stopGracefully/observer"
+      s"/${obsId.show}/${clientId.value}/stopGracefully/observer"
     )
     val r   = for
       engine <- TestObserveEngine.build[IO]
@@ -356,7 +356,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
 
   test("abort sequence"):
     val uri =
-      Uri.unsafeFromString(s"/${obsId.show}/${stepId.show}/${clientId.value}/abort/observer")
+      Uri.unsafeFromString(s"/${obsId.show}/${clientId.value}/abort/observer")
     val r   = for
       engine <- TestObserveEngine.build[IO]
       s      <- commandRoutes(engine)
@@ -367,7 +367,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
 
   test("pause obs sequence"):
     val uri =
-      Uri.unsafeFromString(s"/${obsId.show}/${stepId.show}/${clientId.value}/pauseObs/observer")
+      Uri.unsafeFromString(s"/${obsId.show}/${clientId.value}/pauseObs/observer")
     val r   = for
       engine <- TestObserveEngine.build[IO]
       s      <- commandRoutes(engine)
@@ -378,7 +378,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
 
   test("pause obs gracefully"):
     val uri = Uri.unsafeFromString(
-      s"/${obsId.show}/${stepId.show}/${clientId.value}/pauseObsGracefully/observer"
+      s"/${obsId.show}/${clientId.value}/pauseObsGracefully/observer"
     )
     val r   = for
       engine <- TestObserveEngine.build[IO]
@@ -390,7 +390,7 @@ class ObserveCommandRoutesSuite extends munit.CatsEffectSuite with TestRoutes:
 
   test("resume obs"):
     val uri =
-      Uri.unsafeFromString(s"/${obsId.show}/${stepId.show}/${clientId.value}/resumeObs/observer")
+      Uri.unsafeFromString(s"/${obsId.show}/${clientId.value}/resumeObs/observer")
     val r   = for
       engine <- TestObserveEngine.build[IO]
       s      <- commandRoutes(engine)


### PR DESCRIPTION
Before we were forwarding some of the model update events but this changes will send them all, e.g. when a sequence is paused or removed
Stop/pause/etc.. aren't step specific so I removed `stepId` from the routes