### PR TITLE
Acquisition atoms on demand

### DIFF
--- a/modules/engine/src/main/scala/observe/engine/Event.scala
+++ b/modules/engine/src/main/scala/observe/engine/Event.scala
@@ -122,7 +122,4 @@ object Event {
   def singleRunFailed[F[_], S, U](c: ActionCoords, e: Result.Error): Event[F, S, U] =
     EventSystem[F, S, U](SingleRunFailed(c, e))
 
-  def atomCompleted[F[_], S, U](id: Observation.Id): Event[F, S, U] =
-    EventSystem[F, S, U](AtomCompleted(id))
-
 }

--- a/modules/engine/src/main/scala/observe/engine/Handle.scala
+++ b/modules/engine/src/main/scala/observe/engine/Handle.scala
@@ -101,8 +101,8 @@ object Handle {
       )
   }
 
-  extension [F[_]: Functor, D, V, A](self: StateT[F, D, A])
-    def toHandle: Handle[F, D, V, A] = Handle(self.map((_, None)))
+  extension [F[_]: Functor, D, A](self: StateT[F, D, A])
+    def toHandle[V]: Handle[F, D, V, A] = Handle[F, D, V, A](self.map((_, None)))
 
   def unit[F[_]: Monad, D, V]: Handle[F, D, V, Unit] =
     Applicative[Handle[F, D, V, *]].unit

--- a/modules/engine/src/main/scala/observe/engine/Sequence.scala
+++ b/modules/engine/src/main/scala/observe/engine/Sequence.scala
@@ -268,18 +268,18 @@ object Sequence {
     def userStopRequested[F[_]](st: State[F]): Boolean = st.status.userStopRequested
 
     def anyStopRequested[F[_]](st: State[F]): Boolean = st.status match {
-      case SequenceState.Running(u, i) => u || i
-      case _                           => false
+      case SequenceState.Running(u, i, _) => u || i
+      case _                              => false
     }
 
     def userStopSet[F[_]](v: Boolean): State[F] => State[F] = status.modify {
-      case r @ SequenceState.Running(_, _) => r.copy(userStop = v)
-      case r                               => r
+      case r @ SequenceState.Running(_, _, _) => r.copy(userStop = v)
+      case r                                  => r
     }
 
     def internalStopSet[F[_]](v: Boolean): State[F] => State[F] = status.modify {
-      case r @ SequenceState.Running(_, _) => r.copy(internalStop = v)
-      case r                               => r
+      case r @ SequenceState.Running(_, _, _) => r.copy(internalStop = v)
+      case r                                  => r
     }
 
     /**

--- a/modules/engine/src/main/scala/observe/engine/SystemEvent.scala
+++ b/modules/engine/src/main/scala/observe/engine/SystemEvent.scala
@@ -48,6 +48,4 @@ object SystemEvent {
       extends SystemEvent
   final case class SingleRunFailed(actionCoords: ActionCoords, e: Result.Error) extends SystemEvent
 
-  case class AtomCompleted(id: Observation.Id) extends SystemEvent
-
 }

--- a/modules/engine/src/test/scala/observe/engine/SequenceSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/SequenceSuite.scala
@@ -35,7 +35,7 @@ class SequenceSuite extends munit.CatsEffectSuite {
 
   private val executionEngine = Engine.build[IO, TestState, Unit](
     TestState,
-    _ => Handle.unit[IO, TestState, Event[IO, TestState, Unit]].pure[IO]
+    (eng, obsId) => eng.startNewAtom(obsId)
   )
 
   def simpleStep(id: Step.Id, breakpoint: Breakpoint): EngineStep[IO] =

--- a/modules/engine/src/test/scala/observe/engine/StepSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/StepSuite.scala
@@ -37,7 +37,7 @@ class StepSuite extends CatsEffectSuite {
 
   private val executionEngine = Engine.build[IO, TestState, Unit](
     TestState,
-    _ => Handle.unit[IO, TestState, Event[IO, TestState, Unit]].pure[IO]
+    (eng, obsId) => eng.startNewAtom(obsId)
   )
 
   private object DummyResult extends Result.RetVal with Serializable
@@ -339,7 +339,7 @@ class StepSuite extends CatsEffectSuite {
                ),
                done = Nil
              ),
-             SequenceState.Running(userStop = true, internalStop = false),
+             SequenceState.Running(userStop = true, internalStop = false, waitingNextAtom = false),
              Map.empty
            )
           )

--- a/modules/engine/src/test/scala/observe/engine/packageSpec.scala
+++ b/modules/engine/src/test/scala/observe/engine/packageSpec.scala
@@ -121,7 +121,7 @@ class packageSpec extends munit.CatsEffectSuite {
 
   private def executionEngine = Engine.build[IO, TestState, Unit](
     TestState,
-    _ => Handle.unit[IO, TestState, Event[IO, TestState, Unit]].pure[IO]
+    (eng, obsId) => eng.startNewAtom(obsId)
   )
 
   def isFinished(status: SequenceState): Boolean = status match {

--- a/modules/model/shared/src/main/scala/observe/model/SequenceView.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceView.scala
@@ -34,10 +34,10 @@ case class SequenceView(
 
   // Returns where on the sequence the execution is at
   def runningStep: Option[RunningStep] = status match
-    case SequenceState.Running(_, _) => progress
-    case SequenceState.Failed(_)     => progress
-    case SequenceState.Aborted       => progress
-    case _                           => none
+    case SequenceState.Running(_, _, _) => progress
+    case SequenceState.Failed(_)        => progress
+    case SequenceState.Aborted          => progress
+    case _                              => none
 
   def pausedStep = steps.find(_.isObservePaused).map(_.id).map(PausedStep(_))
 

--- a/modules/model/shared/src/main/scala/observe/model/arb/ObserveModelArbitraries.scala
+++ b/modules/model/shared/src/main/scala/observe/model/arb/ObserveModelArbitraries.scala
@@ -100,7 +100,8 @@ trait ObserveModelArbitraries {
     for {
       u <- arbitrary[Boolean]
       i <- arbitrary[Boolean]
-    } yield SequenceState.Running(u, i)
+      a <- arbitrary[Boolean]
+    } yield SequenceState.Running(u, i, a)
   }
 
   given Arbitrary[SequenceState] = Arbitrary[SequenceState] {

--- a/modules/model/shared/src/test/scala/observe/common/test/package.scala
+++ b/modules/model/shared/src/test/scala/observe/common/test/package.scala
@@ -18,5 +18,6 @@ def stepId(i: Int): Step.Id = i match {
   case 3 => Step.Id(UUID.fromString("bbdd559c-19a3-11ed-861d-0242ac120002"))
   case 4 => Step.Id(UUID.fromString("2e986c9c-e393-4c89-b683-80184642fdf8"))
   case 5 => Step.Id(UUID.fromString("a1bd2538-19a9-11ed-861d-0242ac120002"))
+  case 6 => Step.Id(UUID.fromString("27b0b124-2a43-4baf-b587-5e5a2b90f5cc"))
   case _ => Step.Id(UUID.fromString("c65addaa-19a3-11ed-861d-0242ac120002"))
 }

--- a/modules/server_new/src/main/scala/observe/server/syntax.scala
+++ b/modules/server_new/src/main/scala/observe/server/syntax.scala
@@ -29,7 +29,7 @@ extension [F[_], A, B](fa: EitherT[F, A, B])
   ): F[B] =
     fa.leftMap(at).rethrowT
 
-extension [F[_]](q: ExecutionQueue)
+extension [F[_]](q:                 ExecutionQueue)
   // This assumes that there is only one instance of e in l
   private def moveElement[T](l: List[T], e: T => Boolean, delta: Int)(using eq: Eq[T]): List[T] =
     (l.indexWhere(e), l.find(e)) match
@@ -64,11 +64,10 @@ extension [F[_]](q: ExecutionQueue)
     )
   def clear: ExecutionQueue                                             = q.copy(queue = List.empty)
 
-implicit final class ToHandle[F[_]: Applicative, A](f: EngineState[F] => (EngineState[F], A)) {
-  import Handle.toHandle
-
+import Handle.{toHandle => toHandleT}
+extension [F[_]: Applicative, A](f: EngineState[F] => (EngineState[F], A)) {
   def toHandle: HandlerType[F, A] =
-    StateT[F, EngineState[F], A](st => f(st).pure[F]).toHandle
+    StateT[F, EngineState[F], A](st => f(st).pure[F]).toHandleT[EventType[F]]
 }
 
 extension (r: Either[Throwable, Response])

--- a/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
@@ -76,7 +76,8 @@ object SessionQueue:
         case (Some(Pot.Ready(_)), Some(SequenceState.Idle))                                => Icons.FileCheck
         case (Some(Pot.Ready(_)), Some(SequenceState.Completed))                           =>
           Icons.FileCheck // clazz = selectedIconStyle)
-        case (Some(Pot.Ready(_)), Some(SequenceState.Running(_, _)))                       => Icons.CircleNotch.withSpin()
+        case (Some(Pot.Ready(_)), Some(SequenceState.Running(_, _, _)))                    =>
+          Icons.CircleNotch.withSpin()
         //      clazz = ObserveStyles.runningIcon
         case (Some(Pot.Ready(_)), Some(SequenceState.Failed(_))) | (Some(Pot.Error(_)), _) =>
           Icons.FileCross

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveCommandRoutes.scala
@@ -72,7 +72,7 @@ class ObserveCommandRoutes[F[_]: Async: Compression](
     case req @ POST -> Root / ObsIdVar(obsId) / ClientIDVar(clientId) / "loadNextAtom" /
         ObserverVar(obs) / SequenceTypeVar(seqType) =>
       ssoClient.require(req): user =>
-        oe.loadNextAtom(obsId, user, obs, clientId, seqType, true) *>
+        oe.loadNextAtom(obsId, user, obs, seqType) *>
           NoContent()
 
     case req @ POST -> Root / ObsIdVar(obsId) / StepIdVar(stepId) / ClientIDVar(clientId) /

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
@@ -218,9 +218,7 @@ class TestObserveEngine[F[_]: Sync: Logger](sys: Systems[F]) extends ObserveEngi
     id:       Observation.Id,
     user:     User,
     observer: Observer,
-    clientId: ClientId,
-    atomType: SequenceType,
-    run:      Boolean
+    atomType: SequenceType
   ): F[Unit] = Applicative[F].unit
 }
 

--- a/modules/web_old/client/src/main/scala/observe/web/client/components/SessionQueueTable.scala
+++ b/modules/web_old/client/src/main/scala/observe/web/client/components/SessionQueueTable.scala
@@ -443,7 +443,7 @@ object SessionQueueTable extends Columns {
         row.status match {
           case SequenceState.Completed                     =>
             Icon(name = "checkmark", clazz = selectedIconStyle)
-          case SequenceState.Running(_, _)                 =>
+          case SequenceState.Running(_, _, _)                 =>
             Icon(name = "circle notched",
                  fitted = true,
                  loading = true,

--- a/modules/web_old/client/src/main/scala/observe/web/client/components/queue/CalQueueTable.scala
+++ b/modules/web_old/client/src/main/scala/observe/web/client/components/queue/CalQueueTable.scala
@@ -280,7 +280,7 @@ object CalQueueTable {
         row.status match {
           case SequenceState.Completed     =>
             IconCheckmark.clazz(selectedIconStyle)
-          case SequenceState.Running(_, _) =>
+          case SequenceState.Running(_, _, _) =>
             IconCircleNotched.copy(fitted = true, loading = true, clazz = ObserveStyles.runningIcon)
           case SequenceState.Failed(_)     =>
             IconAttention.copy(color = Red, clazz = selectedIconStyle)

--- a/modules/web_old/client/src/main/scala/observe/web/client/components/tabs/ObserveTabs.scala
+++ b/modules/web_old/client/src/main/scala/observe/web/client/components/tabs/ObserveTabs.scala
@@ -37,7 +37,7 @@ object ObserveTabs {
         val model                = x()
         val tabsL                = model.tabs.toList
         val runningInstruments   = tabsL.collect {
-          case Right(AvailableTab(_, SequenceState.Running(_, _), i, _, _, false, _, _, _, _, _)) =>
+          case Right(AvailableTab(_, SequenceState.Running(_, _, _), i, _, _, false, _, _, _, _, _)) =>
             i
         }
         val tabs: List[VdomNode] =

--- a/modules/web_old/client/src/main/scala/observe/web/client/components/tabs/SequenceTab.scala
+++ b/modules/web_old/client/src/main/scala/observe/web/client/components/tabs/SequenceTab.scala
@@ -126,14 +126,14 @@ object SequenceTab {
       }
 
       val icon: Icon = status match {
-        case SequenceState.Running(_, _) =>
+        case SequenceState.Running(_, _, _) =>
           IconCircleNotched.loading()
         case SequenceState.Completed     => IconCheckmark
         case _                           => IconSelectedRadio
       }
 
       val color = status match {
-        case SequenceState.Running(_, _) => Orange
+        case SequenceState.Running(_, _, _) => Orange
         case SequenceState.Completed     => Green
         case _                           => Grey
       }

--- a/modules/web_old/client/src/main/scala/observe/web/client/model/ModelOps.scala
+++ b/modules/web_old/client/src/main/scala/observe/web/client/model/ModelOps.scala
@@ -20,8 +20,8 @@ object ModelOps {
   given Show[SequenceState] =
     Show.show[SequenceState] {
       case SequenceState.Completed        => "Complete"
-      case SequenceState.Running(true, _) => "Pausing..."
-      case SequenceState.Running(_, _)    => "Running"
+      case SequenceState.Running(true, _, _) => "Pausing..."
+      case SequenceState.Running(_, _, _)    => "Running"
       case SequenceState.Idle             => "Idle"
       case SequenceState.Aborted          => "Aborted"
       case SequenceState.Failed(_)        => s"Error at step "


### PR DESCRIPTION
This PR implements the request of new acquisition atoms on demand. Now the backend will wait for a user command at the end of acquisition atoms, command that will tell it if it must request a new acquisition atom, or proceed with the science atoms. New science atoms are requested automatically at the end of a science atom.
This PR also adds the atomEnd event. 
