### PR TITLE
Move execution state to table meta

### DIFF
--- a/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
@@ -16,7 +16,6 @@ import lucuma.react.fa.IconSize
 import lucuma.react.primereact.Button
 import lucuma.react.syntax.*
 import lucuma.react.table.*
-import lucuma.typed.tanstackTableCore as raw
 import lucuma.ui.reusability.given
 import lucuma.ui.table.*
 import observe.model.RunningStep
@@ -137,9 +136,9 @@ object SessionQueue:
   private def renderCentered(node: VdomNode, css: Css = Css.Empty): VdomNode =
     <.div(ObserveStyles.Centered |+| css)(node)
 
-  private def linked[T, A](
-    f: raw.buildLibCoreCellMod.CellContext[T, A] => VdomNode
-  ): raw.buildLibCoreCellMod.CellContext[T, A] => VdomNode =
+  private def linked[T, A, TM, CM](
+    f: CellContext[T, A, TM, CM] => VdomNode
+  ): CellContext[T, A, TM, CM] => VdomNode =
     f // .andThen(node => renderCell(node))
     //  (_, _, _, row: SessionQueueRow, _) =>
     //    linkTo(p, pageOf(row))(ObserveStyles.queueTextColumn, <.p(ObserveStyles.queueText, f(row)))
@@ -272,7 +271,7 @@ object SessionQueue:
                 ^.onClick --> props.selectObs(row.original.obsId)
               ),
             cellMod = cell =>
-              ColumnId(cell.column.id) match
+              cell.column.id match
                 case StatusIconColumnId => ObserveStyles.LoadButtonCell
                 case _                  => TagMod.empty
             ,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -50,7 +50,7 @@ object Settings {
 
     // Gemini Libraries
     val lucumaCore      = "0.97.1"
-    val lucumaUI        = "0.102.0"
+    val lucumaUI        = "0.103.0"
     val lucumaSchemas   = "0.83.0"
     val lucumaSSO       = "0.6.17"
     val lucumaODBSchema = "0.11.7"
@@ -61,7 +61,7 @@ object Settings {
     // ScalaJS libraries
     val crystal      = "0.37.3"
     val javaTimeJS   = "2.5.0"
-    val lucumaReact  = "0.61.1"
+    val lucumaReact  = "0.63.0"
     val scalaDom     = "2.3.0"
     val scalajsReact = "3.0.0-beta3"
   }


### PR DESCRIPTION
This is now possible with the new react-table facade.

It prevents table components from remounting on each execution status update.

There are other migrations to the new table facade too.

Note: The progress bar lost its "smoothness". Its current code compensates for the the remounts, and the logic has to be simplified now. Will be addressed in a future PR.