### PR TITLE
Fix duplicate expand buttons and extract observation execution component

### DIFF
--- a/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
+++ b/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
@@ -28,8 +28,9 @@ object ObserveStyles:
   val LogArea: Css = Css("ObserveStyles-logArea")
   val Footer: Css  = Css("ObserveStyles-footer")
 
-  val ObservationArea: Css      = Css("ObserveStyles-observationArea")
-  val ObservationAreaError: Css = Css("ObserveStyles-observationAreaError")
+  val ObservationArea: Css           = Css("ObserveStyles-observationArea")
+  val ObservationAreaError: Css      = Css("ObserveStyles-observationAreaError")
+  val SequenceTableExpandButton: Css = Css("ObservationArea-sequenceTableExpandButton")
 
   val ObserveTable: Css = Css("ObserveStyles-observeTable")
 

--- a/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
@@ -33,7 +33,8 @@ case class ObservationSequence(
   requests:        ObservationRequests,
   selectedStep:    Option[Step.Id],
   setSelectedStep: Step.Id => Callback,
-  clientMode:      ClientMode
+  clientMode:      ClientMode,
+  setExpandedButton: VdomNode => Callback
 ) extends ReactFnProps(ObservationSequence.component)
 
 object ObservationSequence:
@@ -68,7 +69,8 @@ object ObservationSequence:
             props.setSelectedStep,
             props.requests,
             isPreview = false,
-            flipBreakPoint
+            flipBreakPoint,
+            props.setExpandedButton,
           )
         case (InstrumentExecutionConfig.GmosSouth(config), ExecutionVisits.GmosSouth(_, visits)) =>
           GmosSouthSequenceTable(
@@ -82,7 +84,8 @@ object ObservationSequence:
             props.setSelectedStep,
             props.requests,
             isPreview = false,
-            flipBreakPoint
+            flipBreakPoint,
+            props.setExpandedButton,
           )
         case _                                                                                   =>
           <.div(ObserveStyles.ObservationAreaError)(

--- a/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
@@ -34,7 +34,6 @@ case class ObservationSequence(
   selectedStep:    Option[Step.Id],
   setSelectedStep: Step.Id => Callback,
   clientMode:      ClientMode,
-  setExpandedButton: VdomNode => Callback
 ) extends ReactFnProps(ObservationSequence.component)
 
 object ObservationSequence:
@@ -70,7 +69,6 @@ object ObservationSequence:
             props.requests,
             isPreview = false,
             flipBreakPoint,
-            props.setExpandedButton,
           )
         case (InstrumentExecutionConfig.GmosSouth(config), ExecutionVisits.GmosSouth(_, visits)) =>
           GmosSouthSequenceTable(
@@ -85,7 +83,6 @@ object ObservationSequence:
             props.requests,
             isPreview = false,
             flipBreakPoint,
-            props.setExpandedButton,
           )
         case _                                                                                   =>
           <.div(ObserveStyles.ObservationAreaError)(

--- a/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ObservationSequence.scala
@@ -33,7 +33,7 @@ case class ObservationSequence(
   requests:        ObservationRequests,
   selectedStep:    Option[Step.Id],
   setSelectedStep: Step.Id => Callback,
-  clientMode:      ClientMode,
+  clientMode:      ClientMode
 ) extends ReactFnProps(ObservationSequence.component)
 
 object ObservationSequence:
@@ -68,7 +68,7 @@ object ObservationSequence:
             props.setSelectedStep,
             props.requests,
             isPreview = false,
-            flipBreakPoint,
+            flipBreakPoint
           )
         case (InstrumentExecutionConfig.GmosSouth(config), ExecutionVisits.GmosSouth(_, visits)) =>
           GmosSouthSequenceTable(
@@ -82,7 +82,7 @@ object ObservationSequence:
             props.setSelectedStep,
             props.requests,
             isPreview = false,
-            flipBreakPoint,
+            flipBreakPoint
           )
         case _                                                                                   =>
           <.div(ObserveStyles.ObservationAreaError)(

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
@@ -22,8 +22,7 @@ case class ObsHeader(
   loadObs:       Observation.Id => Callback,
   sequenceState: SequenceState,
   requests:      ObservationRequests,
-  overrides:     Option[View[SystemOverrides]],
-  expandButton:  VdomNode
+  overrides:     Option[View[SystemOverrides]]
 ) extends ReactFnProps(ObsHeader.component)
 
 object ObsHeader:
@@ -50,6 +49,5 @@ object ObsHeader:
               SubsystemOverrides(props.observation.obsId, props.observation.instrument, overrides)
                 .when(props.loadedObsId.contains_(props.observation.obsId.ready))
             .whenDefined
-        ),
-        <.div(props.expandButton)
+        )
       )

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
@@ -22,7 +22,8 @@ case class ObsHeader(
   loadObs:       Observation.Id => Callback,
   sequenceState: SequenceState,
   requests:      ObservationRequests,
-  overrides:     Option[View[SystemOverrides]]
+  overrides:     Option[View[SystemOverrides]],
+  expandButton:  VdomNode
 ) extends ReactFnProps(ObsHeader.component)
 
 object ObsHeader:
@@ -42,7 +43,7 @@ object ObsHeader:
           s"${props.observation.title} [${props.observation.obsId}]"
         ),
         <.div(ObserveStyles.ObsSummaryDetails)(
-          <.span(^.id := "sequence-table-expand-all"),
+          props.expandButton,
           <.span(props.observation.configurationSummary),
           <.span(props.observation.constraintsSummary),
           props.overrides

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
@@ -43,7 +43,6 @@ object ObsHeader:
           s"${props.observation.title} [${props.observation.obsId}]"
         ),
         <.div(ObserveStyles.ObsSummaryDetails)(
-          props.expandButton,
           <.span(props.observation.configurationSummary),
           <.span(props.observation.constraintsSummary),
           props.overrides
@@ -51,5 +50,6 @@ object ObsHeader:
               SubsystemOverrides(props.observation.obsId, props.observation.instrument, overrides)
                 .when(props.loadedObsId.contains_(props.observation.obsId.ready))
             .whenDefined
-        )
+        ),
+        <.div(props.expandButton)
       )

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/ObservationExecutionDisplay.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/ObservationExecutionDisplay.scala
@@ -26,7 +26,7 @@ import observe.ui.model.ObsSummary
 
 case class ObservationExecutionDisplay(
   selectedObs:     ObsSummary,
-  rootModelData:       View[RootModelData],
+  rootModelData:   View[RootModelData],
   loadObservation: Observation.Id => Callback
 ) extends ReactFnProps(ObservationExecutionDisplay.component)
 
@@ -36,10 +36,9 @@ object ObservationExecutionDisplay:
   private val component =
     ScalaFnComponent
       .withHooks[Props]
-      .useState[VdomNode](EmptyVdom) // expandButton
-      .render: (props, expandButton) =>
-        val selectedObsId                        = props.selectedObs.obsId
-        val rootModelData: RootModelData         = props.rootModelData.get
+      .render: props =>
+        val selectedObsId                = props.selectedObs.obsId
+        val rootModelData: RootModelData = props.rootModelData.get
 
         val executionStateOpt: ViewOpt[ExecutionState] =
           props.rootModelData
@@ -64,8 +63,7 @@ object ObservationExecutionDisplay:
               ObservationRequests.Idle
             ),
             executionStateAndConfig
-              .flatMap(_.toOption.map(_._4.zoom(ExecutionState.systemOverrides))),
-            expandButton.value
+              .flatMap(_.toOption.map(_._4.zoom(ExecutionState.systemOverrides)))
           ),
           // TODO, If ODB cannot generate a sequence, we still show PENDING instead of ERROR
           executionStateAndConfig.map(
@@ -95,8 +93,7 @@ object ObservationExecutionDisplay:
                   requests,
                   selectedStep,
                   setSelectedStep,
-                  rootModelData.clientMode,
-                  expandButton.setState
+                  rootModelData.clientMode
                 )
               },
               errorRender = t =>

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/ObservationExecutionDisplay.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/ObservationExecutionDisplay.scala
@@ -1,0 +1,108 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.ui.components.sequence
+
+import cats.syntax.all.*
+import crystal.Pot
+import crystal.react.*
+import crystal.syntax.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.model.Observation
+import lucuma.core.model.sequence.InstrumentExecutionConfig
+import lucuma.core.model.sequence.Step
+import lucuma.react.common.*
+import lucuma.schemas.model.ExecutionVisits
+import lucuma.ui.DefaultErrorRender
+import lucuma.ui.syntax.all.*
+import observe.model.ExecutionState
+import observe.model.SequenceState
+import observe.model.StepProgress
+import observe.ui.ObserveStyles
+import observe.ui.components.ObservationSequence
+import observe.ui.model.*
+import observe.ui.model.ObsSummary
+
+case class ObservationExecutionDisplay(
+  selectedObs:     ObsSummary,
+  rootModelData:       View[RootModelData],
+  loadObservation: Observation.Id => Callback
+) extends ReactFnProps(ObservationExecutionDisplay.component)
+
+object ObservationExecutionDisplay:
+  private type Props = ObservationExecutionDisplay
+
+  private val component =
+    ScalaFnComponent
+      .withHooks[Props]
+      .useState[VdomNode](EmptyVdom) // expandButton
+      .render: (props, expandButton) =>
+        val selectedObsId                        = props.selectedObs.obsId
+        val rootModelData: RootModelData         = props.rootModelData.get
+
+        val executionStateOpt: ViewOpt[ExecutionState] =
+          props.rootModelData
+            .zoom(RootModelData.executionState.index(selectedObsId))
+
+        val executionStateAndConfig: Option[
+          Pot[
+            (Observation.Id, InstrumentExecutionConfig, ExecutionVisits, View[ExecutionState])
+          ]
+        ] =
+          rootModelData.nighttimeObservation.map: lo =>
+            (lo.obsId.ready, lo.config, lo.visits, executionStateOpt.toOptionView.toPot).tupled
+
+        <.div(ObserveStyles.ObservationArea, ^.key := selectedObsId.toString)(
+          ObsHeader(
+            props.selectedObs,
+            executionStateAndConfig.map(_.map(_._1)),
+            props.loadObservation,
+            executionStateOpt.get.map(_.sequenceState).getOrElse(SequenceState.Idle),
+            rootModelData.obsRequests.getOrElse(
+              selectedObsId,
+              ObservationRequests.Idle
+            ),
+            executionStateAndConfig
+              .flatMap(_.toOption.map(_._4.zoom(ExecutionState.systemOverrides))),
+            expandButton.value
+          ),
+          // TODO, If ODB cannot generate a sequence, we still show PENDING instead of ERROR
+          executionStateAndConfig.map(
+            _.renderPot(
+              { (loadedObsId, config, visits, executionState) =>
+                val progress: Option[StepProgress] =
+                  rootModelData.obsProgress.get(loadedObsId)
+
+                val requests: ObservationRequests =
+                  rootModelData.obsRequests.getOrElse(loadedObsId, ObservationRequests.Idle)
+
+                val selectedStep: Option[Step.Id] =
+                  rootModelData.obsSelectedStep(loadedObsId)
+
+                val setSelectedStep: Step.Id => Callback = stepId =>
+                  props.rootModelData
+                    .zoom(RootModelData.userSelectedStep.at(loadedObsId))
+                    .mod: oldStepId =>
+                      if (oldStepId.contains_(stepId)) none else stepId.some
+
+                ObservationSequence(
+                  loadedObsId,
+                  config,
+                  visits,
+                  executionState,
+                  progress,
+                  requests,
+                  selectedStep,
+                  setSelectedStep,
+                  rootModelData.clientMode,
+                  expandButton.setState
+                )
+              },
+              errorRender = t =>
+                <.div(ObserveStyles.ObservationAreaError)(
+                  DefaultErrorRender(t)
+                )
+            )
+          )
+        )

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
@@ -201,19 +201,20 @@ private sealed trait SequenceTableBuilder[S: Eq, D <: DynamicConfig: Eq]
       .useEffectWithDepsBy((_, _, _, _, _, _, _, _, ref) => ref)((_, _, _, _, _, _, _, _, ref) =>
         _ => ref.narrowOption[dom.Element].foreachCB(scrollIfNeeded)
       )
-      .useEffectWithDepsBy((_, _, cols, _, sequence, _, _, _, _) => (cols, sequence))(
-        (props, _, _, _, _, _, table, _, _) =>
-          (_, _) =>
-            val (icon, label) =
-              if table.getIsAllRowsExpanded() then (Icons.Minus, "Collapse all visits")
-              else (Icons.Plus, "Expand all steps")
-            props.setExpandedButton(
-              Button(
-                icon = icon,
-                label = label,
-                onClick = table.toggleAllRowsExpanded()
-              ).mini.compact
-            )
+      .useEffectWithDepsBy((_, _, cols, _, sequence, _, table, _, _) =>
+        (cols, sequence, table.getIsAllRowsExpanded())
+      )((props, _, _, _, _, _, table, _, _) =>
+        (_, _, _) =>
+          val (icon, label) =
+            if table.getIsAllRowsExpanded() then (Icons.Minus, "Collapse all visits")
+            else (Icons.Plus, "Expand all steps")
+          props.setExpandedButton(
+            Button(
+              icon = icon,
+              label = label,
+              onClick = table.toggleAllRowsExpanded()
+            ).mini.compact
+          )
       )
       .render: (props, resize, cols, _, _, _, table, _, selectedRef) =>
         extension (step: SequenceRow[DynamicConfig])

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
@@ -286,7 +286,7 @@ private sealed trait SequenceTableBuilder[S: Eq, D <: DynamicConfig: Eq]
 
         val (icon, label) =
           if table.getIsAllRowsExpanded() then (Icons.Minus, "Collapse all visits")
-          else (Icons.Plus, "Expand all steps")
+          else (Icons.Plus, "Expand all visits")
         React.Fragment(
           <.div(
             ObserveStyles.SequenceTableExpandButton,

--- a/modules/web/client/src/main/webapp/styles/observe.scss
+++ b/modules/web/client/src/main/webapp/styles/observe.scss
@@ -258,6 +258,10 @@ html {
   display: flex;
   flex-direction: column;
   height: 100%;
+
+  .ObservationArea-sequenceTableExpandButton {
+    margin: 0 0 15px 10px;
+  }
 }
 
 .ObserveStyles-observationAreaError {


### PR DESCRIPTION
Home.scala was the common ancestor between the React Portal source and target, so this also extracts a separate component that has a `useState` because I didn't want to have the `useState`in the Home.scala.
