### PR TITLE
Send step abort event.

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/odb/IdTrackerOps.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/IdTrackerOps.scala
@@ -68,12 +68,7 @@ trait IdTrackerOps[F[_]: MonadThrow](idTracker: Ref[F, ObsRecordedIds]):
         .at(obsId)
         .some
         .andThen(RecordedVisit.step)
-        .modify:
-          case Some(staleStepId) if stepId.isDefined =>
-            throw ObserveFailure.Unexpected:
-              s"Attempted to set current stepId for [$obsId] when it was already set. " +
-                s"Existing value [$staleStepId], new attempted value [${stepId.get}]"
-          case _                                     => stepId.map(RecordedStep(_))
+        .replace(stepId.map(RecordedStep(_)))
 
   protected def getCurrentDatasetId(obsId: Observation.Id, fileId: ImageFileId): F[Dataset.Id] =
     idTracker.get

--- a/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
+++ b/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
@@ -160,6 +160,9 @@ object TestOdbProxy {
         override def stepEndStep(obsId: Observation.Id): F[Boolean] =
           addEvent(StepEndStep(obsId)).as(true)
 
+        override def stepAbort(obsId: Observation.Id): F[Boolean] =
+          addEvent(StepAbort(obsId)).as(true)
+
         override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
           addEvent(SequenceEnd(obsId)).as(true)
 
@@ -205,6 +208,7 @@ object TestOdbProxy {
   case class DatasetEndWrite(obsId: Observation.Id, fileId: ImageFileId)      extends OdbEvent
   case class StepEndObserve(obsId: Observation.Id)                            extends OdbEvent
   case class StepEndStep(obsId: Observation.Id)                               extends OdbEvent
+  case class StepAbort(obsId: Observation.Id)                                 extends OdbEvent
   case class SequenceEnd(obsId: Observation.Id)                               extends OdbEvent
   case class ObsAbort(obsId: Observation.Id, reason: String)                  extends OdbEvent
   case class ObsContinue(obsId: Observation.Id)                               extends OdbEvent


### PR DESCRIPTION
Two changes:
 - A Step Abort event is now sent to the ODB whenever the execution is stopped because of a fault.
 - Allow to record a new Step even when the current one does not complete normally.