### PR TITLE
ODB Proxy: Track dataset ids, rework id tracking

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/ObserveActions.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveActions.scala
@@ -9,7 +9,6 @@ import cats.effect.Temporal
 import cats.syntax.all.*
 import fs2.Stream
 import lucuma.core.util.TimeSpan
-import lucuma.schemas.ObservationDB.Scalars.DatasetId
 import observe.engine.*
 import observe.model.Observation
 import observe.model.dhs.*
@@ -64,13 +63,11 @@ trait ObserveActions {
    * Send the datasetEnd command to the odb
    */
   private def sendDataEnd[F[_]: MonadThrow](
-    odb:       OdbProxy[F],
-    datasetId: DatasetId,
-    obsId:     Observation.Id,
-    fileId:    ImageFileId
+    odb:   OdbProxy[F],
+    obsId: Observation.Id
   ): F[Unit] =
     odb
-      .datasetComplete(datasetId, obsId, fileId)
+      .datasetComplete(obsId)
       .ensure(
         ObserveFailure.Unexpected("Unable to send DataEnd message to ODB.")
       )(identity)
@@ -143,7 +140,7 @@ trait ObserveActions {
       _ <- notifyObserveEnd(env)
       _ <- env.headers(env.ctx).reverseIterator.toList.traverse(_.sendAfter(fileId))
       _ <- closeImage(fileId, env)
-      _ <- sendDataEnd(env.odb, null, env.obsId, fileId)
+      _ <- sendDataEnd(env.odb, env.obsId)
     } yield
       if (stopped) Result.OKStopped(Response.Observed(fileId))
       else Result.OK(Response.Observed(fileId))

--- a/modules/server_new/src/main/scala/observe/server/ObserveActions.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveActions.scala
@@ -63,11 +63,12 @@ trait ObserveActions {
    * Send the datasetEnd command to the odb
    */
   private def sendDataEnd[F[_]: MonadThrow](
-    odb:   OdbProxy[F],
-    obsId: Observation.Id
+    odb:    OdbProxy[F],
+    obsId:  Observation.Id,
+    fileId: ImageFileId
   ): F[Unit] =
     odb
-      .datasetComplete(obsId)
+      .datasetComplete(obsId, fileId)
       .ensure(
         ObserveFailure.Unexpected("Unable to send DataEnd message to ODB.")
       )(identity)
@@ -140,7 +141,7 @@ trait ObserveActions {
       _ <- notifyObserveEnd(env)
       _ <- env.headers(env.ctx).reverseIterator.toList.traverse(_.sendAfter(fileId))
       _ <- closeImage(fileId, env)
-      _ <- sendDataEnd(env.odb, env.obsId)
+      _ <- sendDataEnd(env.odb, env.obsId, fileId)
     } yield
       if (stopped) Result.OKStopped(Response.Observed(fileId))
       else Result.OK(Response.Observed(fileId))

--- a/modules/server_new/src/main/scala/observe/server/Systems.scala
+++ b/modules/server_new/src/main/scala/observe/server/Systems.scala
@@ -26,6 +26,7 @@ import observe.server.gems.*
 import observe.server.gmos.*
 import observe.server.gsaoi.*
 import observe.server.keywords.*
+import observe.server.odb.ObsRecordedIds
 import observe.server.odb.OdbProxy
 import observe.server.odb.OdbProxy.TestOdbProxy
 import observe.server.tcs.*
@@ -93,7 +94,7 @@ object Systems {
       odbCommands                        <-
         if (settings.odbNotifications)
           Ref
-            .of[F, OdbProxy.ObsRecordedIds](OdbProxy.ObsRecordedIds.Empty)
+            .of[F, ObsRecordedIds](ObsRecordedIds.Empty)
             .map(OdbProxy.OdbCommandsImpl[F](sk, _))
         else new OdbProxy.DummyOdbCommands[F].pure[F]
     } yield OdbProxy[F](odbCommands)

--- a/modules/server_new/src/main/scala/observe/server/odb/IdTrackerOps.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/IdTrackerOps.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.server.odb
+
+import cats.MonadThrow
+import cats.effect.Ref
+import cats.syntax.all.*
+import lucuma.core.model.Observation
+import lucuma.core.model.Visit
+import lucuma.core.model.sequence.Dataset
+import observe.server.ObserveFailure
+
+trait IdTrackerOps[F[_]: MonadThrow](idTracker: Ref[F, ObsRecordedIds]):
+  protected def getCurrentVisitId(obsId: Observation.Id): F[Visit.Id] =
+    idTracker.get
+      .map:
+        ObsRecordedIds
+          .at(obsId)
+          .get(_)
+          .map(RecordedVisit.visitId.get)
+          .toRight(ObserveFailure.Unexpected(s"No current recorded visit for obsId [$obsId]"))
+      .rethrow
+
+  protected def setCurrentVisitId(obsId: Observation.Id, visitId: Option[Visit.Id]): F[Unit] =
+    idTracker.update:
+      ObsRecordedIds.at(obsId).replace(visitId.map(RecordedVisit(_)))
+
+  protected def getCurrentAtomId(obsId: Observation.Id): F[RecordedAtomId] =
+    idTracker.get
+      .map:
+        ObsRecordedIds
+          .at(obsId)
+          .get(_)
+          .flatMap(RecordedVisit.atomId.getOption)
+          .toRight(ObserveFailure.Unexpected(s"No current recorded atom for obsId [$obsId]"))
+      .rethrow
+
+  protected def setCurrentAtomId(obsId: Observation.Id, atomId: RecordedAtomId): F[Unit] =
+    idTracker.update:
+      ObsRecordedIds.at(obsId).some.andThen(RecordedVisit.atom).replace(RecordedAtom(atomId).some)
+
+  protected def getCurrentStepId(obsId: Observation.Id): F[RecordedStepId] =
+    idTracker.get
+      .map:
+        ObsRecordedIds
+          .at(obsId)
+          .get(_)
+          .flatMap(RecordedVisit.stepId.getOption)
+          .toRight(ObserveFailure.Unexpected(s"No current recorded step for obsId [$obsId]"))
+      .rethrow
+
+  protected def setCurrentStepId(obsId: Observation.Id, stepId: Option[RecordedStepId]): F[Unit] =
+    idTracker.update:
+      ObsRecordedIds.at(obsId).some.andThen(RecordedVisit.step).replace(stepId.map(RecordedStep(_)))
+
+  protected def getCurrentDatasetId(obsId: Observation.Id): F[Dataset.Id] =
+    idTracker.get
+      .map:
+        ObsRecordedIds
+          .at(obsId)
+          .get(_)
+          .flatMap(RecordedVisit.datasetId.getOption)
+          .flatten
+          .toRight(ObserveFailure.Unexpected(s"No current recorded dataset for obsId [$obsId]"))
+      .rethrow
+
+  protected def setCurrentDatasetId(obsId: Observation.Id, datasetId: Option[Dataset.Id]): F[Unit] =
+    idTracker.update:
+      ObsRecordedIds.at(obsId).some.andThen(RecordedVisit.datasetId).replace(datasetId)

--- a/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
@@ -30,8 +30,6 @@ import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Scalars.DatasetId
 import lucuma.schemas.ObservationDB.Scalars.VisitId
 import lucuma.schemas.odb.input.*
-import monocle.Iso
-import monocle.Lens
 import observe.common.ObsQueriesGQL.*
 import observe.model.dhs.*
 import observe.server.ObserveFailure
@@ -41,14 +39,6 @@ import org.typelevel.log4cats.Logger
 import scala.annotation.unused
 
 sealed trait OdbEventCommands[F[_]] {
-  def datasetStart(obsId:       Observation.Id, fileId: ImageFileId): F[Boolean]
-  def datasetComplete(
-    datasetId: DatasetId,
-    obsId:     Observation.Id,
-    fileId:    ImageFileId
-  ): F[Boolean]
-  def obsAbort(obsId:           Observation.Id, reason: String): F[Boolean]
-  def sequenceEnd(obsId:        Observation.Id): F[Boolean]
   def sequenceStart(
     obsId:        Observation.Id,
     instrument:   Instrument,
@@ -56,9 +46,6 @@ sealed trait OdbEventCommands[F[_]] {
     stepCount:    NonNegShort,
     staticCfg:    StaticConfig
   ): F[Unit]
-  def obsContinue(obsId:        Observation.Id): F[Boolean]
-  def obsPause(obsId:           Observation.Id, reason: String): F[Boolean]
-  def obsStop(obsId:            Observation.Id, reason: String): F[Boolean]
   def stepStartStep(
     obsId:         Observation.Id,
     dynamicConfig: DynamicConfig,
@@ -68,8 +55,16 @@ sealed trait OdbEventCommands[F[_]] {
   def stepStartConfigure(obsId: Observation.Id): F[Unit]
   def stepEndConfigure(obsId:   Observation.Id): F[Boolean]
   def stepStartObserve(obsId:   Observation.Id): F[Boolean]
+  def datasetStart(obsId:       Observation.Id, fileId: ImageFileId): F[Boolean]
+  def datasetComplete(obsId:    Observation.Id): F[Boolean]
   def stepEndObserve(obsId:     Observation.Id): F[Boolean]
   def stepEndStep(obsId:        Observation.Id): F[Boolean]
+  def sequenceEnd(obsId:        Observation.Id): F[Boolean]
+  def obsAbort(obsId:           Observation.Id, reason: String): F[Boolean]
+  def obsContinue(obsId:        Observation.Id): F[Boolean]
+  def obsPause(obsId:           Observation.Id, reason: String): F[Boolean]
+  def obsStop(obsId:            Observation.Id, reason: String): F[Boolean]
+
 }
 
 sealed trait OdbProxy[F[_]] extends OdbEventCommands[F] {
@@ -104,25 +99,6 @@ object OdbProxy {
     }
 
   class DummyOdbCommands[F[_]: Applicative] extends OdbEventCommands[F] {
-    override def datasetStart(
-      obsId:  Observation.Id,
-      fileId: ImageFileId
-    ): F[Boolean] = true.pure[F]
-
-    override def datasetComplete(
-      datasetId: DatasetId,
-      obsId:     Observation.Id,
-      fileId:    ImageFileId
-    ): F[Boolean] = true.pure[F]
-
-    override def obsAbort(
-      obsId:  Observation.Id,
-      reason: String
-    ): F[Boolean] = false.pure[F]
-
-    override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
-      false.pure[F]
-
     override def sequenceStart(
       obsId:        Observation.Id,
       instrument:   Instrument,
@@ -131,15 +107,6 @@ object OdbProxy {
       staticCfg:    StaticConfig
     ): F[Unit] =
       ().pure[F]
-
-    override def obsContinue(obsId: Observation.Id): F[Boolean] =
-      false.pure[F]
-
-    override def obsPause(obsId: Observation.Id, reason: String): F[Boolean] =
-      false.pure[F]
-
-    override def obsStop(obsId: Observation.Id, reason: String): F[Boolean] =
-      false.pure[F]
 
     override def stepStartStep(
       obsId:         Observation.Id,
@@ -150,23 +117,38 @@ object OdbProxy {
 
     override def stepStartConfigure(obsId: Observation.Id): F[Unit] = Applicative[F].unit
 
-    override def stepEndStep(obsId: Observation.Id): F[Boolean] = false.pure[F]
-
     override def stepEndConfigure(obsId: Observation.Id): F[Boolean] =
       false.pure[F]
 
     override def stepStartObserve(obsId: Observation.Id): F[Boolean] =
       false.pure[F]
 
+    override def datasetStart(obsId: Observation.Id, fileId: ImageFileId): F[Boolean] =
+      true.pure[F]
+
+    override def datasetComplete(obsId: Observation.Id): F[Boolean] =
+      true.pure[F]
+
     override def stepEndObserve(obsId: Observation.Id): F[Boolean] =
       false.pure[F]
-  }
 
-  type ObsRecordedIds = Map[Observation.Id, RecordedIds]
-  object ObsRecordedIds:
-    val Empty: ObsRecordedIds                                                = Map.empty
-    def at(obsId: Observation.Id): Lens[ObsRecordedIds, Option[RecordedIds]] =
-      Iso.id[ObsRecordedIds].at(obsId)
+    override def stepEndStep(obsId: Observation.Id): F[Boolean] = false.pure[F]
+
+    override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
+      false.pure[F]
+
+    override def obsAbort(obsId: Observation.Id, reason: String): F[Boolean] =
+      false.pure[F]
+
+    override def obsContinue(obsId: Observation.Id): F[Boolean] =
+      false.pure[F]
+
+    override def obsPause(obsId: Observation.Id, reason: String): F[Boolean] =
+      false.pure[F]
+
+    override def obsStop(obsId: Observation.Id, reason: String): F[Boolean] =
+      false.pure[F]
+  }
 
   case class OdbCommandsImpl[F[_]](
     client:    FetchClient[F, ObservationDB],
@@ -174,103 +156,15 @@ object OdbProxy {
   )(using
     val F:     Sync[F],
     L:         Logger[F]
-  ) extends OdbEventCommands[F] {
+  ) extends OdbEventCommands[F]
+      with IdTrackerOps[F](idTracker) {
     given FetchClient[F, ObservationDB] = client
-
-    private def getCurrentVisitId(obsId: Observation.Id): F[Visit.Id] =
-      idTracker.get
-        .map:
-          _.get(obsId)
-            .flatMap(RecordedIds.visitId.get)
-            .toRight(ObserveFailure.Unexpected(s"No current recorded visit for obsId [$obsId]"))
-        .rethrow
-
-    private def setCurrentVisitId(obsId: Observation.Id, visitId: Visit.Id): F[Unit] =
-      idTracker.update:
-        ObsRecordedIds.at(obsId).replace(RecordedIds(visitId.some, none, none).some)
-
-    private def getCurrentAtomId(obsId: Observation.Id): F[RecordedAtomId] =
-      idTracker.get
-        .map:
-          _.get(obsId)
-            .flatMap(RecordedIds.atomId.get)
-            .toRight(ObserveFailure.Unexpected(s"No current recorded atom for obsId [$obsId]"))
-        .rethrow
-
-    private def setCurrentAtomId(obsId: Observation.Id, atomId: RecordedAtomId): F[Unit] =
-      idTracker.update:
-        ObsRecordedIds.at(obsId).some.andThen(RecordedIds.atomId).replace(atomId.some)
-
-    private def getCurrentStepId(obsId: Observation.Id): F[RecordedStepId] =
-      idTracker.get
-        .map:
-          _.get(obsId)
-            .flatMap(RecordedIds.stepId.get)
-            .toRight(ObserveFailure.Unexpected(s"No current recorded step for obsId [$obsId]"))
-        .rethrow
-
-    private def setCurrentStepId(obsId: Observation.Id, stepId: RecordedStepId): F[Unit] =
-      idTracker.update:
-        ObsRecordedIds.at(obsId).some.andThen(RecordedIds.stepId).replace(stepId.some)
 
     private val fitsFileExtension                                   = ".fits"
     @unused private def normalizeFilename(fileName: String): String = if (
       fileName.endsWith(fitsFileExtension)
     ) fileName
     else fileName + fitsFileExtension
-
-    override def datasetStart(
-      obsId:  Observation.Id,
-      fileId: ImageFileId
-    ): F[Boolean] =
-      for {
-        stepId <- getCurrentStepId(obsId)
-        _      <-
-          L.debug(
-            s"Send ODB event datasetStart for obsId: $obsId, stepId: $stepId with fileId: $fileId"
-          )
-        did    <- recordDataset(stepId, fileId)
-        _      <- L.debug(s"Recorded dataset id $did")
-        _      <- AddDatasetEventMutation[F]
-                    .execute(datasetId = did, stg = DatasetStage.StartObserve)
-        _      <- L.debug("ODB event datasetStart sent")
-      } yield true
-
-    private def recordDataset(stepId: RecordedStepId, fileId: ImageFileId): F[DatasetId] =
-      RecordDatasetMutation[F]
-        .execute(stepId.value, normalizeFilename(fileId.value))
-        .map(_.recordDataset.dataset.id)
-
-    override def datasetComplete(
-      datasetId: DatasetId,
-      obsId:     Observation.Id,
-      fileId:    ImageFileId
-    ): F[Boolean] =
-      for {
-        _ <-
-          L.debug(
-            s"Send ODB event datasetComplete for obsId: $obsId datasetId: $datasetId with fileId: $fileId"
-          )
-        // FIXME Data set id is null
-        // _ <- AddDatasetEventMutation[F]
-        //        .execute(datasetId = datasetId, stg = DatasetStage.EndObserve)
-        _ <- L.debug("ODB event datasetComplete sent")
-      } yield true
-
-    override def obsAbort(
-      obsId:  Observation.Id,
-      reason: String
-    ): F[Boolean] =
-      for {
-        visitId <- getCurrentVisitId(obsId)
-        _       <- L.debug(s"Send ODB event observationAbort for obsId: $obsId")
-        _       <- AddSequenceEventMutation[F].execute(vId = visitId, cmd = SequenceCommand.Abort)
-        _       <- L.debug("ODB event observationAbort sent")
-      } yield true
-
-    override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
-      L.debug(s"Skipped sending ODB event sequenceEnd for obsId: $obsId")
-        .as(true)
 
     override def sequenceStart(
       obsId:        Observation.Id,
@@ -283,7 +177,7 @@ object OdbProxy {
         // TODO Check that there are no current visits or atoms??
         _       <- L.debug(s"Record visit for obsId: $obsId")
         visitId <- recordVisit(obsId, staticCfg)
-        -       <- setCurrentVisitId(obsId, visitId)
+        -       <- setCurrentVisitId(obsId, visitId.some)
         _       <- L.debug(s"Record atom for obsId: $obsId and visitId: $visitId")
         atomId  <- recordAtom(visitId, sequenceType, stepCount, instrument)
         -       <- setCurrentAtomId(obsId, atomId)
@@ -292,6 +186,101 @@ object OdbProxy {
         _       <- AddSequenceEventMutation[F].execute(vId = visitId, cmd = SequenceCommand.Start)
         _       <- L.debug(s"ODB event sequenceStart sent for obsId: $obsId")
       } yield ()
+
+    override def stepStartStep(
+      obsId:         Observation.Id,
+      dynamicConfig: DynamicConfig,
+      stepConfig:    StepConfig,
+      observeClass:  ObserveClass
+    ): F[Unit] =
+      for {
+        atomId <- getCurrentAtomId(obsId)
+        stepId <- recordStep(atomId, dynamicConfig, stepConfig, observeClass)
+        _      <- setCurrentStepId(obsId, stepId.some)
+        _      <- L.debug(s"Recorded step for obsId: $obsId, recordedStepId: $stepId")
+        _      <- AddStepEventMutation[F]
+                    .execute(stepId = stepId.value, stg = StepStage.StartStep)
+        _      <- L.debug(s"ODB event stepStartStep sent with stepId $stepId")
+      } yield ()
+
+    override def stepStartConfigure(obsId: Observation.Id): F[Unit] =
+      for {
+        stepId <- getCurrentStepId(obsId)
+        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.StartConfigure)
+        _      <- L.debug(s"ODB event stepStartConfigure sent with stepId ${stepId.value}")
+      } yield ()
+
+    override def stepEndConfigure(obsId: Observation.Id): F[Boolean] =
+      for {
+        stepId <- getCurrentStepId(obsId)
+        _      <- L.debug(s"Send ODB event stepEndConfigure for obsId: $obsId, step $stepId")
+        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.EndConfigure)
+        _      <- L.debug("ODB event stepEndConfigure sent")
+      } yield true
+
+    override def stepStartObserve(obsId: Observation.Id): F[Boolean] =
+      for {
+        stepId <- getCurrentStepId(obsId)
+        _      <- L.debug(s"Send ODB event stepStartConfigure for obsId: $obsId, step $stepId")
+        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.StartObserve)
+        _      <- L.debug("ODB event stepStartObserve sent")
+      } yield true
+
+    override def datasetStart(obsId: Observation.Id, fileId: ImageFileId): F[Boolean] =
+      for {
+        stepId    <- getCurrentStepId(obsId)
+        _         <-
+          L.debug(
+            s"Send ODB event datasetStart for obsId: $obsId, stepId: $stepId with fileId: $fileId"
+          )
+        datasetId <- recordDataset(stepId, fileId)
+        _         <- setCurrentDatasetId(obsId, datasetId.some)
+        _         <- L.debug(s"Recorded dataset id $datasetId")
+        _         <- AddDatasetEventMutation[F]
+                       .execute(datasetId = datasetId, stg = DatasetStage.StartObserve)
+        _         <- L.debug("ODB event datasetStart sent")
+      } yield true
+
+    override def datasetComplete(obsId: Observation.Id): F[Boolean] =
+      for {
+        datasetId <- getCurrentDatasetId(obsId)
+        _         <- L.debug(s"Send ODB event datasetComplete for obsId: $obsId datasetId: $datasetId")
+        _         <- AddDatasetEventMutation[F]
+                       .execute(datasetId = datasetId, stg = DatasetStage.EndObserve)
+        _         <- setCurrentDatasetId(obsId, none)
+        _         <- L.debug("ODB event datasetComplete sent")
+      } yield true
+
+    override def stepEndObserve(obsId: Observation.Id): F[Boolean] =
+      for {
+        stepId <- getCurrentStepId(obsId)
+        _      <- L.debug(s"Send ODB event stepEndConfigure for obsId: $obsId, step $stepId")
+        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.EndObserve)
+        _      <- L.debug("ODB event stepEndObserve sent")
+      } yield true
+
+    override def stepEndStep(obsId: Observation.Id): F[Boolean] =
+      for {
+        stepId <- getCurrentStepId(obsId)
+        _      <- L.debug(s"Send ODB event stepEndStep for obsId: $obsId, step $stepId")
+        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.EndStep)
+        _      <- setCurrentStepId(obsId, none)
+        _      <- L.debug("ODB event stepEndStep sent")
+      } yield true
+
+    override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
+      for {
+        _ <- setCurrentVisitId(obsId, none)
+        _ <- L.debug(s"Skipped sending ODB event sequenceEnd for obsId: $obsId")
+      } yield true
+
+    override def obsAbort(obsId: Observation.Id, reason: String): F[Boolean] =
+      for {
+        visitId <- getCurrentVisitId(obsId)
+        _       <- L.debug(s"Send ODB event observationAbort for obsId: $obsId")
+        _       <- AddSequenceEventMutation[F].execute(vId = visitId, cmd = SequenceCommand.Abort)
+        _       <- L.debug("ODB event observationAbort sent")
+      } yield true
 
     override def obsContinue(obsId: Observation.Id): F[Boolean] =
       for {
@@ -317,61 +306,6 @@ object OdbProxy {
         _       <- L.debug("ODB event observationStop sent")
       } yield true
 
-    override def stepStartStep(
-      obsId:         Observation.Id,
-      dynamicConfig: DynamicConfig,
-      stepConfig:    StepConfig,
-      observeClass:  ObserveClass
-    ): F[Unit] =
-      for {
-        atomId <- getCurrentAtomId(obsId)
-        stepId <- recordStep(atomId, dynamicConfig, stepConfig, observeClass)
-        _      <- setCurrentStepId(obsId, stepId)
-        _      <- L.debug(s"Recorded step for obsId: $obsId, recordedStepId: $stepId")
-        _      <- AddStepEventMutation[F]
-                    .execute(stepId = stepId.value, stg = StepStage.StartStep)
-        _      <- L.debug(s"ODB event stepStartStep sent with stepId $stepId")
-      } yield ()
-
-    override def stepStartConfigure(obsId: Observation.Id): F[Unit] =
-      for {
-        stepId <- getCurrentStepId(obsId)
-        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.StartConfigure)
-        _      <- L.debug(s"ODB event stepStartConfigure sent with stepId ${stepId.value}")
-      } yield ()
-
-    override def stepEndStep(obsId: Observation.Id): F[Boolean] =
-      for {
-        stepId <- getCurrentStepId(obsId)
-        _      <- L.debug(s"Send ODB event stepEndStep for obsId: $obsId, step $stepId")
-        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.EndStep)
-        _      <- L.debug("ODB event stepEndStep sent")
-      } yield true
-
-    override def stepEndConfigure(obsId: Observation.Id): F[Boolean] =
-      for {
-        stepId <- getCurrentStepId(obsId)
-        _      <- L.debug(s"Send ODB event stepEndConfigure for obsId: $obsId, step $stepId")
-        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.EndConfigure)
-        _      <- L.debug("ODB event stepEndConfigure sent")
-      } yield true
-
-    override def stepStartObserve(obsId: Observation.Id): F[Boolean] =
-      for {
-        stepId <- getCurrentStepId(obsId)
-        _      <- L.debug(s"Send ODB event stepStartConfigure for obsId: $obsId, step $stepId")
-        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.StartObserve)
-        _      <- L.debug("ODB event stepStartObserve sent")
-      } yield true
-
-    override def stepEndObserve(obsId: Observation.Id): F[Boolean] =
-      for {
-        stepId <- getCurrentStepId(obsId)
-        _      <- L.debug(s"Send ODB event stepEndConfigure for obsId: $obsId, step $stepId")
-        _      <- AddStepEventMutation[F].execute(stepId = stepId.value, stg = StepStage.EndObserve)
-        _      <- L.debug("ODB event stepEndObserve sent")
-      } yield true
-
     private def recordVisit(
       obsId:     Observation.Id,
       staticCfg: StaticConfig
@@ -384,23 +318,17 @@ object OdbProxy {
       obsId:     Observation.Id,
       staticCfg: StaticConfig.GmosNorth
     ): F[VisitId] =
-      for
-        visitId <- RecordGmosNorthVisitMutation[F]
-                     .execute(obsId, staticCfg.toInput)
-                     .map(_.recordGmosNorthVisit.visit.id)
-        _       <- setCurrentVisitId(obsId, visitId)
-      yield visitId
+      RecordGmosNorthVisitMutation[F]
+        .execute(obsId, staticCfg.toInput)
+        .map(_.recordGmosNorthVisit.visit.id)
 
     private def recordGmosSouthVisit(
       obsId:     Observation.Id,
       staticCfg: StaticConfig.GmosSouth
     ): F[VisitId] =
-      for
-        visitId <- RecordGmosSouthVisitMutation[F]
-                     .execute(obsId, staticCfg.toInput)
-                     .map(_.recordGmosSouthVisit.visit.id)
-        _       <- setCurrentVisitId(obsId, visitId)
-      yield visitId
+      RecordGmosSouthVisitMutation[F]
+        .execute(obsId, staticCfg.toInput)
+        .map(_.recordGmosSouthVisit.visit.id)
 
     private def recordAtom(
       visitId:      Visit.Id,
@@ -444,6 +372,11 @@ object OdbProxy {
         .execute(atomId.value, dynamicConfig.toInput, stepConfig.toInput, observeClass)
         .map(_.recordGmosSouthStep.stepRecord.id)
         .map(RecordedStepId(_))
+
+    private def recordDataset(stepId: RecordedStepId, fileId: ImageFileId): F[DatasetId] =
+      RecordDatasetMutation[F]
+        .execute(stepId.value, normalizeFilename(fileId.value))
+        .map(_.recordDataset.dataset.id)
   }
 
   class TestOdbProxy[F[_]: MonadThrow] extends OdbProxy[F] {
@@ -474,13 +407,13 @@ object OdbProxy {
 
     override def stepStartConfigure(obsId: Observation.Id): F[Unit] = Applicative[F].unit
 
-    override def stepEndStep(obsId: Observation.Id): F[Boolean] = false.pure[F]
-
     override def stepEndConfigure(obsId: Observation.Id): F[Boolean] = false.pure[F]
 
     override def stepStartObserve(obsId: Observation.Id): F[Boolean] = false.pure[F]
 
     override def stepEndObserve(obsId: Observation.Id): F[Boolean] = false.pure[F]
+
+    override def stepEndStep(obsId: Observation.Id): F[Boolean] = false.pure[F]
   }
 
 }

--- a/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
@@ -174,7 +174,6 @@ object OdbProxy {
       staticCfg:    StaticConfig
     ): F[Unit] =
       for {
-        // TODO Check that there are no current visits or atoms??
         _       <- L.debug(s"Record visit for obsId: $obsId")
         visitId <- recordVisit(obsId, staticCfg)
         -       <- setCurrentVisitId(obsId, visitId.some)

--- a/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
@@ -37,6 +37,7 @@ import observe.server.given
 import org.typelevel.log4cats.Logger
 
 import scala.annotation.unused
+import alleycats.std.set
 
 sealed trait OdbEventCommands[F[_]] {
   def sequenceStart(
@@ -278,6 +279,7 @@ object OdbProxy {
         visitId <- getCurrentVisitId(obsId)
         _       <- L.debug(s"Send ODB event observationAbort for obsId: $obsId")
         _       <- AddSequenceEventMutation[F].execute(vId = visitId, cmd = SequenceCommand.Abort)
+        _       <- setCurrentVisitId(obsId, none)
         _       <- L.debug("ODB event observationAbort sent")
       } yield true
 
@@ -302,6 +304,7 @@ object OdbProxy {
         _       <- L.debug(s"Send ODB event observationStop for obsId: $obsId")
         visitId <- getCurrentVisitId(obsId)
         _       <- AddSequenceEventMutation[F].execute(vId = visitId, cmd = SequenceCommand.Stop)
+        _       <- setCurrentVisitId(obsId, none)
         _       <- L.debug("ODB event observationStop sent")
       } yield true
 

--- a/modules/server_new/src/main/scala/observe/server/odb/RecordedIds.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/RecordedIds.scala
@@ -6,16 +6,35 @@ package observe.server.odb
 import cats.Eq
 import cats.derived.*
 import lucuma.core.model.Visit
+import lucuma.core.model.sequence.Dataset
 import monocle.Focus
 import monocle.Lens
+import monocle.Optional
 
-protected[odb] case class RecordedIds(
-  visitId: Option[Visit.Id],
-  atomId:  Option[RecordedAtomId],
-  stepId:  Option[RecordedStepId]
-) derives Eq
+protected[odb] case class RecordedVisit(visitId: Visit.Id, atom: Option[RecordedAtom] = None)
+    derives Eq
+object RecordedVisit:
+  val visitId: Lens[RecordedVisit, Visit.Id]                 = Focus[RecordedVisit](_.visitId)
+  val atom: Lens[RecordedVisit, Option[RecordedAtom]]        = Focus[RecordedVisit](_.atom)
+  val atomId: Optional[RecordedVisit, RecordedAtomId]        =
+    atom.some.andThen(RecordedAtom.atomId)
+  val step: Optional[RecordedVisit, Option[RecordedStep]]    =
+    atom.some.andThen(RecordedAtom.step)
+  val stepId: Optional[RecordedVisit, RecordedStepId]        =
+    atom.some.andThen(RecordedAtom.stepId)
+  val datasetId: Optional[RecordedVisit, Option[Dataset.Id]] =
+    step.some.andThen(RecordedStep.datasetId)
 
-object RecordedIds:
-  val visitId: Lens[RecordedIds, Option[Visit.Id]]      = Focus[RecordedIds](_.visitId)
-  val atomId: Lens[RecordedIds, Option[RecordedAtomId]] = Focus[RecordedIds](_.atomId)
-  val stepId: Lens[RecordedIds, Option[RecordedStepId]] = Focus[RecordedIds](_.stepId)
+protected[odb] case class RecordedAtom(atomId: RecordedAtomId, step: Option[RecordedStep] = None)
+    derives Eq
+object RecordedAtom:
+  val atomId: Lens[RecordedAtom, RecordedAtomId]     = Focus[RecordedAtom](_.atomId)
+  val step: Lens[RecordedAtom, Option[RecordedStep]] = Focus[RecordedAtom](_.step)
+  val stepId: Optional[RecordedAtom, RecordedStepId] =
+    step.some.andThen(RecordedStep.stepId)
+
+protected[odb] case class RecordedStep(stepId: RecordedStepId, datasetId: Option[Dataset.Id] = None)
+    derives Eq
+object RecordedStep:
+  val stepId: Lens[RecordedStep, RecordedStepId]        = Focus[RecordedStep](_.stepId)
+  val datasetId: Lens[RecordedStep, Option[Dataset.Id]] = Focus[RecordedStep](_.datasetId)

--- a/modules/server_new/src/main/scala/observe/server/odb/RecordedIds.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/RecordedIds.scala
@@ -10,20 +10,21 @@ import lucuma.core.model.sequence.Dataset
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
+import observe.model.dhs.ImageFileId
 
 protected[odb] case class RecordedVisit(visitId: Visit.Id, atom: Option[RecordedAtom] = None)
     derives Eq
 object RecordedVisit:
-  val visitId: Lens[RecordedVisit, Visit.Id]                 = Focus[RecordedVisit](_.visitId)
-  val atom: Lens[RecordedVisit, Option[RecordedAtom]]        = Focus[RecordedVisit](_.atom)
-  val atomId: Optional[RecordedVisit, RecordedAtomId]        =
+  val visitId: Lens[RecordedVisit, Visit.Id]                                      = Focus[RecordedVisit](_.visitId)
+  val atom: Lens[RecordedVisit, Option[RecordedAtom]]                             = Focus[RecordedVisit](_.atom)
+  val atomId: Optional[RecordedVisit, RecordedAtomId]                             =
     atom.some.andThen(RecordedAtom.atomId)
-  val step: Optional[RecordedVisit, Option[RecordedStep]]    =
+  val step: Optional[RecordedVisit, Option[RecordedStep]]                         =
     atom.some.andThen(RecordedAtom.step)
-  val stepId: Optional[RecordedVisit, RecordedStepId]        =
+  val stepId: Optional[RecordedVisit, RecordedStepId]                             =
     atom.some.andThen(RecordedAtom.stepId)
-  val datasetId: Optional[RecordedVisit, Option[Dataset.Id]] =
-    step.some.andThen(RecordedStep.datasetId)
+  def datasetId(fileId: ImageFileId): Optional[RecordedVisit, Option[Dataset.Id]] =
+    step.some.andThen(RecordedStep.datasetIds).andThen(DatasetIdMap.at(fileId))
 
 protected[odb] case class RecordedAtom(atomId: RecordedAtomId, step: Option[RecordedStep] = None)
     derives Eq
@@ -33,8 +34,10 @@ object RecordedAtom:
   val stepId: Optional[RecordedAtom, RecordedStepId] =
     step.some.andThen(RecordedStep.stepId)
 
-protected[odb] case class RecordedStep(stepId: RecordedStepId, datasetId: Option[Dataset.Id] = None)
-    derives Eq
+protected[odb] case class RecordedStep(
+  stepId:     RecordedStepId,
+  datasetIds: DatasetIdMap = DatasetIdMap.Empty
+) derives Eq
 object RecordedStep:
-  val stepId: Lens[RecordedStep, RecordedStepId]        = Focus[RecordedStep](_.stepId)
-  val datasetId: Lens[RecordedStep, Option[Dataset.Id]] = Focus[RecordedStep](_.datasetId)
+  val stepId: Lens[RecordedStep, RecordedStepId]   = Focus[RecordedStep](_.stepId)
+  val datasetIds: Lens[RecordedStep, DatasetIdMap] = Focus[RecordedStep](_.datasetIds)

--- a/modules/server_new/src/main/scala/observe/server/odb/newTypes.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/newTypes.scala
@@ -5,10 +5,15 @@ package observe.server.odb
 
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Atom
+import lucuma.core.model.sequence.Dataset
 import lucuma.core.model.sequence.Step
 import lucuma.core.util.NewType
 import monocle.Lens
+import observe.model.dhs.ImageFileId
 
+// Atom.Ids and Step.Ids exist both in input sequences and in recorded ones.
+// So, it is useful to have a new type for recorded ones in order to distinguish them.
+// Visit.Ids and Dataset.Ids only exist in recorded sequences, so they don't need a new type.
 object RecordedAtomId extends NewType[Atom.Id]
 type RecordedAtomId = RecordedAtomId.Type
 
@@ -21,3 +26,10 @@ object ObsRecordedIds extends NewType[Map[Observation.Id, RecordedVisit]]:
   def at(obsId: Observation.Id): Lens[ObsRecordedIds, Option[RecordedVisit]] =
     value.at(obsId)
 type ObsRecordedIds = ObsRecordedIds.Type
+
+object DatasetIdMap extends NewType[Map[ImageFileId, Dataset.Id]]:
+  val Empty: DatasetIdMap                                             =
+    DatasetIdMap(Map.empty)
+  def at(fileId: ImageFileId): Lens[DatasetIdMap, Option[Dataset.Id]] =
+    value.at(fileId)
+type DatasetIdMap = DatasetIdMap.Type

--- a/modules/server_new/src/main/scala/observe/server/odb/newTypes.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/newTypes.scala
@@ -3,12 +3,21 @@
 
 package observe.server.odb
 
+import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Step
 import lucuma.core.util.NewType
+import monocle.Lens
 
 object RecordedAtomId extends NewType[Atom.Id]
 type RecordedAtomId = RecordedAtomId.Type
 
 object RecordedStepId extends NewType[Step.Id]
 type RecordedStepId = RecordedStepId.Type
+
+object ObsRecordedIds extends NewType[Map[Observation.Id, RecordedVisit]]:
+  val Empty: ObsRecordedIds                                                  =
+    ObsRecordedIds(Map.empty)
+  def at(obsId: Observation.Id): Lens[ObsRecordedIds, Option[RecordedVisit]] =
+    value.at(obsId)
+type ObsRecordedIds = ObsRecordedIds.Type


### PR DESCRIPTION
- Add missing functionality of tracking dataset ids in the ODB Proxy.
- Id tracking model is reworked to better reflect reality: now you can't have i.e. a recorded step id without having an atom id.
- Check that visit, step and dataset ids are not already set when attempting to set them.
- Id tracking Map is now an opaque type.
- Tracking methods have been extracted to a trait in another file to avoid clutter.
- Multiple concurrent dataset ids are now supported.
- Unused parameters have been removed.
- Methods have also been sorted to reflect the flow.