### PR TITLE
Deploy Docker image both to DockerHub and Heroku

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,11 +120,15 @@ jobs:
           cd modules/web/client
           npm clean-install --verbose
 
-      - name: Login to Heroku Container
-        run: 'heroku container:login'
+      - name: Login to Docker Hub
+        run: echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login --username nlsoftware --password-stdin
 
-      - name: Build and deploy Docker image to Heroku
+      - name: Build and Publish Docker image
         run: 'sbt -v -J-Xmx6g ''++ ${{ matrix.scala }}'' deploy/docker:publish'
 
-      - name: Release app in Heroku
-        run: 'heroku container:release web -a ${{ secrets.HEROKU_APP_NAME }}'
+      - name: Deploy and release app in Heroku
+        run: |
+          heroku container:login
+          docker tag noirlab/gpp-obs registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web
+          docker push registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web
+          heroku container:release web -a ${{ secrets.HEROKU_APP_NAME }} -v


### PR DESCRIPTION
Docker deploy is simplified so that the built image is deployed to DockerHub by the sbt plugin on PR merge.

Then, with a custom action, we also deploy it to Heroku and release the staging app.