### PR TITLE
Fixed encoding of GMOS grating order

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/gmos/GmosControllerEpics.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/GmosControllerEpics.scala
@@ -64,7 +64,7 @@ trait GmosEncoders {
   given EncodeEpicsValue[BinningY, Int] = EncodeEpicsValue(_.count)
 
   given disperserOrderEncoder: EncodeEpicsValue[GratingOrder, String] = EncodeEpicsValue(
-    _.longName
+    _.shortName
   )
 
   given disperserOrderEncoderInt: EncodeEpicsValue[GratingOrder, Int] = EncodeEpicsValue(


### PR DESCRIPTION
Observe was writing the order name (Zero, One), while the instrument expects the number as string ("0", "1")