### PR TITLE
Keep UI updated when step/atom is completed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -333,7 +333,6 @@ lazy val observe_model = crossProject(JVMPlatform, JSPlatform)
   .enablePlugins(GitBranchPrompt)
   .settings(
     libraryDependencies ++= Seq(
-      PPrint.value,
       Mouse.value,
       CatsTime.value,
       Http4sCore.value,

--- a/modules/model/shared/src/main/scala/observe/model/events/ClientEvent.scala
+++ b/modules/model/shared/src/main/scala/observe/model/events/ClientEvent.scala
@@ -13,7 +13,9 @@ import io.circe.Encoder
 import io.circe.refined.*
 import io.circe.syntax.*
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.SequenceType
 import lucuma.core.model.Observation
+import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Step
 import lucuma.core.util.Enumerated
 import observe.model.ClientConfig
@@ -84,6 +86,9 @@ object ClientEvent:
         Encoder.AsObject,
         Decoder
 
+  case class AtomLoaded(obsId: Observation.Id, sequenceType: SequenceType, atomId: Atom.Id)
+      extends AllClientEvent derives Eq, Encoder.AsObject, Decoder
+
   given Encoder[ClientEvent] = Encoder.instance:
     case e @ BaDum                            => e.asJson
     case e @ InitialEvent(_)                  => e.asJson
@@ -91,6 +96,7 @@ object ClientEvent:
     case e @ SingleActionEvent(_, _, _, _, _) => e.asJson
     case e @ ChecksOverrideEvent(_)           => e.asJson
     case e @ ProgressEvent(_)                 => e.asJson
+    case e @ AtomLoaded(_, _, _)              => e.asJson
 
   given Decoder[ClientEvent] =
     List[Decoder[ClientEvent]](
@@ -99,5 +105,6 @@ object ClientEvent:
       Decoder[ObserveState].widen,
       Decoder[SingleActionEvent].widen,
       Decoder[ChecksOverrideEvent].widen,
-      Decoder[ProgressEvent].widen
+      Decoder[ProgressEvent].widen,
+      Decoder[AtomLoaded].widen
     ).reduceLeft(_ or _)

--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -1688,8 +1688,13 @@ object ObserveEngine {
       // case ResourceBusy(oid, sid, res, cid)   =>
       //   Stream.emit(UserNotification(SubsystemBusy(oid, sid, res), cid))
       // case NoMoreAtoms(_)                     => Stream.empty
-      // case NewAtomLoaded(_)                   => Stream.empty
-      case e if e.isModelUpdate                                             => Stream.emit(ClientEvent.ObserveState.fromSequenceViewQueue(svs))
+      case NewAtomLoaded(obsId, sequenceType, atomId)                       =>
+        Stream.emits(
+          ClientEvent.AtomLoaded(obsId, sequenceType, atomId) ::
+            ObserveState.fromSequenceViewQueue(svs) :: Nil
+        )
+      case e if e.isModelUpdate                                             =>
+        Stream.emit(ClientEvent.ObserveState.fromSequenceViewQueue(svs))
       case _                                                                => Stream.empty
     }
 
@@ -1884,7 +1889,7 @@ object ObserveEngine {
                                atm.sequenceType,
                                NonNegShort.unsafeFrom(atm.steps.length.toShort)
                     )
-                    .as(SeqEvent.NewAtomLoaded(obsId))
+                    .as(SeqEvent.NewAtomLoaded(obsId, atm.sequenceType, atm.atomId))
                 )
             }
         }

--- a/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
@@ -6,9 +6,11 @@ package observe.server
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.SequenceType
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
 import lucuma.core.model.User
+import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Step
 import observe.model.ClientId
 import observe.model.Conditions
@@ -83,5 +85,6 @@ object SeqEvent {
   ) extends SeqEvent
   case object NullSeqEvent                                                       extends NoUserSeqEvent
   case class NoMoreAtoms(obsId: Observation.Id)                                  extends SeqEvent
-  case class NewAtomLoaded(obsId: Observation.Id)                                extends SeqEvent
+  case class NewAtomLoaded(obsId: Observation.Id, sequenceType: SequenceType, atomId: Atom.Id)
+      extends SeqEvent
 }

--- a/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
@@ -1050,8 +1050,8 @@ class ObserveEngineSuite extends TestCommon {
             .drop(1)
             .takeThrough(x =>
               x._1 match {
-                case EventResult.UserCommandResponse(_, _, Some(SeqEvent.NewAtomLoaded(_))) => false
-                case _                                                                      => true
+                case EventResult.UserCommandResponse(_, _, Some(SeqEvent.NewAtomLoaded(_, _, _))) => false
+                case _                                                                            => true
               }
             )
             .compile

--- a/modules/web/client-model/src/main/scala/observe/ui/model/LoadedObservation.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/LoadedObservation.scala
@@ -6,6 +6,7 @@ package observe.ui.model
 import cats.syntax.all.*
 import crystal.Pot
 import lucuma.core.model.Observation
+import lucuma.core.model.Visit
 import lucuma.core.model.sequence.InstrumentExecutionConfig
 import lucuma.schemas.model.ExecutionVisits
 import monocle.Focus
@@ -24,6 +25,11 @@ case class LoadedObservation private (
 
   def reset: LoadedObservation =
     copy(config = Pot.pending, visits = Pot.pending)
+
+  lazy val lastVisitId: Option[Visit.Id] =
+    visits.toOption.flatMap:
+      case ExecutionVisits.GmosNorth(_, visits) => visits.lastOption.map(_.id)
+      case ExecutionVisits.GmosSouth(_, visits) => visits.lastOption.map(_.id)
 
 object LoadedObservation:
   def apply(obsId: Observation.Id): LoadedObservation = new LoadedObservation(obsId)

--- a/modules/web/client/src/clue/scala/observe/queries/VisitQueriesGQL.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/VisitQueriesGQL.scala
@@ -14,7 +14,7 @@ object VisitQueriesGQL:
   @GraphQL
   trait ObservationVisits extends GraphQLOperation[ObservationDB]:
     val document = s"""
-      query($$obsId: ObservationId!) {
+      query($$obsId: ObservationId!, $$visitIdOffset: VisitId) {
         observation(observationId: $$obsId) {
           execution $ExecutionVisitsSubquery
         }

--- a/modules/web/client/src/main/scala/observe/ui/services/ODBQueryApi.scala
+++ b/modules/web/client/src/main/scala/observe/ui/services/ODBQueryApi.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.ui.services
+
+import cats.effect.IO
+import cats.effect.Sync
+import japgolly.scalajs.react.React
+import japgolly.scalajs.react.feature.Context
+
+trait ODBQueryApi[F[_]: Sync]:
+  def refreshNighttimeVisits: F[Unit] =
+    Sync[F].delay(println("refreshNighttimeVisits invoked without being initialized"))
+
+object ODBQueryApi:
+  // Default value noop implementations with warning
+  val ctx: Context[ODBQueryApi[IO]] = React.createContext(new ODBQueryApi[IO] {})

--- a/modules/web/client/src/main/scala/observe/ui/services/ODBQueryApiImpl.scala
+++ b/modules/web/client/src/main/scala/observe/ui/services/ODBQueryApiImpl.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.ui.services
+
+import cats.effect.IO
+import cats.syntax.all.*
+import clue.*
+import crystal.ViewF
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.model.AtomRecord
+import lucuma.schemas.model.ExecutionVisits
+import lucuma.schemas.model.StepRecord
+import lucuma.schemas.model.Visit
+import lucuma.schemas.model.enums.StepExecutionState
+import monocle.Traversal
+import observe.queries.VisitQueriesGQL
+import observe.ui.model.LoadedObservation
+import org.typelevel.log4cats.Logger
+
+case class ODBQueryApiImpl(nighttimeObservation: ViewF[IO, Option[LoadedObservation]])(using
+  FetchClient[IO, ObservationDB],
+  Logger[IO]
+) extends ODBQueryApi[IO]:
+
+  private val gmosNorthVisitsSteps: Traversal[ExecutionVisits, List[StepRecord.GmosNorth]] =
+    ExecutionVisits.gmosNorth
+      .andThen(ExecutionVisits.GmosNorth.visits.each)
+      .andThen(Visit.GmosNorth.atoms.each)
+      .andThen(AtomRecord.GmosNorth.steps)
+
+  private val gmosSouthVisitsSteps: Traversal[ExecutionVisits, List[StepRecord.GmosSouth]] =
+    ExecutionVisits.gmosSouth
+      .andThen(ExecutionVisits.GmosSouth.visits.each)
+      .andThen(Visit.GmosSouth.atoms.each)
+      .andThen(AtomRecord.GmosSouth.steps)
+
+  private val gmosNorthRemoveOngoingSteps: ExecutionVisits => ExecutionVisits =
+    gmosNorthVisitsSteps.modify(_.filter(_.executionState =!= StepExecutionState.Ongoing))
+
+  private val gmosSouthRemoveOngoingSteps: ExecutionVisits => ExecutionVisits =
+    gmosSouthVisitsSteps.modify(_.filter(_.executionState =!= StepExecutionState.Ongoing))
+
+  private val removeOngoingSteps: ExecutionVisits => ExecutionVisits =
+    gmosNorthRemoveOngoingSteps >>> gmosSouthRemoveOngoingSteps
+
+  override def refreshNighttimeVisits: IO[Unit] =
+    nighttimeObservation.toOptionView.fold(
+      Logger[IO].error("refreshNighttimeVisits with undefined loaded observation")
+    ): loadedObs =>
+      VisitQueriesGQL
+        .ObservationVisits[IO]
+        .query(loadedObs.get.obsId)(ErrorPolicy.IgnoreOnData)
+        .map(_.observation.flatMap(_.execution))
+        .attempt
+        .flatMap: visits =>
+          loadedObs.mod:
+            _.withVisits:
+              // Ongoing step is shown from current atom, not from visits, so we remove it.
+              visits.map:
+                _.map(removeOngoingSteps)

--- a/modules/web/client/vite.config.js
+++ b/modules/web/client/vite.config.js
@@ -46,7 +46,7 @@ const pathExists = async (path) => {
 
 // https://vitejs.dev/config/
 export default defineConfig(async ({ mode }) => {
-  const scalaClassesDir = path.resolve(__dirname, 'target/scala-3.4.0');
+  const scalaClassesDir = path.resolve(__dirname, 'target/scala-3.4.1');
   const isProduction = mode == 'production';
   const sjs = isProduction
     ? path.resolve(scalaClassesDir, 'observe_web_client-opt')

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveEventRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveEventRoutes.scala
@@ -19,7 +19,6 @@ import observe.model.*
 import observe.model.ClientConfig
 import observe.model.ClientId
 import observe.model.events.*
-import observe.model.events.ClientEvent
 import observe.model.events.ClientEvent.InitialEvent
 import observe.server.ObserveEngine
 import observe.server.OcsBuildInfo

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -50,8 +50,8 @@ object Settings {
 
     // Gemini Libraries
     val lucumaCore      = "0.95.1"
-    val lucumaUI        = "0.96.1"
-    val lucumaSchemas   = "0.80.0"
+    val lucumaUI        = "0.97.0"
+    val lucumaSchemas   = "0.81.0"
     val lucumaSSO       = "0.6.15"
     val lucumaODBSchema = "0.11.4"
 


### PR DESCRIPTION
In this PR:
- When a step completes, visits are refreshed (only from the last loaded visit), to show the newly completed step.
- When an atom completes, it is removed from the `possibleFuture`.

`ServerEventHandler`  was reworked to receive modifier callbacks instead of `View`s, since the `View`s it could receive were stale. In other words, it cannot read values, only modify them.