### PR TITLE
Unbump core, fileId simulated logic

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/odb/IdTrackerOps.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/IdTrackerOps.scala
@@ -27,12 +27,15 @@ trait IdTrackerOps[F[_]: MonadThrow](idTracker: Ref[F, ObsRecordedIds]):
     idTracker.update:
       ObsRecordedIds
         .at(obsId)
-        .modify:
-          case Some(staleVisitId) if visitId.isDefined =>
-            throw ObserveFailure.Unexpected:
-              s"Attempted to set visitId for [$obsId] when it was already set. " +
-                s"Existing value [$staleVisitId], new attempted value [${visitId.get}]"
-          case _                                       => visitId.map(RecordedVisit(_))
+        .replace:
+          visitId.map(RecordedVisit(_))
+    // For the moment, we don't check if there's an existing visit, since there's no "visitEnd".
+    //     .modify:
+    //       case Some(staleVisitId) if visitId.isDefined =>
+    //         throw ObserveFailure.Unexpected:
+    //           s"Attempted to set visitId for [$obsId] when it was already set. " +
+    //             s"Existing value [$staleVisitId], new attempted value [${visitId.get}]"
+    //       case _                                       => visitId.map(RecordedVisit(_))
 
   // AtomId is never set to None, there's no "end atom" event in the engine.
   protected def getCurrentAtomId(obsId: Observation.Id): F[RecordedAtomId] =

--- a/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
@@ -273,7 +273,7 @@ object OdbProxy {
         _         <- setCurrentDatasetId(obsId, fileId, datasetId.some)
         _         <- L.debug(s"Recorded dataset id $datasetId")
         _         <- AddDatasetEventMutation[F]
-                       .execute(datasetId = datasetId, stg = DatasetStage.StartExpose)
+                       .execute(datasetId = datasetId, stg = DatasetStage.StartObserve)
         _         <- L.debug("ODB event datasetStartExposure sent")
       } yield true
 
@@ -282,7 +282,7 @@ object OdbProxy {
         datasetId <- getCurrentDatasetId(obsId, fileId)
         _         <- L.debug(s"Send ODB event datasetEndExposure for obsId: $obsId datasetId: $datasetId")
         _         <- AddDatasetEventMutation[F]
-                       .execute(datasetId = datasetId, stg = DatasetStage.EndExpose)
+                       .execute(datasetId = datasetId, stg = DatasetStage.EndObserve)
         _         <- L.debug("ODB event datasetEndExposure sent")
       } yield true
 

--- a/modules/server_new/src/test/scala/observe/server/keywords/DhsClientSimSpec.scala
+++ b/modules/server_new/src/test/scala/observe/server/keywords/DhsClientSimSpec.scala
@@ -9,13 +9,13 @@ import observe.server.keywords.DhsClient.Permanent
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.noop.NoOpLogger
 
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 class DhsClientSimSpec extends munit.CatsEffectSuite {
   private given Logger[IO] = NoOpLogger.impl[IO]
 
   test("produce data labels for today") {
-    (DhsClientSim[IO](LocalDate.of(2016, 4, 15))
+    (DhsClientSim[IO](LocalDateTime.of(2016, 4, 15, 0, 0, 0))
       .flatMap(_.createImage(DhsClient.ImageParameters(Permanent, Nil)))
       .map(_.value)
       .unsafeRunSync(): String) match {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -49,7 +49,7 @@ object Settings {
     val pprint        = "0.8.1"
 
     // Gemini Libraries
-    val lucumaCore      = "0.92.0"
+    val lucumaCore      = "0.91.1"
     val lucumaUI        = "0.90.0"
     val lucumaSchemas   = "0.72.0"
     val lucumaSSO       = "0.6.11"


### PR DESCRIPTION
I had to dial back `lucuma-core` since the latest version renames a `DatasetStage` instance, producing incompatibilities.

Also, I make sure the DHS simulator produces filenames that do not conflict (implements @jluhrs 's idea).
