### PR TITLE
Backend interface for requesting next atom.

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -20,6 +20,7 @@ import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.SequenceType
 import lucuma.core.enums.Site
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
@@ -89,6 +90,15 @@ trait ObserveEngine[F[_]] {
     stp:         Step.Id,
     clientId:    ClientId,
     runOverride: RunOverride
+  ): F[Unit]
+
+  def nextAtom(
+    id:       Observation.Id,
+    user:     User,
+    observer: Observer,
+    clientId: ClientId,
+    atomType: SequenceType,
+    run:      Boolean = true
   ): F[Unit]
 
   def requestPause(
@@ -1482,6 +1492,15 @@ object ObserveEngine {
                      enabled,
                      clientId: ClientId
       )
+
+    override def nextAtom(
+      id:       Observation.Id,
+      user:     User,
+      observer: Observer,
+      clientId: ClientId,
+      atomType: SequenceType,
+      run:      Boolean
+    ): F[Unit] = Applicative[F].unit
 
   }
 

--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -92,7 +92,7 @@ trait ObserveEngine[F[_]] {
     runOverride: RunOverride
   ): F[Unit]
 
-  def nextAtom(
+  def loadNextAtom(
     id:       Observation.Id,
     user:     User,
     observer: Observer,
@@ -1493,7 +1493,7 @@ object ObserveEngine {
                      clientId: ClientId
       )
 
-    override def nextAtom(
+    override def loadNextAtom(
       id:       Observation.Id,
       user:     User,
       observer: Observer,

--- a/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
@@ -87,4 +87,6 @@ object SeqEvent {
   case class NoMoreAtoms(obsId: Observation.Id)                                  extends SeqEvent
   case class NewAtomLoaded(obsId: Observation.Id, sequenceType: SequenceType, atomId: Atom.Id)
       extends SeqEvent
+  case class AtomCompleted(obsId: Observation.Id, sequenceType: SequenceType, atomId: Atom.Id)
+      extends SeqEvent
 }

--- a/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
@@ -1050,7 +1050,8 @@ class ObserveEngineSuite extends TestCommon {
             .drop(1)
             .takeThrough(x =>
               x._1 match {
-                case EventResult.UserCommandResponse(_, _, Some(SeqEvent.NewAtomLoaded(_, _, _))) => false
+                case EventResult.UserCommandResponse(_, _, Some(SeqEvent.NewAtomLoaded(_, _, _))) =>
+                  false
                 case _                                                                            => true
               }
             )

--- a/modules/web/client/src/main/scala/observe/ui/Icons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/Icons.scala
@@ -199,7 +199,7 @@ object Icons:
   inline def FileCheck         = FontAwesomeIcon(faFileCheck)
   inline def FileCross         = FontAwesomeIcon(faFileCross)
   inline def Gears             = FontAwesomeIcon(faGears)
-  inline def Minus            = FontAwesomeIcon(faMinus)
+  inline def Minus             = FontAwesomeIcon(faMinus)
   inline def Logout            = FontAwesomeIcon(faSignOutAlt)
   inline def Moon              = FontAwesomeIcon(faMoon)
   inline def Pause             = FontAwesomeIcon(faPause)

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
@@ -69,6 +69,12 @@ class ObserveCommandRoutes[F[_]: Async: Compression](
       ssoClient.require(req): user =>
         oe.requestCancelPause(obsId, obs, user) *> NoContent()
 
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "nextAtom" /
+        ObserverVar(obs) / SequenceTypeVar(seqType) =>
+      ssoClient.require(req): user =>
+        oe.nextAtom(obsId, user, obs, clientId, seqType, true) *>
+          NoContent()
+
     case req @ POST -> Root / ObsIdVar(obsId) / StepIdVar(stepId) / ClientIDVar(clientId) /
         "breakpoint" / ObserverVar(obs) / BreakpointVar(bp) =>
       ssoClient.require(req): user =>

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
@@ -69,10 +69,10 @@ class ObserveCommandRoutes[F[_]: Async: Compression](
       ssoClient.require(req): user =>
         oe.requestCancelPause(obsId, obs, user) *> NoContent()
 
-    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "nextAtom" /
+    case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "loadNextAtom" /
         ObserverVar(obs) / SequenceTypeVar(seqType) =>
       ssoClient.require(req): user =>
-        oe.nextAtom(obsId, user, obs, clientId, seqType, true) *>
+        oe.loadNextAtom(obsId, user, obs, clientId, seqType, true) *>
           NoContent()
 
     case req @ POST -> Root / ObsIdVar(obsId) / StepIdVar(stepId) / ClientIDVar(clientId) /

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/vars.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/vars.scala
@@ -7,6 +7,7 @@ import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.SequenceType
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Step
 import lucuma.core.util.Enumerated
@@ -77,3 +78,6 @@ object BreakpointVar extends BooleanBasedVar[Breakpoint]:
 
 object SubsystemEnabledVar extends BooleanBasedVar[SubsystemEnabled]:
   def item(b: Boolean) = if b then SubsystemEnabled.Enabled else SubsystemEnabled.Disabled
+
+object SequenceTypeVar:
+  def unapply(str: String): Option[SequenceType] = Enumerated[SequenceType].fromTag(str)

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
@@ -214,7 +214,7 @@ class TestObserveEngine[F[_]: Sync: Logger](sys: Systems[F]) extends ObserveEngi
     s0: EngineState[F]
   ): fs2.Stream[F, (EventResult[SeqEvent], EngineState[F])] = Stream.empty
 
-  override def nextAtom(
+  override def loadNextAtom(
     id:       Observation.Id,
     user:     User,
     observer: Observer,

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
@@ -12,8 +12,10 @@ import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.SequenceType
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
+import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.core.model.sequence.Step
 import observe.engine.EventResult
@@ -211,6 +213,15 @@ class TestObserveEngine[F[_]: Sync: Logger](sys: Systems[F]) extends ObserveEngi
   override def stream(
     s0: EngineState[F]
   ): fs2.Stream[F, (EventResult[SeqEvent], EngineState[F])] = Stream.empty
+
+  override def nextAtom(
+    id:       Observation.Id,
+    user:     User,
+    observer: Observer,
+    clientId: ClientId,
+    atomType: SequenceType,
+    run:      Boolean
+  ): F[Unit] = Applicative[F].unit
 }
 
 object TestObserveEngine {


### PR DESCRIPTION
This PR only implements the entry point for requesting more acquisition atoms. It does not include the actual code to load new atoms.
It also defines a new event that will eventually inform the client that the current atom run to completion. The event itself is not yet emitted in this version.