### PR TITLE
Atom start/end invocations in ODBProxy

### DIFF
--- a/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
+++ b/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
@@ -164,6 +164,9 @@ object TestOdbProxy {
         override def stepAbort(obsId: Observation.Id): F[Boolean] =
           addEvent(StepAbort(obsId)).as(true)
 
+        override def atomEnd(obsId: Observation.Id): F[Boolean] =
+          addEvent(AtomEnd(obsId)).as(true)
+
         override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
           addEvent(SequenceEnd(obsId)).as(true)
 
@@ -212,6 +215,7 @@ object TestOdbProxy {
   case class StepEndObserve(obsId: Observation.Id)                            extends OdbEvent
   case class StepEndStep(obsId: Observation.Id)                               extends OdbEvent
   case class StepAbort(obsId: Observation.Id)                                 extends OdbEvent
+  case class AtomEnd(obsId: Observation.Id)                                   extends OdbEvent
   case class SequenceEnd(obsId: Observation.Id)                               extends OdbEvent
   case class ObsAbort(obsId: Observation.Id, reason: String)                  extends OdbEvent
   case class ObsContinue(obsId: Observation.Id)                               extends OdbEvent

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -51,7 +51,7 @@ object Settings {
     // Gemini Libraries
     val lucumaCore      = "0.97.1"
     val lucumaUI        = "0.101.3"
-    val lucumaSchemas   = "0.81.5"
+    val lucumaSchemas   = "0.82.0"
     val lucumaSSO       = "0.6.17"
     val lucumaODBSchema = "0.11.7"
 


### PR DESCRIPTION
The actual record of the `StartAtom` event is already being executed as part of the `atomStart` method.

Invocation to `atomEnd` from the engine is pending.