### PR TITLE
Stop+abort sequence, preload observation summaries into state

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ stopObserveAll
 
 # How to package for deployment
 
-If you haven't already, create a symlink `jre` that points to the JRE you want bundled with the deployment.
+If you haven't already, create a symlink `jre` in the project directory that points to the Linux JRE you want bundled with the deployment.
 
 To deploy, run in `sbt`:
 

--- a/modules/model/shared/src/main/scala/observe/model/operations.scala
+++ b/modules/model/shared/src/main/scala/observe/model/operations.scala
@@ -47,7 +47,6 @@ object operations:
       isObservePaused: Boolean,
       isMultiLevel:    Boolean
     ): List[Operations] =
-      println(s"QUERYING $level, $isObservePaused, $isMultiLevel")
       level match
         case Observation =>
           if (isMultiLevel)

--- a/modules/model/shared/src/main/scala/observe/model/operations.scala
+++ b/modules/model/shared/src/main/scala/observe/model/operations.scala
@@ -47,27 +47,26 @@ object operations:
       isObservePaused: Boolean,
       isMultiLevel:    Boolean
     ): List[Operations] =
+      println(s"QUERYING $level, $isObservePaused, $isMultiLevel")
       level match
         case Observation =>
-          if (isMultiLevel) {
-            if (isObservePaused) {
+          if (isMultiLevel)
+            if (isObservePaused)
               List(Operations.ResumeObservation, Operations.AbortObservation)
-            } else {
+            else
               List(Operations.AbortObservation)
-            }
-          } else {
-            if (isObservePaused) {
-              List(Operations.ResumeObservation,
-                   Operations.StopObservation,
-                   Operations.AbortObservation
-              )
-            } else {
-              List(Operations.PauseObservation,
-                   Operations.StopObservation,
-                   Operations.AbortObservation
-              )
-            }
-          }
+          else if (isObservePaused)
+            List(
+              Operations.ResumeObservation,
+              Operations.StopObservation,
+              Operations.AbortObservation
+            )
+          else
+            List(
+              Operations.PauseObservation,
+              Operations.StopObservation,
+              Operations.AbortObservation
+            )
         case NsCycle     =>
           List(Operations.PauseGracefullyObservation, Operations.StopGracefullyObservation)
         case NsNod       =>

--- a/modules/web/client-model/src/main/scala/observe/ui/model/LoadedObservation.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/LoadedObservation.scala
@@ -7,6 +7,8 @@ import cats.syntax.all.*
 import crystal.Pot
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.InstrumentExecutionConfig
+import monocle.Focus
+import monocle.Lens
 
 case class LoadedObservation private (
   obsId:  Observation.Id,
@@ -17,3 +19,7 @@ case class LoadedObservation private (
 
 object LoadedObservation:
   def apply(obsId: Observation.Id): LoadedObservation = new LoadedObservation(obsId)
+
+  val obsId: Lens[LoadedObservation, Observation.Id]                  = Focus[LoadedObservation](_.obsId)
+  val config: Lens[LoadedObservation, Pot[InstrumentExecutionConfig]] =
+    Focus[LoadedObservation](_.config)

--- a/modules/web/client-model/src/main/scala/observe/ui/model/LoadedObservation.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/LoadedObservation.scala
@@ -7,24 +7,19 @@ import cats.syntax.all.*
 import crystal.Pot
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.InstrumentExecutionConfig
-import monocle.Focus
-import monocle.Lens
 
 case class LoadedObservation private (
-  obsId:   Observation.Id,
-  summary: Pot[ObsSummary] = Pot.pending,
-  config:  Pot[InstrumentExecutionConfig] = Pot.pending
+  // summary: ObsSummary,
+  obsId:  Observation.Id,
+  config: Pot[InstrumentExecutionConfig] = Pot.pending
 ):
-  def withSummary(summary: Either[Throwable, ObsSummary]): LoadedObservation =
-    copy(summary = Pot.fromTry(summary.toTry))
+  // export summary.obsId
 
   def withConfig(config: Either[Throwable, Option[InstrumentExecutionConfig]]): LoadedObservation =
     copy(config = Pot.fromTry(config.map(Pot.fromOption).toTry).flatten)
 
-  def unPot: Pot[(Observation.Id, ObsSummary, InstrumentExecutionConfig)] =
-    (summary, config).mapN((s, c) => (obsId, s, c))
+  // def unPot: Pot[(Observation.Id, InstrumentExecutionConfig)] =
+  //   config.map(c => (obsId, c))
 
 object LoadedObservation:
   def apply(obsId: Observation.Id): LoadedObservation = new LoadedObservation(obsId)
-
-  val id: Lens[LoadedObservation, Observation.Id] = Focus[LoadedObservation](_.obsId)

--- a/modules/web/client-model/src/main/scala/observe/ui/model/LoadedObservation.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/LoadedObservation.scala
@@ -9,17 +9,11 @@ import lucuma.core.model.Observation
 import lucuma.core.model.sequence.InstrumentExecutionConfig
 
 case class LoadedObservation private (
-  // summary: ObsSummary,
   obsId:  Observation.Id,
   config: Pot[InstrumentExecutionConfig] = Pot.pending
 ):
-  // export summary.obsId
-
   def withConfig(config: Either[Throwable, Option[InstrumentExecutionConfig]]): LoadedObservation =
     copy(config = Pot.fromTry(config.map(Pot.fromOption).toTry).flatten)
-
-  // def unPot: Pot[(Observation.Id, InstrumentExecutionConfig)] =
-  //   config.map(c => (obsId, c))
 
 object LoadedObservation:
   def apply(obsId: Observation.Id): LoadedObservation = new LoadedObservation(obsId)

--- a/modules/web/client-model/src/main/scala/observe/ui/model/RootModel.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/RootModel.scala
@@ -83,6 +83,8 @@ object RootModelData:
   val userVault: Lens[RootModelData, Option[UserVault]]                        = Focus[RootModelData](_.userVault)
   val readyObservations: Lens[RootModelData, Pot[List[ObsSummary]]]            =
     Focus[RootModelData](_.readyObservations)
+  val selectedObservation: Lens[RootModelData, Option[Observation.Id]]         =
+    Focus[RootModelData](_.selectedObservation)
   val nighttimeObservation: Lens[RootModelData, Option[LoadedObservation]]     =
     Focus[RootModelData](_.nighttimeObservation)
   val daytimeObservations: Lens[RootModelData, List[LoadedObservation]]        =

--- a/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbLoadedObservation.scala
+++ b/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbLoadedObservation.scala
@@ -11,8 +11,6 @@ import lucuma.core.model.sequence.InstrumentExecutionConfig
 import lucuma.core.model.sequence.arb.ArbInstrumentExecutionConfig.given
 import lucuma.core.util.arb.ArbGid.given
 import observe.ui.model.LoadedObservation
-import observe.ui.model.ObsSummary
-import observe.ui.model.arb.ArbObsSummary.given
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen
@@ -20,19 +18,15 @@ import org.scalacheck.Cogen
 trait ArbLoadedObservation:
   given Arbitrary[LoadedObservation] = Arbitrary:
     for {
-      obsId   <- arbitrary[Observation.Id]
-      summary <- arbitrary[Pot[ObsSummary]]
-      config  <- arbitrary[Pot[InstrumentExecutionConfig]]
+      obsId  <- arbitrary[Observation.Id]
+      config <- arbitrary[Pot[InstrumentExecutionConfig]]
     } yield
-      val base            = LoadedObservation(obsId)
-      val baseWithSummary = summary.toOptionTry.fold(base)(t => base.withSummary(t.toEither))
-      config.toOptionTry.fold(baseWithSummary)(t =>
-        baseWithSummary.withConfig(t.map(_.some).toEither)
-      )
+      val base = LoadedObservation(obsId)
+      config.toOptionTry.fold(base)(t => base.withConfig(t.map(_.some).toEither))
 
   given Cogen[LoadedObservation] =
-    Cogen[(Observation.Id, Pot[ObsSummary], Pot[InstrumentExecutionConfig])]
+    Cogen[(Observation.Id, Pot[InstrumentExecutionConfig])]
       .contramap: s =>
-        (s.obsId, s.summary, s.config)
+        (s.obsId, s.config)
 
 object ArbLoadedObservation extends ArbLoadedObservation

--- a/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbObsSummary.scala
+++ b/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbObsSummary.scala
@@ -4,13 +4,16 @@
 package observe.ui.model.arb
 
 import cats.Order.given
+import lucuma.core.enums.Instrument
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ObsAttachment
+import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.TimingWindow
 import lucuma.core.model.arb.ArbConstraintSet.given
 import lucuma.core.model.arb.ArbPosAngleConstraint.given
 import lucuma.core.model.arb.ArbTimingWindow.given
+import lucuma.core.util.arb.ArbEnumerated.given
 import lucuma.core.util.arb.ArbGid.given
 import lucuma.schemas.model.ObservingMode
 import lucuma.schemas.model.arb.ArbObservingMode.given
@@ -25,7 +28,10 @@ import scala.collection.immutable.SortedSet
 trait ArbObsSummary:
   given Arbitrary[ObsSummary] = Arbitrary:
     for
+      obsId              <- arbitrary[Observation.Id]
       title              <- arbitrary[String]
+      subtitle           <- arbitrary[String]
+      instrument         <- arbitrary[Instrument]
       constraints        <- arbitrary[ConstraintSet]
       timingWindows      <- arbitrary[List[TimingWindow]]
       attachmentIds      <- arbitrary[List[ObsAttachment.Id]]
@@ -33,7 +39,10 @@ trait ArbObsSummary:
       visualizationTime  <- arbitrary[Option[Instant]]
       posAngleConstraint <- arbitrary[PosAngleConstraint]
     yield ObsSummary(
+      obsId,
       title,
+      subtitle,
+      instrument,
       constraints,
       timingWindows,
       SortedSet.from(attachmentIds),
@@ -44,7 +53,10 @@ trait ArbObsSummary:
 
   given Cogen[ObsSummary] =
     Cogen[
-      (String,
+      (Observation.Id,
+       String,
+       String,
+       Instrument,
        ConstraintSet,
        List[TimingWindow],
        List[ObsAttachment.Id],
@@ -54,7 +66,10 @@ trait ArbObsSummary:
       )
     ]
       .contramap: s =>
-        (s.title,
+        (s.obsId,
+         s.title,
+         s.subtitle,
+         s.instrument,
          s.constraints,
          s.timingWindows,
          s.attachmentIds.toList,

--- a/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbRootModel.scala
+++ b/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbRootModel.scala
@@ -3,6 +3,8 @@
 
 package observe.ui.model.arb
 
+import crystal.Pot
+import crystal.arb.given
 import eu.timepit.refined.scalacheck.string.given
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.math.arb.ArbRefined.given
@@ -22,8 +24,10 @@ import observe.model.arb.ArbExecutionState.given
 import observe.model.arb.ArbStepProgress.given
 import observe.model.arb.ObserveModelArbitraries.given
 import observe.ui.model.LoadedObservation
+import observe.ui.model.ObsSummary
 import observe.ui.model.RootModelData
 import observe.ui.model.arb.ArbLoadedObservation.given
+import observe.ui.model.arb.ArbObsSummary.given
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen
@@ -37,6 +41,8 @@ trait ArbRootModel:
   given Arbitrary[RootModelData] = Arbitrary:
     for
       uv   <- arbitrary[Option[UserVault]]
+      ros  <- arbitrary[Pot[List[ObsSummary]]]
+      so   <- arbitrary[Option[Observation.Id]]
       nto  <- arbitrary[Option[LoadedObservation]]
       dtos <- arbitrary[List[LoadedObservation]]
       se   <- arbitrary[Map[Observation.Id, ExecutionState]]
@@ -47,11 +53,13 @@ trait ArbRootModel:
       op   <- arbitrary[Option[Operator]]
       usm  <- arbitrary[Option[NonEmptyString]]
       log  <- arbitrary[List[NonEmptyString]]
-    yield RootModelData(uv, nto, dtos, se, sp, uss, cs, obs, op, usm, log)
+    yield RootModelData(uv, ros, so, nto, dtos, se, sp, uss, cs, obs, op, usm, log)
 
   given Cogen[RootModelData] = Cogen[
     (
       Option[UserVault],
+      Pot[List[ObsSummary]],
+      Option[Observation.Id],
       Option[LoadedObservation],
       List[LoadedObservation],
       List[(Observation.Id, ExecutionState)],
@@ -64,6 +72,8 @@ trait ArbRootModel:
     )
   ].contramap: x =>
     (x.userVault,
+     x.readyObservations,
+     x.selectedObservation,
      x.nighttimeObservation,
      x.daytimeObservations,
      x.executionState.toList,

--- a/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
@@ -7,15 +7,6 @@ import clue.GraphQLOperation
 import clue.annotation.GraphQL
 import lucuma.schemas.ObservationDB
 import observe.ui.model.ObsSummary
-// import lucuma.core.enums.Site
-// import io.circe.{Decoder, Encoder}
-// import io.circe.generic.auto.*
-// import lucuma.core.math
-// import lucuma.core.enums
-// import lucuma.core.model
-// import cats.syntax.functor.*
-// import lucuma.core.model.sequence.{Atom, ExecutionSequence, Step}
-// import lucuma.core.model.sequence.gmos.{DynamicConfig, GmosGratingConfig, StaticConfig}
 
 object ObsQueriesGQL {
 
@@ -43,13 +34,4 @@ object ObsQueriesGQL {
       }
     """
   }
-
-  // @GraphQL
-  // trait ObservationSummary extends GraphQLOperation[ObservationDB] {
-  //   val document = s"""
-  //     query($$obsId: ObservationId!) {
-  //       observation(observationId: $$obsId) $ObservationSummarySubquery
-  //     }
-  //   """
-  // }
 }

--- a/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
@@ -6,6 +6,7 @@ package observe.queries
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 import lucuma.schemas.ObservationDB
+import observe.ui.model.ObsSummary
 // import lucuma.core.enums.Site
 // import io.circe.{Decoder, Encoder}
 // import io.circe.generic.auto.*
@@ -16,26 +17,20 @@ import lucuma.schemas.ObservationDB
 // import lucuma.core.model.sequence.{Atom, ExecutionSequence, Step}
 // import lucuma.core.model.sequence.gmos.{DynamicConfig, GmosGratingConfig, StaticConfig}
 
-// gql: import io.circe.refined.*
-
 object ObsQueriesGQL {
 
   @GraphQL
   trait ActiveObservationIdsQuery extends GraphQLOperation[ObservationDB] {
-    val document = """
+    val document = s"""
       query {
         observations(WHERE: { status: { EQ: READY } }) {
-          matches {
-            id
-            title
-            subtitle
-            status
-            activeStatus
-            instrument
-          }
+          matches $ObservationSummarySubquery
         }
       }
     """
+
+    object Observations:
+      type Matches = ObsSummary
   }
 
   @GraphQL
@@ -49,12 +44,12 @@ object ObsQueriesGQL {
     """
   }
 
-  @GraphQL
-  trait ObservationSummary extends GraphQLOperation[ObservationDB] {
-    val document = s"""
-      query($$obsId: ObservationId!) {
-        observation(observationId: $$obsId) $ObservationSummarySubquery
-      }
-    """
-  }
+  // @GraphQL
+  // trait ObservationSummary extends GraphQLOperation[ObservationDB] {
+  //   val document = s"""
+  //     query($$obsId: ObservationId!) {
+  //       observation(observationId: $$obsId) $ObservationSummarySubquery
+  //     }
+  //   """
+  // }
 }

--- a/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
@@ -17,6 +17,8 @@ object ObservationSummarySubquery
         {
           id
           title
+          subtitle
+          instrument
           visualizationTime
           posAngleConstraint $PosAngleConstraintSubquery
           constraintSet $ConstraintSetSubquery

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -41,10 +41,12 @@ import lucuma.ui.components.state.IfLogged
 import lucuma.ui.reusability.given
 import lucuma.ui.sso.SSOClient
 import lucuma.ui.sso.UserVault
-import lucuma.ui.syntax.pot.*
+import lucuma.ui.syntax.all.*
 import observe.model.Environment
 import observe.model.events.client.ClientEvent
+import observe.queries.ObsQueriesGQL
 import observe.ui.BroadcastEvent
+import observe.ui.DefaultErrorPolicy
 import observe.ui.ObserveStyles
 import observe.ui.components.services.ObservationSyncer
 import observe.ui.components.services.ServerEventHandler
@@ -272,6 +274,35 @@ object MainApp extends ServerEventHandler:
             .drain
             .start
             .map(_.cancel) // Previous fiber is cancelled when effect is re-run
+      // .useStreamResourceOnMountBy: (props, ctx) =>
+      .useAsyncEffectWhenDepsReady((_, _, _, _, ctxPot, rootModelDataPot, _, _, odbStatus, _, _) =>
+        (rootModelDataPot.toPotView,
+         ctxPot,
+         odbStatus.toPot.filter(_ === PersistentClientStatus.Initialized)
+        ).tupled
+      ): (_, _, syncStatus, _, _, _, environment, _, _, _, configApiStatus) =>
+        (rootModelData, ctx, _) =>
+          import ctx.given
+
+          val readyObservations = rootModelData
+            .zoom(RootModelData.readyObservations)
+            .async
+
+          // TODO RECONNECT ON ERRORS
+          val obsSummaryUpdaterResource =
+            for
+              obsStream <-
+                ObsQueriesGQL
+                  .ActiveObservationIdsQuery[IO]
+                  .query()
+                  .flatMap(data => readyObservations.set(data.observations.matches.ready))
+                  .recoverWith(t => readyObservations.set(Pot.error(t)))
+                  .reRunOnResourceSignals(ObsQueriesGQL.ObservationEditSubscription.subscribe[IO]())
+              _         <- Resource.make(obsStream.compile.drain.start)(_.cancel)
+            yield ()
+
+          obsSummaryUpdaterResource.allocated
+            .map((_, close) => close)
       .useEffectResultOnMount(Semaphore[IO](1).map(_.permit))
       .render:
         (

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -274,7 +274,6 @@ object MainApp extends ServerEventHandler:
             .drain
             .start
             .map(_.cancel) // Previous fiber is cancelled when effect is re-run
-      // .useStreamResourceOnMountBy: (props, ctx) =>
       .useAsyncEffectWhenDepsReady((_, _, _, _, ctxPot, rootModelDataPot, _, _, odbStatus, _, _) =>
         (rootModelDataPot.toPotView,
          ctxPot,

--- a/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
@@ -17,31 +17,25 @@ import lucuma.react.common.given
 import observe.model.ExecutionState
 import observe.model.StepProgress
 import observe.model.given
-import observe.ui.ObserveStyles
 import observe.ui.components.sequence.GmosNorthSequenceTables
 import observe.ui.components.sequence.GmosSouthSequenceTables
 import observe.ui.model.AppContext
-import observe.ui.model.ObsSummary
 import observe.ui.model.SequenceOperations
 import observe.ui.model.SubsystemRunOperation
 import observe.ui.model.enums.ClientMode
-import observe.ui.model.enums.OperationRequest
 import observe.ui.services.SequenceApi
 
 import scala.collection.immutable.SortedMap
 
-import sequence.ObsHeader
-
 case class ObservationSequence(
-  summary:         ObsSummary,
+  obsId:           Observation.Id,
   config:          InstrumentExecutionConfig,
   executionState:  View[ExecutionState],
   progress:        Option[StepProgress],
   selectedStep:    Option[Step.Id],
   setSelectedStep: Step.Id => Callback,
   clientMode:      ClientMode
-) extends ReactFnProps(ObservationSequence.component):
-  val obsId: Observation.Id = summary.obsId
+) extends ReactFnProps(ObservationSequence.component)
 
 object ObservationSequence:
   private type Props = ObservationSequence
@@ -75,13 +69,6 @@ object ObservationSequence:
                 }.toList.flatten)
                 .orEmpty
             )
-
-        // <.div(ObserveStyles.ObservationArea, ^.key := props.obsId.toString)(
-        //   ObsHeader(
-        //     props.summary,
-        //     props.executionState.get.sequenceState.isRunning,
-        //     props.executionState.zoom(OperationRequest.PauseState)
-        //   ),
 
       props.config match
         case InstrumentExecutionConfig.GmosNorth(config) =>

--- a/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
@@ -33,7 +33,6 @@ import scala.collection.immutable.SortedMap
 import sequence.ObsHeader
 
 case class ObservationSequence(
-  obsId:           Observation.Id,
   summary:         ObsSummary,
   config:          InstrumentExecutionConfig,
   executionState:  View[ExecutionState],
@@ -41,7 +40,8 @@ case class ObservationSequence(
   selectedStep:    Option[Step.Id],
   setSelectedStep: Step.Id => Callback,
   clientMode:      ClientMode
-) extends ReactFnProps(ObservationSequence.component)
+) extends ReactFnProps(ObservationSequence.component):
+  val obsId: Observation.Id = summary.obsId
 
 object ObservationSequence:
   private type Props = ObservationSequence

--- a/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
@@ -76,38 +76,38 @@ object ObservationSequence:
                 .orEmpty
             )
 
-      <.div(ObserveStyles.ObservationArea, ^.key := props.obsId.toString)(
-        ObsHeader(
-          props.obsId,
-          props.summary,
-          props.executionState.get.sequenceState.isRunning,
-          props.executionState.zoom(OperationRequest.PauseState)
-        ),
-        props.config match
-          case InstrumentExecutionConfig.GmosNorth(config) =>
-            GmosNorthSequenceTables(
-              props.clientMode,
-              props.obsId,
-              config,
-              props.executionState.get,
-              props.progress,
-              props.selectedStep,
-              props.setSelectedStep,
-              seqOperations,
-              isPreview = false,
-              flipBreakPoint
-            )
-          case InstrumentExecutionConfig.GmosSouth(config) =>
-            GmosSouthSequenceTables(
-              props.clientMode,
-              props.obsId,
-              config,
-              props.executionState.get,
-              props.progress,
-              props.selectedStep,
-              props.setSelectedStep,
-              seqOperations,
-              isPreview = false,
-              flipBreakPoint
-            )
-      )
+        // <.div(ObserveStyles.ObservationArea, ^.key := props.obsId.toString)(
+        //   ObsHeader(
+        //     props.summary,
+        //     props.executionState.get.sequenceState.isRunning,
+        //     props.executionState.zoom(OperationRequest.PauseState)
+        //   ),
+
+      props.config match
+        case InstrumentExecutionConfig.GmosNorth(config) =>
+          GmosNorthSequenceTables(
+            props.clientMode,
+            props.obsId,
+            config,
+            props.executionState.get,
+            props.progress,
+            props.selectedStep,
+            props.setSelectedStep,
+            seqOperations,
+            isPreview = false,
+            flipBreakPoint
+          )
+        case InstrumentExecutionConfig.GmosSouth(config) =>
+          GmosSouthSequenceTables(
+            props.clientMode,
+            props.obsId,
+            config,
+            props.executionState.get,
+            props.progress,
+            props.selectedStep,
+            props.setSelectedStep,
+            seqOperations,
+            isPreview = false,
+            flipBreakPoint
+            // )
+          )

--- a/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
@@ -219,8 +219,7 @@ object SessionQueue:
       TargetColumnId,
       _.title,
       header = "Target",
-      cell = linked(_.value.toString)
-      // cell = linked(_.value.getOrElse(UnknownTargetName))
+      cell = linked(_.value.toString.some.filter(_.nonEmpty).getOrElse(UnknownTargetName))
     ),
     ColDef(
       ObsNameColumnId,

--- a/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
@@ -32,6 +32,7 @@ import observe.ui.model.reusability.given
 case class SessionQueue(
   queue:     List[SessionQueueRow],
   obsStates: Map[Observation.Id, SequenceState],
+  selectObs: Observation.Id => Callback,
   loadedObs: Option[LoadedObservation],
   loadObs:   Observation.Id => Callback
 ) extends ReactFnProps(SessionQueue.component):
@@ -266,7 +267,8 @@ object SessionQueue:
                   props.obsIdPotOpt.map(_.void),
                   row.original,
                   props.loadedObs.map(_.obsId)
-                )
+                ),
+                ^.onClick --> props.selectObs(row.original.obsId)
               ),
             cellMod = cell =>
               ColumnId(cell.column.id) match

--- a/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
@@ -35,7 +35,7 @@ case class SessionQueue(
   loadedObs: Option[LoadedObservation],
   loadObs:   Observation.Id => Callback
 ) extends ReactFnProps(SessionQueue.component):
-  val obsIdPotOpt: Option[Pot[Observation.Id]] = loadedObs.map(_.unPot.map(_._1))
+  val obsIdPotOpt: Option[Pot[Observation.Id]] = loadedObs.map(obs => obs.config.as(obs.obsId))
 
   val isProcessing: Boolean =
     obsIdPotOpt.exists: obsIdPot =>
@@ -217,13 +217,14 @@ object SessionQueue:
     ),
     ColDef(
       TargetColumnId,
-      _.targetName,
+      _.title,
       header = "Target",
-      cell = linked(_.value.getOrElse(UnknownTargetName))
+      cell = linked(_.value.toString)
+      // cell = linked(_.value.getOrElse(UnknownTargetName))
     ),
     ColDef(
       ObsNameColumnId,
-      _.name,
+      _.subtitle,
       header = "Obs. Name",
       cell = linked(_.value.toString)
     ),
@@ -262,7 +263,11 @@ object SessionQueue:
             tableMod = ObserveStyles.ObserveTable |+| ObserveStyles.SessionTable,
             rowMod = row =>
               TagMod(
-                rowClass(props.obsIdPotOpt.map(_.void), row.original, props.loadedObs.map(_.obsId))
+                rowClass(
+                  props.obsIdPotOpt.map(_.void),
+                  row.original,
+                  props.loadedObs.map(_.obsId)
+                )
               ),
             cellMod = cell =>
               ColumnId(cell.column.id) match

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
@@ -13,7 +13,6 @@ import observe.ui.model.ObsSummary
 import observe.ui.model.enums.OperationRequest
 
 case class ObsHeader(
-  obsId:          Observation.Id,
   observation:    ObsSummary,
   isRunning:      Boolean,
   pauseRequested: ViewOpt[OperationRequest]
@@ -26,8 +25,8 @@ object ObsHeader:
     ScalaFnComponent[Props]: props =>
       <.div(ObserveStyles.ObsSummary)(
         <.div(ObserveStyles.ObsSummaryTitle)(
-          SeqControlButtons(props.obsId, props.isRunning, props.pauseRequested),
-          s"${props.observation.title} [${props.obsId}]"
+          SeqControlButtons(props.observation.obsId, props.isRunning, props.pauseRequested),
+          s"${props.observation.title} [${props.observation.obsId}]"
         ),
         <.div(ObserveStyles.ObsSummaryDetails)(
           <.span(props.observation.configurationSummary),

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
@@ -3,17 +3,20 @@
 
 package observe.ui.components.sequence
 
-import crystal.react.ViewOpt
+import crystal.Pot
+import crystal.react.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.model.Observation
 import lucuma.react.common.*
-import observe.model.Observation
 import observe.ui.ObserveStyles
 import observe.ui.model.ObsSummary
 import observe.ui.model.enums.OperationRequest
 
 case class ObsHeader(
   observation:    ObsSummary,
+  loadedObsId:    Option[Pot[Observation.Id]],
+  loadObs:        Observation.Id => Callback,
   isRunning:      Boolean,
   pauseRequested: ViewOpt[OperationRequest]
 ) extends ReactFnProps(ObsHeader.component)
@@ -25,7 +28,13 @@ object ObsHeader:
     ScalaFnComponent[Props]: props =>
       <.div(ObserveStyles.ObsSummary)(
         <.div(ObserveStyles.ObsSummaryTitle)(
-          SeqControlButtons(props.observation.obsId, props.isRunning, props.pauseRequested),
+          SeqControlButtons(
+            props.observation.obsId,
+            props.loadedObsId,
+            props.loadObs,
+            props.isRunning,
+            props.pauseRequested
+          ),
           s"${props.observation.title} [${props.observation.obsId}]"
         ),
         <.div(ObserveStyles.ObsSummaryDetails)(

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
@@ -43,11 +43,9 @@ object SeqControlButtons:
         InputGroup(
           Button(
             clazz = ObserveStyles.PlayButton |+| ObserveStyles.ObsSummaryButton,
-            icon =
-              if (props.isRunning)
-                Icons.CircleNotch.withFixedWidth().withSize(IconSize.LG).withSpin()
-              else
-                Icons.Play.withFixedWidth().withSize(IconSize.LG),
+            loading = props.isRunning,
+            icon = Icons.Play.withFixedWidth().withSize(IconSize.LG),
+            loadingIcon = Icons.CircleNotch.withFixedWidth().withSize(IconSize.LG).withSpin(),
             tooltip = "Start/Resume sequence",
             tooltipOptions = tooltipOptions,
             onClick = sequenceApi.start(props.obsId, RunOverride.Override).runAsync,
@@ -67,5 +65,19 @@ object SeqControlButtons:
               .set(OperationRequest.InFlight) >> sequenceApi.pause(props.obsId).runAsync,
             disabled = props.pauseRequested.get.contains_(OperationRequest.InFlight)
           ).when(props.isRunning)
+          // Button(
+          //   clazz = ObserveStyles.AbortButton |+| ObserveStyles.ObsSummaryButton,
+          //   icon =
+          //     // TODO Overlay this if abort pending
+          //     // if (props.isRunning)
+          //     //   Icons.CircleNotch.withFixedWidth().withSize(IconSize.LG).withSpin()
+          //     // else
+          //     Icons.Pause.withFixedWidth().withSize(IconSize.LG),
+          //   tooltip = "Abort sequence",
+          //   tooltipOptions = tooltipOptions,
+          //   onClick = // props.pauseRequested.set(OperationRequest.InFlight) >>
+          //     sequenceApi.abort(props.obsId).runAsync,
+          //   // disabled = props.pauseRequested.get.contains_(OperationRequest.InFlight)
+          // ).when(props.isRunning)
         )
     // TODO Cancel pause

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
@@ -65,19 +65,5 @@ object SeqControlButtons:
               .set(OperationRequest.InFlight) >> sequenceApi.pause(props.obsId).runAsync,
             disabled = props.pauseRequested.get.contains_(OperationRequest.InFlight)
           ).when(props.isRunning)
-          // Button(
-          //   clazz = ObserveStyles.AbortButton |+| ObserveStyles.ObsSummaryButton,
-          //   icon =
-          //     // TODO Overlay this if abort pending
-          //     // if (props.isRunning)
-          //     //   Icons.CircleNotch.withFixedWidth().withSize(IconSize.LG).withSpin()
-          //     // else
-          //     Icons.Pause.withFixedWidth().withSize(IconSize.LG),
-          //   tooltip = "Abort sequence",
-          //   tooltipOptions = tooltipOptions,
-          //   onClick = // props.pauseRequested.set(OperationRequest.InFlight) >>
-          //     sequenceApi.abort(props.obsId).runAsync,
-          //   // disabled = props.pauseRequested.get.contains_(OperationRequest.InFlight)
-          // ).when(props.isRunning)
         )
     // TODO Cancel pause

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTables.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTables.scala
@@ -216,7 +216,7 @@ private sealed trait SequenceTablesBuilder[S: Eq, D: Eq]:
           clientMode,
           instrument,
           obsId,
-          tabOperations,
+          seqOperations,
           executionState,
           progress,
           isPreview,
@@ -283,7 +283,7 @@ private sealed trait SequenceTablesBuilder[S: Eq, D: Eq]:
                         isFinished = step.isFinished,
                         stepIndex = cell.row.index.toInt,
                         obsId = obsId,
-                        seqOperations = tabOperations,
+                        seqOperations = seqOperations,
                         runningStepId = executionState.runningStepId,
                         sequenceState = executionState.sequenceState,
                         configStatus = executionState.stepResources

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
@@ -3,6 +3,7 @@
 
 package observe.ui.components.sequence.steps
 
+import crystal.react.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.Instrument
@@ -19,6 +20,8 @@ import observe.ui.Icons
 import observe.ui.ObserveStyles
 import observe.ui.components.DefaultTooltipOptions
 import observe.ui.model.SequenceOperations
+import observe.ui.services.SequenceApi
+import observe.ui.model.AppContext
 
 /**
  * Contains a set of control buttons like stop/abort
@@ -29,6 +32,7 @@ case class StepControlButtons(
   sequenceState:   SequenceState,
   stepId:          Step.Id,
   isObservePaused: Boolean,
+  isReadingOut:    Boolean,
   isMultiLevel:    Boolean,
   seqOperations:   SequenceOperations
 ) extends ReactFnProps(StepControlButtons.component):
@@ -37,121 +41,125 @@ case class StepControlButtons(
 
   val requestInFlight: Boolean = seqOperations.stepRequestInFlight
 
-  // TODO Substitute for a stream hook - Progress should be a Topic somewhere
-  // protected[steps] val connect: ReactConnectProxy[Option[Progress]] =
-  //   ObserveCircuit.connect(ObserveCircuit.obsProgressReader[Progress](obsId, stepId))
-
 object StepControlButtons:
   private type Props = StepControlButtons
 
-  private val component = ScalaFnComponent[Props] { props =>
-    // def requestedIcon(icon: FontAwesomeIcon): VdomNode =
-    //   icon
-    // IconGroup(
-    //   icon(^.key                                                   := "main"),
-    //   IconCircleNotched.copy(loading = true, color = Yellow)(^.key := "requested")
-    // )
+  private val component = ScalaFnComponent
+    .withHooks[Props]
+    .useContext(AppContext.ctx)
+    .useContext(SequenceApi.ctx)
+    .render: (props, ctx, sequenceApi) =>
+      import ctx.given
 
-    // val pauseGracefullyIcon: VdomNode =
-    //   props.nsPendingObserveCmd match
-    //     case Some(NodAndShuffleStep.PendingObserveCmd.PauseGracefully) => requestedIcon(Icons.Pause)
-    //     case _                                                         => Icons.Pause
+      // def requestedIcon(icon: FontAwesomeIcon): VdomNode =
+      //   icon
+      // IconGroup(
+      //   icon(^.key                                                   := "main"),
+      //   IconCircleNotched.copy(loading = true, color = Yellow)(^.key := "requested")
+      // )
 
-    // val stopGracefullyIcon: VdomNode =
-    //   props.nsPendingObserveCmd match
-    //     case Some(NodAndShuffleStep.PendingObserveCmd.StopGracefully) => requestedIcon(Icons.Stop)
-    //     case _                                                        => Icons.Stop
+      // val pauseGracefullyIcon: VdomNode =
+      //   props.nsPendingObserveCmd match
+      //     case Some(NodAndShuffleStep.PendingObserveCmd.PauseGracefully) => requestedIcon(Icons.Pause)
+      //     case _                                                         => Icons.Pause
 
-    // p.connect { proxy =>
-    // val isReadingOut = false // proxy().exists(_.stage === ObserveStage.ReadingOut)
+      // val stopGracefullyIcon: VdomNode =
+      //   props.nsPendingObserveCmd match
+      //     case Some(NodAndShuffleStep.PendingObserveCmd.StopGracefully) => requestedIcon(Icons.Stop)
+      //     case _                                                        => Icons.Stop
 
-    InputGroup(ObserveStyles.ControlButtonStrip)(
-      // ObserveStyles.notInMobile,
-      props.operations
-        .map[VdomNode]:
-          case PauseObservation =>
-            Button(
-              clazz = ObserveStyles.PauseButton,
-              icon = Icons.Pause.withFixedWidth(), // .withSize(IconSize.LG),
-              tooltip = "Pause the current exposure",
-              tooltipOptions = DefaultTooltipOptions,
-              disabled = true,                     // props.requestInFlight || props.isObservePaused || isReadingOut
-              onClickE = _.stopPropagationCB       // >> requestObsPause(p.obsId, p.stepId)
-            )
-          case StopObservation  =>
-            Button(
-              clazz = ObserveStyles.StopButton,
-              icon = Icons.Stop.withFixedWidth().withSize(IconSize.LG),
-              tooltip = "Stop the current exposure early",
-              tooltipOptions = DefaultTooltipOptions,
-              disabled = true,               // props.requestInFlight || isReadingOut
-              onClickE = _.stopPropagationCB // >> requestStop(p.obsId, p.stepId)
-            )
-          case AbortObservation =>
-            Button(
-              clazz = ObserveStyles.AbortButton,
-              icon = Icons.XMark.withFixedWidth().withSize(IconSize.LG),
-              tooltip = "Abort the current exposure",
-              tooltipOptions = DefaultTooltipOptions,
-              disabled = true,               // props.requestInFlight || isReadingOut
-              onClickE = _.stopPropagationCB // >> requestAbort(p.obsId, p.stepId),
-            )
-          // case ResumeObservation           =>
-          //   Popup(
-          //     position = PopupPosition.TopRight,
-          //     trigger = Button(
-          //       icon = true,
-          //       color = Blue,
-          //       onClick = requestObsResume(p.obsId, p.stepId),
-          //       disabled = p.requestInFlight || !p.isObservePaused || isReadingOut
-          //     )(IconPlay)
-          //   )("Resume the current exposure")
-          // // N&S operations
-          // case PauseImmediatelyObservation =>
-          //   Popup(
-          //     position = PopupPosition.TopRight,
-          //     trigger = Button(
-          //       icon = true,
-          //       color = Teal,
-          //       basic = true,
-          //       onClick = requestObsPause(p.obsId, p.stepId),
-          //       disabled = p.requestInFlight || p.isObservePaused || isReadingOut
-          //     )(IconPause)
-          //   )("Pause the current exposure immediately")
-          // case PauseGracefullyObservation  =>
-          //   Popup(
-          //     position = PopupPosition.TopRight,
-          //     trigger = Button(
-          //       icon = true,
-          //       color = Teal,
-          //       onClick = requestGracefulObsPause(p.obsId, p.stepId),
-          //       disabled =
-          //         p.requestInFlight || p.isObservePaused || p.nsPendingObserveCmd.isDefined || isReadingOut
-          //     )(pauseGracefullyIcon)
-          //   )("Pause the current exposure at the end of the cycle")
-          // case StopImmediatelyObservation  =>
-          //   Popup(
-          //     position = PopupPosition.TopRight,
-          //     trigger = Button(
-          //       icon = true,
-          //       color = Orange,
-          //       basic = true,
-          //       onClick = requestStop(p.obsId, p.stepId),
-          //       disabled = p.requestInFlight || isReadingOut
-          //     )(IconStop)
-          //   )("Stop the current exposure immediately")
-          // case StopGracefullyObservation   =>
-          //   Popup(
-          //     position = PopupPosition.TopRight,
-          //     trigger = Button(
-          //       icon = true,
-          //       color = Orange,
-          //       onClick = requestGracefulStop(p.obsId, p.stepId),
-          //       disabled =
-          //         p.requestInFlight || p.isObservePaused || p.nsPendingObserveCmd.isDefined || isReadingOut
-          //     )(stopGracefullyIcon)
-          //   )("Stop the current exposure at the end of the cycle")
-          case _                => EmptyVdom
-        .toTagMod
-    )
-  }
+      // p.connect { proxy =>
+      // val isReadingOut = false // proxy().exists(_.stage === ObserveStage.ReadingOut)
+
+      println(s"reading out: ${props.isReadingOut}")
+
+      InputGroup(ObserveStyles.ControlButtonStrip)(
+        // ObserveStyles.notInMobile,
+        props.operations
+          .map[VdomNode]:
+            case PauseObservation =>
+              Button(
+                clazz = ObserveStyles.PauseButton,
+                icon = Icons.Pause.withFixedWidth(),
+                tooltip = "Pause the current exposure",
+                tooltipOptions = DefaultTooltipOptions,
+                disabled =
+                  props.isReadingOut, // props.requestInFlight || props.isObservePaused || isReadingOut
+                onClickE = _.stopPropagationCB >> sequenceApi.pauseObs(props.obsId).runAsync
+              )
+            case StopObservation  =>
+              Button(
+                clazz = ObserveStyles.StopButton,
+                icon = Icons.Stop.withFixedWidth().withSize(IconSize.LG),
+                tooltip = "Stop the current exposure early",
+                tooltipOptions = DefaultTooltipOptions,
+                disabled = props.isReadingOut, // props.requestInFlight || isReadingOut
+                onClickE = _.stopPropagationCB >> sequenceApi.stop(props.obsId).runAsync
+              )
+            case AbortObservation =>
+              Button(
+                clazz = ObserveStyles.AbortButton,
+                icon = Icons.XMark.withFixedWidth().withSize(IconSize.LG),
+                tooltip = "Abort the current exposure",
+                tooltipOptions = DefaultTooltipOptions,
+                disabled = props.isReadingOut, // props.requestInFlight || isReadingOut
+                onClickE = _.stopPropagationCB >> sequenceApi.abort(props.obsId).runAsync
+              )
+            // case ResumeObservation           =>
+            //   Popup(
+            //     position = PopupPosition.TopRight,
+            //     trigger = Button(
+            //       icon = true,
+            //       color = Blue,
+            //       onClick = requestObsResume(p.obsId, p.stepId),
+            //       disabled = p.requestInFlight || !p.isObservePaused || isReadingOut
+            //     )(IconPlay)
+            //   )("Resume the current exposure")
+            // // N&S operations
+            // case PauseImmediatelyObservation =>
+            //   Popup(
+            //     position = PopupPosition.TopRight,
+            //     trigger = Button(
+            //       icon = true,
+            //       color = Teal,
+            //       basic = true,
+            //       onClick = requestObsPause(p.obsId, p.stepId),
+            //       disabled = p.requestInFlight || p.isObservePaused || isReadingOut
+            //     )(IconPause)
+            //   )("Pause the current exposure immediately")
+            // case PauseGracefullyObservation  =>
+            //   Popup(
+            //     position = PopupPosition.TopRight,
+            //     trigger = Button(
+            //       icon = true,
+            //       color = Teal,
+            //       onClick = requestGracefulObsPause(p.obsId, p.stepId),
+            //       disabled =
+            //         p.requestInFlight || p.isObservePaused || p.nsPendingObserveCmd.isDefined || isReadingOut
+            //     )(pauseGracefullyIcon)
+            //   )("Pause the current exposure at the end of the cycle")
+            // case StopImmediatelyObservation  =>
+            //   Popup(
+            //     position = PopupPosition.TopRight,
+            //     trigger = Button(
+            //       icon = true,
+            //       color = Orange,
+            //       basic = true,
+            //       onClick = requestStop(p.obsId, p.stepId),
+            //       disabled = p.requestInFlight || isReadingOut
+            //     )(IconStop)
+            //   )("Stop the current exposure immediately")
+            // case StopGracefullyObservation   =>
+            //   Popup(
+            //     position = PopupPosition.TopRight,
+            //     trigger = Button(
+            //       icon = true,
+            //       color = Orange,
+            //       onClick = requestGracefulStop(p.obsId, p.stepId),
+            //       disabled =
+            //         p.requestInFlight || p.isObservePaused || p.nsPendingObserveCmd.isDefined || isReadingOut
+            //     )(stopGracefullyIcon)
+            //   )("Stop the current exposure at the end of the cycle")
+            case _                => EmptyVdom
+          .toTagMod
+      )

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
@@ -71,8 +71,6 @@ object StepControlButtons:
       // p.connect { proxy =>
       // val isReadingOut = false // proxy().exists(_.stage === ObserveStage.ReadingOut)
 
-      println(s"reading out: ${props.isReadingOut}")
-
       InputGroup(ObserveStyles.ControlButtonStrip)(
         // ObserveStyles.notInMobile,
         props.operations

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
@@ -19,9 +19,9 @@ import observe.model.operations.*
 import observe.ui.Icons
 import observe.ui.ObserveStyles
 import observe.ui.components.DefaultTooltipOptions
+import observe.ui.model.AppContext
 import observe.ui.model.SequenceOperations
 import observe.ui.services.SequenceApi
-import observe.ui.model.AppContext
 
 /**
  * Contains a set of control buttons like stop/abort

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepProgressCell.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepProgressCell.scala
@@ -11,6 +11,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Step
 import lucuma.react.common.*
 import lucuma.ui.sequence.StepTypeDisplay
+import observe.model.ObserveStage
 import observe.model.SequenceState
 import observe.model.StepProgress
 import observe.model.dhs.ImageFileId
@@ -20,7 +21,6 @@ import observe.ui.ObserveStyles
 import observe.ui.model.SequenceOperations
 import observe.ui.model.StopOperation
 import observe.ui.model.enums.ClientMode
-import observe.model.ObserveStage
 
 case class StepProgressCell(
   clientMode:    ClientMode,

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepProgressCell.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepProgressCell.scala
@@ -20,6 +20,7 @@ import observe.ui.ObserveStyles
 import observe.ui.model.SequenceOperations
 import observe.ui.model.StopOperation
 import observe.ui.model.enums.ClientMode
+import observe.model.ObserveStage
 
 case class StepProgressCell(
   clientMode:    ClientMode,
@@ -77,8 +78,8 @@ object StepProgressCell:
       props.sequenceState,
       props.stepId,
       false, // props.step.get.isObservePaused,
+      props.progress.exists(_.stage === ObserveStage.ReadingOut),
       false, // props.isNs,
-      // props.step.get.isMultiLevel,
       props.seqOperations
     )        // .when(props.controlButtonsActive)
 

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
@@ -34,40 +34,24 @@ object ObservationSyncer:
           _.map: obsId =>
             import ctx.given
 
-            // val fetchSummary =
-            //   ObsQueriesGQL
-            //     .ObservationSummary[IO]
-            //     .query(obsId)
-            //     .map(_.observation)
-            //     .attempt
-            //     .map:
-            //       _.flatMap:
-            //         _.toRight:
-            //           Exception(s"Observation [$obsId] not found")
-            //     .flatTap: obs =>
-            //       props.nighttimeObservation.async.mod(_.map(_.withSummary(obs)))
-
             // TODO We will have to requery under certain conditions:
             // - After step is executed/paused/aborted.
             // - If sequence changes... How do we know this??? Update: Shane will add a hash to the API
-            val fetchSequence =
-              SequenceSQL
-                .SequenceQuery[IO]
-                .query(obsId)
-                .adaptError:
-                  case ResponseException(errors, _) =>
-                    Exception(errors.map(_.message).toList.mkString("\n"))
-                .map(_.observation.map(_.execution.config))
-                .attempt
-                .map:
-                  _.flatMap:
-                    _.toRight:
-                      Exception(s"Execution Configuration not defined for observation [$obsId]")
-                .flatTap: config =>
-                  props.nighttimeObservation.async.mod(_.map(_.withConfig(config)))
+            SequenceSQL
+              .SequenceQuery[IO]
+              .query(obsId)
+              .adaptError:
+                case ResponseException(errors, _) =>
+                  Exception(errors.map(_.message).toList.mkString("\n"))
+              .map(_.observation.map(_.execution.config))
+              .attempt
+              .map:
+                _.flatMap:
+                  _.toRight:
+                    Exception(s"Execution Configuration not defined for observation [$obsId]")
+              .flatMap: config =>
+                props.nighttimeObservation.async.mod(_.map(_.withConfig(config)))
 
-            fetchSequence.void
-            // (fetchSummary, fetchSequence).parTupled.void
             // TODO Breakpoint initialization should happen in the server, not here.
             // Leaving the code commented here until we move it to the server.
             // >>= ((_, configEither) =>

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
@@ -12,7 +12,6 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.ReactFnProps
 import lucuma.schemas.odb.SequenceSQL
 import lucuma.ui.reusability.given
-import observe.queries.ObsQueriesGQL
 import observe.ui.DefaultErrorPolicy
 import observe.ui.model.AppContext
 import observe.ui.model.LoadedObservation
@@ -35,18 +34,18 @@ object ObservationSyncer:
           _.map: obsId =>
             import ctx.given
 
-            val fetchSummary =
-              ObsQueriesGQL
-                .ObservationSummary[IO]
-                .query(obsId)
-                .map(_.observation)
-                .attempt
-                .map:
-                  _.flatMap:
-                    _.toRight:
-                      Exception(s"Observation [$obsId] not found")
-                .flatTap: obs =>
-                  props.nighttimeObservation.async.mod(_.map(_.withSummary(obs)))
+            // val fetchSummary =
+            //   ObsQueriesGQL
+            //     .ObservationSummary[IO]
+            //     .query(obsId)
+            //     .map(_.observation)
+            //     .attempt
+            //     .map:
+            //       _.flatMap:
+            //         _.toRight:
+            //           Exception(s"Observation [$obsId] not found")
+            //     .flatTap: obs =>
+            //       props.nighttimeObservation.async.mod(_.map(_.withSummary(obs)))
 
             // TODO We will have to requery under certain conditions:
             // - After step is executed/paused/aborted.
@@ -67,7 +66,8 @@ object ObservationSyncer:
                 .flatTap: config =>
                   props.nighttimeObservation.async.mod(_.map(_.withConfig(config)))
 
-            (fetchSummary, fetchSequence).parTupled.void
+            fetchSequence.void
+            // (fetchSummary, fetchSequence).parTupled.void
             // TODO Breakpoint initialization should happen in the server, not here.
             // Leaving the code commented here until we move it to the server.
             // >>= ((_, configEither) =>

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
@@ -69,7 +69,8 @@ trait ServerEventHandler:
             .mod(obs => // Only set if loaded obsId changed, otherwise config and summary are lost.
               if (obs.map(_.obsId) =!= nighttimeLoadedObsId)
                 nighttimeLoadedObsId.map(LoadedObservation(_))
-              else obs
+              else
+                obs
             ) >>
           syncStatus.async.set(SyncStatus.Synced.some) >>
           configApiStatus.async.set(ApiStatus.Idle)

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
@@ -74,8 +74,7 @@ trait ServerEventHandler:
           syncStatus.async.set(SyncStatus.Synced.some) >>
           configApiStatus.async.set(ApiStatus.Idle)
       case ClientEvent.ProgressEvent(ObservationProgress(obsId, stepProgress))   =>
-        IO.println(s"PROGRESS! $stepProgress") >>
-          asyncRootModel.zoom(RootModelData.obsProgress.at(obsId)).set(stepProgress.some)
+        asyncRootModel.zoom(RootModelData.obsProgress.at(obsId)).set(stepProgress.some)
 
   protected def processStreamError(
     rootModelData: View[RootModelData]

--- a/modules/web/client/src/main/scala/observe/ui/model/SessionQueueRow.scala
+++ b/modules/web/client/src/main/scala/observe/ui/model/SessionQueueRow.scala
@@ -9,7 +9,6 @@ import eu.timepit.refined.cats.given
 import japgolly.scalajs.react.ReactCats.*
 import japgolly.scalajs.react.Reusability
 import lucuma.core.enums.Instrument
-import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Step
 import observe.model.Observer
 import observe.model.RunningStep
@@ -17,19 +16,16 @@ import observe.model.SequenceState
 import observe.ui.model.enums.ObsClass
 
 case class SessionQueueRow(
-  obsId:         Observation.Id,
+  obsSummary:    ObsSummary,
   status:        SequenceState,
-  instrument:    Instrument,
-  targetName:    Option[String],
   observer:      Option[Observer],
-  name:          String,
   obsClass:      ObsClass,
-  // active:        Boolean,
   loaded:        Boolean,
   nextStepToRun: Option[Step.Id],
   runningStep:   Option[RunningStep],
   inDayCalQueue: Boolean
-) derives Eq
+) derives Eq:
+  export obsSummary.*
 
 object SessionQueueRow:
   given Reusability[SessionQueueRow] = Reusability.byEq

--- a/modules/web/client/src/main/scala/observe/ui/services/SequenceApi.scala
+++ b/modules/web/client/src/main/scala/observe/ui/services/SequenceApi.scala
@@ -36,17 +36,17 @@ trait SequenceApi[F[_]: MonadThrow]:
 
   def cancelPause(obsId: Observation.Id): F[Unit] = NotAuthorized
 
-  def stop(obsId: Observation.Id, stepId: Step.Id): F[Unit] = NotAuthorized
+  def stop(obsId: Observation.Id): F[Unit] = NotAuthorized
 
-  def stopGracefully(obsId: Observation.Id, stepId: Step.Id): F[Unit] = NotAuthorized
+  def stopGracefully(obsId: Observation.Id): F[Unit] = NotAuthorized
 
-  def abort(obsId: Observation.Id, stepId: Step.Id): F[Unit] = NotAuthorized
+  def abort(obsId: Observation.Id): F[Unit] = NotAuthorized
 
-  def pauseObs(obsId: Observation.Id, stepId: Step.Id): F[Unit] = NotAuthorized
+  def pauseObs(obsId: Observation.Id): F[Unit] = NotAuthorized
 
-  def pauseObsGracefully(obsId: Observation.Id, stepId: Step.Id): F[Unit] = NotAuthorized
+  def pauseObsGracefully(obsId: Observation.Id): F[Unit] = NotAuthorized
 
-  def resumeObs(obsId: Observation.Id, stepId: Step.Id): F[Unit] = NotAuthorized
+  def resumeObs(obsId: Observation.Id): F[Unit] = NotAuthorized
 
   def execute(obsId: Observation.Id, stepId: Step.Id, subsystem: Resource | Instrument): F[Unit] =
     NotAuthorized

--- a/modules/web/client/src/main/scala/observe/ui/services/SequenceApiImpl.scala
+++ b/modules/web/client/src/main/scala/observe/ui/services/SequenceApiImpl.scala
@@ -77,34 +77,34 @@ case class SequenceApiImpl(
       Uri.Path.empty / obsId.toString / client.clientId.value / "cancelPause" / observer.toString
     )
 
-  override def stop(obsId: Observation.Id, stepId: Step.Id): IO[Unit] =
+  override def stop(obsId: Observation.Id): IO[Unit] =
     client.postNoData(
-      Uri.Path.empty / obsId.toString / stepId.toString / client.clientId.value / "stop" / observer.toString
+      Uri.Path.empty / obsId.toString / client.clientId.value / "stop" / observer.toString
     )
 
-  override def stopGracefully(obsId: Observation.Id, stepId: Step.Id): IO[Unit] =
+  override def stopGracefully(obsId: Observation.Id): IO[Unit] =
     client.postNoData(
-      Uri.Path.empty / obsId.toString / stepId.toString / client.clientId.value / "stopGracefully" / observer.toString
+      Uri.Path.empty / obsId.toString / client.clientId.value / "stopGracefully" / observer.toString
     )
 
-  override def abort(obsId: Observation.Id, stepId: Step.Id): IO[Unit] =
+  override def abort(obsId: Observation.Id): IO[Unit] =
     client.postNoData(
-      Uri.Path.empty / obsId.toString / stepId.toString / client.clientId.value / "abort" / observer.toString
+      Uri.Path.empty / obsId.toString / client.clientId.value / "abort" / observer.toString
     )
 
-  override def pauseObs(obsId: Observation.Id, stepId: Step.Id): IO[Unit] =
+  override def pauseObs(obsId: Observation.Id): IO[Unit] =
     client.postNoData(
-      Uri.Path.empty / obsId.toString / stepId.toString / client.clientId.value / "pauseObs" / observer.toString
+      Uri.Path.empty / obsId.toString / client.clientId.value / "pauseObs" / observer.toString
     )
 
-  override def pauseObsGracefully(obsId: Observation.Id, stepId: Step.Id): IO[Unit] =
+  override def pauseObsGracefully(obsId: Observation.Id): IO[Unit] =
     client.postNoData(
-      Uri.Path.empty / obsId.toString / stepId.toString / client.clientId.value / "pauseObsGracefully" / observer.toString
+      Uri.Path.empty / obsId.toString / client.clientId.value / "pauseObsGracefully" / observer.toString
     )
 
-  override def resumeObs(obsId: Observation.Id, stepId: Step.Id): IO[Unit] =
+  override def resumeObs(obsId: Observation.Id): IO[Unit] =
     client.postNoData(
-      Uri.Path.empty / obsId.toString / stepId.toString / client.clientId.value / "resumeObs" / observer.toString
+      Uri.Path.empty / obsId.toString / client.clientId.value / "resumeObs" / observer.toString
     )
 
   override def execute(

--- a/modules/web/server/src/main/resources/app.conf
+++ b/modules/web/server/src/main/resources/app.conf
@@ -17,7 +17,7 @@ smart-gcal {
 lucuma-sso {
   service-token = "DummyToken"
   service-token = ${?ODB_SERVICE_JWT}
-  sso-url = "https://lucuma-sso-dev.lucuma.xyz"
+  sso-url = "https://sso-dev.gpp.lucuma.xyz"
   public-key = "DummyKey"
   public-key = ${?ODB_SSO_PUBLIC_KEY}
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,7 +10,7 @@ object Settings {
   /** Library versions */
   object LibraryVersions {
     // ScalaJS libraries
-    val crystal      = "0.37.0-14-e0907bf-SNAPSHOT"
+    val crystal      = "0.37.1"
     val javaTimeJS   = "2.5.0"
     val lucumaReact  = "0.47.1"
     val scalaDom     = "2.3.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,7 +10,7 @@ object Settings {
   /** Library versions */
   object LibraryVersions {
     // ScalaJS libraries
-    val crystal      = "0.37.0"
+    val crystal      = "0.37.0-14-e0907bf-SNAPSHOT"
     val javaTimeJS   = "2.5.0"
     val lucumaReact  = "0.47.1"
     val scalaDom     = "2.3.0"


### PR DESCRIPTION
- Enable stop and abort buttons at the step level. Sometimes these buttons are enabled when they shouldn't. This will be addressed in future PR, I'm still working on migrating the logic from seqexec.
- Preload observation summaries into state. The idea here is to show the observation information when an observation is selected in the table, without the need of loading it into observe. ~That part of the UI is still pending for the next PR.~ Information is shown now, and the sequence can be loaded from the header too.

An issue we have here is that, after a sequence is loaded, preview functionality is lost since now the observation header is locked into the loaded sequence. We probably want to display observation details from the list somewhere else. A tooltip? A side panel? I'm open to suggestions.

This probably should have been 2 separate PRs, sorry for that.