### PR TITLE
Upgrade libs with the now required explicit circe codecs

### DIFF
--- a/modules/model/shared/src/main/scala/observe/model/Conditions.scala
+++ b/modules/model/shared/src/main/scala/observe/model/Conditions.scala
@@ -4,7 +4,10 @@
 package observe.model
 
 import cats.Eq
+import cats.derived.*
 import cats.syntax.all.*
+import io.circe.Decoder
+import io.circe.Encoder
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.SkyBackground
@@ -12,14 +15,16 @@ import lucuma.core.enums.WaterVapor
 import monocle.Focus
 import monocle.Lens
 
-final case class Conditions(
+case class Conditions(
   ce: Option[CloudExtinction],
   iq: Option[ImageQuality],
   sb: Option[SkyBackground],
   wv: Option[WaterVapor]
-)
+) derives Eq,
+      Encoder.AsObject,
+      Decoder
 
-object Conditions {
+object Conditions:
 
   val Unknown: Conditions =
     Conditions(
@@ -58,12 +63,7 @@ object Conditions {
   val Default: Conditions =
     Unknown // Taken from ODB
 
-  given Eq[Conditions] =
-    Eq.by(x => (x.ce, x.iq, x.sb, x.wv))
-
   val ce: Lens[Conditions, Option[CloudExtinction]] = Focus[Conditions](_.ce)
   val iq: Lens[Conditions, Option[ImageQuality]]    = Focus[Conditions](_.iq)
   val sb: Lens[Conditions, Option[SkyBackground]]   = Focus[Conditions](_.sb)
   val wv: Lens[Conditions, Option[WaterVapor]]      = Focus[Conditions](_.wv)
-
-}

--- a/modules/model/shared/src/main/scala/observe/model/InstrumentDynamicConfig.scala
+++ b/modules/model/shared/src/main/scala/observe/model/InstrumentDynamicConfig.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.model
+
+import cats.Eq
+import cats.syntax.either.*
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.Encoder
+import io.circe.JsonObject
+import io.circe.syntax.*
+import lucuma.core.enums.Instrument
+import lucuma.core.model.sequence.gmos.DynamicConfig
+import lucuma.odb.json.gmos.given
+import lucuma.odb.json.time.transport.given
+import lucuma.odb.json.wavelength.transport.given
+
+// The whole purpose of this class is to bundle the instrument with its dynamic configuration,
+// so that the dynamic configuration can be decoded correctly.
+enum InstrumentDynamicConfig(val instrument: Instrument):
+  def config: DynamicConfig
+
+  case GmosNorth(config: DynamicConfig.GmosNorth)
+      extends InstrumentDynamicConfig(Instrument.GmosNorth)
+
+  case GmosSouth(config: DynamicConfig.GmosSouth)
+      extends InstrumentDynamicConfig(Instrument.GmosSouth)
+
+object InstrumentDynamicConfig:
+  // object GmosNorth:
+  //   given Eq[InstrumentDynamicConfig.GmosNorth] = Eq.by(x => (x.instrument, x.config))
+  // object GmosSouth:
+  //   given Eq[InstrumentDynamicConfig.GmosSouth] = Eq.by(x => (x.instrument, x.config))
+
+  given Eq[InstrumentDynamicConfig] = Eq.by(x => (x.instrument, x.config))
+  // case xInstrumentDynamicConfig.GmosNorth => x
+  // case x: InstrumentDynamicConfig.GmosSouth => x
+
+  given Encoder.AsObject[InstrumentDynamicConfig] = Encoder.AsObject.instance: idc =>
+    JsonObject(
+      "instrument" -> idc.instrument.asJson,
+      "config"     -> (idc match
+        case InstrumentDynamicConfig.GmosNorth(config) => config.asJson
+        case InstrumentDynamicConfig.GmosSouth(config) => config.asJson
+      )
+    )
+
+  given Decoder[InstrumentDynamicConfig] = Decoder.instance: c =>
+    c.downField("instrument")
+      .as[Instrument]
+      .flatMap:
+        case Instrument.GmosNorth =>
+          c.downField("config")
+            .as[DynamicConfig.GmosNorth]
+            .map(InstrumentDynamicConfig.GmosNorth(_))
+        case Instrument.GmosSouth =>
+          c.downField("config")
+            .as[DynamicConfig.GmosSouth]
+            .map(InstrumentDynamicConfig.GmosSouth(_))
+        case i                    =>
+          DecodingFailure(
+            s"Attempted to decode InstrumentDynamicConfig with unavailable instrument: $i",
+            c.history
+          ).asLeft
+
+  def fromDynamicConfig(config: DynamicConfig): InstrumentDynamicConfig =
+    config match
+      case c @ DynamicConfig.GmosNorth(_, _, _, _, _, _, _) => InstrumentDynamicConfig.GmosNorth(c)
+      case c @ DynamicConfig.GmosSouth(_, _, _, _, _, _, _) => InstrumentDynamicConfig.GmosSouth(c)

--- a/modules/model/shared/src/main/scala/observe/model/InstrumentDynamicConfig.scala
+++ b/modules/model/shared/src/main/scala/observe/model/InstrumentDynamicConfig.scala
@@ -28,14 +28,7 @@ enum InstrumentDynamicConfig(val instrument: Instrument):
       extends InstrumentDynamicConfig(Instrument.GmosSouth)
 
 object InstrumentDynamicConfig:
-  // object GmosNorth:
-  //   given Eq[InstrumentDynamicConfig.GmosNorth] = Eq.by(x => (x.instrument, x.config))
-  // object GmosSouth:
-  //   given Eq[InstrumentDynamicConfig.GmosSouth] = Eq.by(x => (x.instrument, x.config))
-
   given Eq[InstrumentDynamicConfig] = Eq.by(x => (x.instrument, x.config))
-  // case xInstrumentDynamicConfig.GmosNorth => x
-  // case x: InstrumentDynamicConfig.GmosSouth => x
 
   given Encoder.AsObject[InstrumentDynamicConfig] = Encoder.AsObject.instance: idc =>
     JsonObject(

--- a/modules/model/shared/src/main/scala/observe/model/ObserveStep.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ObserveStep.scala
@@ -23,9 +23,6 @@ import monocle.syntax.all.*
 import observe.model.dhs.*
 import observe.model.enums.*
 import observe.model.enums.PendingObserveCmd
-// import observe.model.codecs.given
-// import lucuma.odb.json.sequence.given
-// import lucuma.schemas.odb.given
 
 enum ObserveStep(
   val id:           Step.Id,

--- a/modules/model/shared/src/main/scala/observe/model/ObserveStep.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ObserveStep.scala
@@ -12,12 +12,8 @@ import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.StepConfig
-import lucuma.core.model.sequence.gmos.DynamicConfig
-import lucuma.odb.json.gmos.given
 import lucuma.odb.json.offset.transport.given
 import lucuma.odb.json.stepconfig.given
-import lucuma.odb.json.time.transport.given
-import lucuma.odb.json.wavelength.transport.given
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
@@ -27,10 +23,13 @@ import monocle.syntax.all.*
 import observe.model.dhs.*
 import observe.model.enums.*
 import observe.model.enums.PendingObserveCmd
+// import observe.model.codecs.given
+// import lucuma.odb.json.sequence.given
+// import lucuma.schemas.odb.given
 
 enum ObserveStep(
   val id:           Step.Id,
-  val instConfig:   DynamicConfig,
+  val instConfig:   InstrumentDynamicConfig,
   val stepConfig:   StepConfig,
   val status:       StepState,
   val breakpoint:   Breakpoint,
@@ -42,7 +41,7 @@ enum ObserveStep(
       Decoder:
   case Standard(
     override val id:           Step.Id,
-    override val instConfig:   DynamicConfig,
+    override val instConfig:   InstrumentDynamicConfig,
     override val stepConfig:   StepConfig,
     override val status:       StepState,
     override val breakpoint:   Breakpoint,
@@ -54,7 +53,7 @@ enum ObserveStep(
 
   case NodAndShuffle(
     override val id:           Step.Id,
-    override val instConfig:   DynamicConfig,
+    override val instConfig:   InstrumentDynamicConfig,
     override val stepConfig:   StepConfig,
     override val status:       StepState,
     override val breakpoint:   Breakpoint,
@@ -117,8 +116,8 @@ object ObserveStep:
       }
     }
 
-  def instConfig: Lens[ObserveStep, DynamicConfig] =
-    Lens[ObserveStep, DynamicConfig] {
+  def instConfig: Lens[ObserveStep, InstrumentDynamicConfig] =
+    Lens[ObserveStep, InstrumentDynamicConfig] {
       _.instConfig
     } { d =>
       {

--- a/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
@@ -6,13 +6,15 @@ package observe.model
 import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
+import io.circe.Decoder
+import io.circe.Encoder
 import lucuma.core.util.Display
 import monocle.Focus
 import monocle.Lens
 import monocle.Prism
 import monocle.macros.GenPrism
 
-enum SequenceState(val name: String) derives Eq:
+enum SequenceState(val name: String) derives Eq, Encoder, Decoder:
   case Idle                                              extends SequenceState("Idle")
   case Running(userStop: Boolean, internalStop: Boolean) extends SequenceState("Running")
   case Completed                                         extends SequenceState("Completed")

--- a/modules/model/shared/src/main/scala/observe/model/SystemOverrides.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SystemOverrides.scala
@@ -5,6 +5,8 @@ package observe.model
 
 import cats.Eq
 import cats.derived.*
+import io.circe.Decoder
+import io.circe.Encoder
 import monocle.Focus
 import monocle.Lens
 
@@ -13,7 +15,9 @@ case class SystemOverrides(
   isInstrumentEnabled: SubsystemEnabled,
   isGcalEnabled:       SubsystemEnabled,
   isDhsEnabled:        SubsystemEnabled
-) derives Eq:
+) derives Eq,
+      Encoder.AsObject,
+      Decoder:
   def disableTcs: SystemOverrides = copy(isTcsEnabled = SubsystemEnabled.Disabled)
 
   def enableTcs: SystemOverrides = copy(isTcsEnabled = SubsystemEnabled.Enabled)

--- a/modules/model/shared/src/main/scala/observe/model/arb/ArbInstrumentDynamicConfig.scala
+++ b/modules/model/shared/src/main/scala/observe/model/arb/ArbInstrumentDynamicConfig.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.model.arb
+
+import lucuma.core.model.sequence.gmos.DynamicConfig
+import lucuma.core.model.sequence.gmos.arb.ArbDynamicConfig.given
+import observe.model.InstrumentDynamicConfig
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbInstrumentDynamicConfig:
+  given Arbitrary[InstrumentDynamicConfig] = Arbitrary:
+    Gen.oneOf(
+      arbitrary[DynamicConfig.GmosNorth].map(InstrumentDynamicConfig.GmosNorth(_)),
+      arbitrary[DynamicConfig.GmosSouth].map(InstrumentDynamicConfig.GmosSouth(_))
+    )
+
+  given Cogen[InstrumentDynamicConfig] =
+    Cogen[Either[DynamicConfig.GmosNorth, DynamicConfig.GmosSouth]].contramap:
+      case InstrumentDynamicConfig.GmosNorth(c) => Left(c)
+      case InstrumentDynamicConfig.GmosSouth(c) => Right(c)
+
+object ArbInstrumentDynamicConfig extends ArbInstrumentDynamicConfig

--- a/modules/model/shared/src/main/scala/observe/model/arb/ArbNodAndShuffleStep.scala
+++ b/modules/model/shared/src/main/scala/observe/model/arb/ArbNodAndShuffleStep.scala
@@ -8,8 +8,6 @@ import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.arb.ArbStepConfig.given
-import lucuma.core.model.sequence.gmos.DynamicConfig
-import lucuma.core.model.sequence.gmos.arb.ArbDynamicConfig.given
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.arb.ArbEnumerated.given
 import lucuma.core.util.arb.ArbTimeSpan.given
@@ -27,6 +25,7 @@ import org.scalacheck.Gen
 
 import ArbDhsTypes.given
 import ArbGmosParameters.given
+import ArbInstrumentDynamicConfig.given
 import ArbNsRunningState.given
 import ArbStepState.given
 import ArbSystem.given
@@ -57,7 +56,7 @@ trait ArbNodAndShuffleStep {
     Arbitrary[ObserveStep.NodAndShuffle] {
       for {
         id <- arbitrary[Step.Id]
-        d  <- arbitrary[DynamicConfig]
+        d  <- arbitrary[InstrumentDynamicConfig]
         t  <- arbitrary[StepConfig]
         s  <- arbitrary[StepState]
         b  <- arbitrary[Breakpoint]
@@ -84,7 +83,7 @@ trait ArbNodAndShuffleStep {
     Cogen[
       (
         Step.Id,
-        DynamicConfig,
+        InstrumentDynamicConfig,
         StepConfig,
         StepState,
         Breakpoint,

--- a/modules/model/shared/src/main/scala/observe/model/arb/ArbStandardStep.scala
+++ b/modules/model/shared/src/main/scala/observe/model/arb/ArbStandardStep.scala
@@ -8,8 +8,6 @@ import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.arb.ArbStepConfig.given
-import lucuma.core.model.sequence.gmos.DynamicConfig
-import lucuma.core.model.sequence.gmos.arb.ArbDynamicConfig.given
 import lucuma.core.util.arb.ArbEnumerated.given
 import lucuma.core.util.arb.ArbUid.given
 import observe.model.*
@@ -19,6 +17,7 @@ import org.scalacheck.Arbitrary.*
 import org.scalacheck.Cogen
 
 import ArbDhsTypes.given
+import ArbInstrumentDynamicConfig.given
 import ArbStepState.given
 import ArbSystem.given
 
@@ -27,7 +26,7 @@ trait ArbStandardStep {
   given Arbitrary[ObserveStep.Standard] = Arbitrary[ObserveStep.Standard] {
     for {
       id <- arbitrary[Step.Id]
-      d  <- arbitrary[DynamicConfig]
+      d  <- arbitrary[InstrumentDynamicConfig]
       t  <- arbitrary[StepConfig]
       s  <- arbitrary[StepState]
       b  <- arbitrary[Breakpoint]
@@ -52,7 +51,7 @@ trait ArbStandardStep {
     Cogen[
       (
         Step.Id,
-        DynamicConfig,
+        InstrumentDynamicConfig,
         StepConfig,
         StepState,
         Breakpoint,

--- a/modules/model/shared/src/main/scala/observe/model/events/ClientEvent.scala
+++ b/modules/model/shared/src/main/scala/observe/model/events/ClientEvent.scala
@@ -26,7 +26,6 @@ import observe.model.Operator
 import observe.model.SequenceView
 import observe.model.SequencesQueue
 import observe.model.UserPrompt.ChecksOverride
-import observe.model.UserPrompt.SeqCheck
 import observe.model.enums.Resource
 import observe.model.given
 import observe.model.odb.ObsRecordedIds

--- a/modules/server_new/src/clue/scala/observe/common/ObsQueriesGQL.scala
+++ b/modules/server_new/src/clue/scala/observe/common/ObsQueriesGQL.scala
@@ -314,6 +314,18 @@ object ObsQueriesGQL:
       """
 
   @GraphQL
+  trait AddAtomEventMutation extends GraphQLOperation[ObservationDB]:
+    val document = """
+      mutation($atomId: AtomId!, $stg: AtomStage!)  {
+        addAtomEvent(input: { atomId: $atomId, atomStage: $stg } ) {
+          event {
+            id
+          }
+        }
+      }
+      """
+
+  @GraphQL
   trait AddStepEventMutation extends GraphQLOperation[ObservationDB]:
     val document = """
       mutation($stepId: StepId!, $stg: StepStage!)  {

--- a/modules/server_new/src/main/scala/observe/server/StepsView.scala
+++ b/modules/server_new/src/main/scala/observe/server/StepsView.scala
@@ -13,6 +13,7 @@ import observe.engine.Action
 import observe.engine.Action.ActionState
 import observe.engine.ParallelActions
 import observe.model.ActionType
+import observe.model.InstrumentDynamicConfig
 import observe.model.ObserveStep
 import observe.model.StepState
 import observe.model.dhs.ImageFileId
@@ -149,7 +150,7 @@ object StepsView {
 
       ObserveStep.Standard(
         id = step.id,
-        instConfig = stepg.instConfig,
+        instConfig = InstrumentDynamicConfig.fromDynamicConfig(stepg.instConfig),
         stepConfig = stepg.config,
         status = status,
         breakpoint = step.breakpoint,

--- a/modules/server_new/src/main/scala/observe/server/gmos/GmosStepsView.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/GmosStepsView.scala
@@ -51,7 +51,7 @@ class GmosStepsView[F[_]] extends StepsView[F] {
 
         ObserveStep.NodAndShuffle(
           id = step.id,
-          instConfig = stepg.instConfig,
+          instConfig = InstrumentDynamicConfig.fromDynamicConfig(stepg.instConfig),
           stepConfig = stepg.config,
           status = status,
           breakpoint = step.breakpoint,

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/CurrentAtomStepRow.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/CurrentAtomStepRow.scala
@@ -17,8 +17,7 @@ case class CurrentAtomStepRow[+D](
   signalToNoise: Option[SignalToNoise] = none // TODO Propagate S/N through the server
 ) extends SequenceRow[D]:
   val id                   = step.id.asRight
-  // TODO We should type-parameterize ObserveStep on D and get rid of this cast
-  val instrumentConfig     = step.instConfig.asInstanceOf[D].some
+  val instrumentConfig     = step.instConfig.config.asInstanceOf[D].some
   val stepConfig           = step.stepConfig.some
   val isFinished           = step.status.isFinished
   // TODO This could be an estimate for pending steps, or the time it took for finished steps.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -27,7 +27,7 @@ object Settings {
     val coulomb          = "0.8.0"
     val commonsHttp      = "3.1"
     val unboundId        = "3.2.1"
-    val jwt              = "10.0.0"
+    val jwt              = "10.0.1"
     val slf4j            = "2.0.13"
     val log4cats         = "2.7.0"
     val log4catsLogLevel = "0.3.1"
@@ -35,7 +35,7 @@ object Settings {
     val janino           = "3.1.12"
     val pureConfig       = "0.17.6"
     val monocleVersion   = "3.2.0"
-    val circeVersion     = "0.14.6"
+    val circeVersion     = "0.14.7"
 
     // test libraries
     val jUnitInterface         = "0.13.2"
@@ -49,11 +49,11 @@ object Settings {
     val pprint        = "0.9.0"
 
     // Gemini Libraries
-    val lucumaCore      = "0.96.1"
+    val lucumaCore      = "0.97.1"
     val lucumaUI        = "0.101.3"
-    val lucumaSchemas   = "0.81.1"
+    val lucumaSchemas   = "0.81.5"
     val lucumaSSO       = "0.6.17"
-    val lucumaODBSchema = "0.11.5"
+    val lucumaODBSchema = "0.11.7"
 
     // Clue
     val clue = "0.35.2"


### PR DESCRIPTION
The new version of circe requires explicit codecs, whereas previous versions would derive codecs for all referenced classes.

This means that we now have to save the instrument in `ObserveStep` in order to be able to decode the correct `DynamicConfig` (I have no idea what circe what doing with this before).

I created a wrapper `InstrumentDynamicConfig` solely for the purpose of transporting the generic `DynamicConfig`.