### PR TITLE
Embed JRE with deployed package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ calibrations/
 project/project/.bloop/
 metals.sbt
 .vscode
+jre
 
 # hydra
 .hydra/

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / resolvers += "Gemini Repository".at(
 
 // This key is used to find the JRE dir that will be bundled with packaged deployments.
 // It could/should be overridden on a user basis. E.g. add a `jres.sbt` file with your particular configuration.
-ThisBuild / packagedJreDir := Path.userHome / ".jres" / "linux" / "jdk-11.0.21+9-jre"
+ThisBuild / packagedJreDir := Path.userHome / ".jres" / "linux" / "jdk-17.0.9+9-jre"
 
 ThisBuild / evictionErrorLevel := Level.Info
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,10 +34,6 @@ ThisBuild / resolvers += "Gemini Repository".at(
   "https://github.com/gemini-hlsw/maven-repo/raw/master/releases"
 )
 
-// This key is used to find the JRE dir that will be bundled with packaged deployments.
-// It could/should be overridden on a user basis. E.g. add a `jres.sbt` file with your particular configuration.
-ThisBuild / packagedJreDir := Path.userHome / ".jres" / "linux" / "jdk-17.0.9+9-jre"
-
 ThisBuild / evictionErrorLevel := Level.Info
 
 // Uncomment for local gmp testing

--- a/project/AppsCommon.scala
+++ b/project/AppsCommon.scala
@@ -7,8 +7,6 @@ import sbt.{Project, Resolver, _}
  * Define tasks and settings used by application definitions
  */
 object AppsCommon {
-  lazy val packagedJreDir        =
-    settingKey[File]("Directory of the JREs that will be bundled with deployment packages.")
   lazy val applicationConfName   =
     settingKey[String]("Name of the application to lookup the configuration")
   lazy val applicationConfSite   =
@@ -51,7 +49,10 @@ object AppsCommon {
   lazy val embeddedJreSettings = Seq(
     // Put the jre in the tarball
     Universal / mappings ++= {
-      val jreDir = (ThisBuild / packagedJreDir).value
+      // We look for the JRE in the project's base directory. This can be a symlink.
+      val jreDir = (ThisBuild / baseDirectory).value / "jre"
+      if (!jreDir.exists)
+        throw new Exception("JRE directory does not exist: " + jreDir)
       directory(jreDir).map { path =>
         path._1 -> ("jre/" + path._1.relativeTo(jreDir).get.getPath)
       }

--- a/project/AppsCommon.scala
+++ b/project/AppsCommon.scala
@@ -7,7 +7,8 @@ import sbt.{Project, Resolver, _}
  * Define tasks and settings used by application definitions
  */
 object AppsCommon {
-  lazy val ocsJreDir             = settingKey[File]("Directory where distribution JREs are stored.")
+  lazy val packagedJreDir        =
+    settingKey[File]("Directory of the JREs that will be bundled with deployment packages.")
   lazy val applicationConfName   =
     settingKey[String]("Name of the application to lookup the configuration")
   lazy val applicationConfSite   =
@@ -19,15 +20,6 @@ object AppsCommon {
   object LogType {
     case object ConsoleAndFiles extends LogType
     case object Files           extends LogType
-  }
-
-  sealed trait DeploymentTarget {
-    def subdir: String
-  }
-  object DeploymentTarget       {
-    case object Linux64 extends DeploymentTarget {
-      override def subdir: String = "linux"
-    }
   }
 
   sealed trait DeploymentSite {
@@ -56,15 +48,12 @@ object AppsCommon {
     }
   )
 
-  private def embeddedJreSettings(target: DeploymentTarget) = Seq(
+  lazy val embeddedJreSettings = Seq(
     // Put the jre in the tarball
     Universal / mappings ++= {
-      val jresDir    = (ThisBuild / ocsJreDir).value
-      // Map the location of jre files
-      val jreLink    = "JRE64_1.8"
-      val linux64Jre = jresDir.toPath.resolve(target.subdir).resolve(jreLink)
-      directory(linux64Jre.toFile).map { j =>
-        j._1 -> j._2.replace(jreLink, "jre")
+      val jreDir = (ThisBuild / packagedJreDir).value
+      directory(jreDir).map { path =>
+        path._1 -> ("jre/" + path._1.relativeTo(jreDir).get.getPath)
       }
     },
 
@@ -73,7 +62,4 @@ object AppsCommon {
       "-java-home ${app_home}/../jre"
     )
   )
-
-  lazy val embeddedJreSettingsLinux64 = embeddedJreSettings(DeploymentTarget.Linux64)
-
 }


### PR DESCRIPTION
I simplified the logic since we are only deploying for linux-x64. If we need to support multiple environments, we can add the logic back.

For the moment, a single artifact is still built for all environments, which should be enough for upcoming tests. Differentiation of site and test/prod upcoming in future, not urgent, PR.