### PR TITLE
Notify user of errors in engine

### DIFF
--- a/modules/model/shared/src/main/scala/observe/model/Notification.scala
+++ b/modules/model/shared/src/main/scala/observe/model/Notification.scala
@@ -6,11 +6,13 @@ package observe.model
 import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
+import io.circe.Decoder
+import io.circe.Encoder
 import lucuma.core.enums.Instrument
 import lucuma.core.model.sequence.Step
 import observe.model.enums.Resource
 
-enum Notification derives Eq:
+enum Notification derives Eq, Encoder, Decoder:
   // Notification that user tried to run a sequence that used resource already in use
   case ResourceConflict(obsId: Observation.Id)                 extends Notification
   // Notification that user tried to select a sequence for an instrument for which a sequence was already running

--- a/modules/model/shared/src/main/scala/observe/model/events/ClientEvent.scala
+++ b/modules/model/shared/src/main/scala/observe/model/events/ClientEvent.scala
@@ -21,6 +21,7 @@ import lucuma.core.util.Enumerated
 import observe.model.ClientConfig
 import observe.model.Conditions
 import observe.model.ExecutionState
+import observe.model.Notification
 import observe.model.ObservationProgress
 import observe.model.Operator
 import observe.model.SequenceView
@@ -93,6 +94,11 @@ object ClientEvent:
   case class AtomLoaded(obsId: Observation.Id, sequenceType: SequenceType, atomId: Atom.Id)
       extends AllClientEvent derives Eq, Encoder.AsObject, Decoder
 
+  case class UserNotification(memo: Notification) extends SingleClientEvent
+      derives Eq,
+        Encoder.AsObject,
+        Decoder
+
   given Encoder[ClientEvent] = Encoder.instance:
     case e @ BaDum                            => e.asJson
     case e @ InitialEvent(_)                  => e.asJson
@@ -101,6 +107,7 @@ object ClientEvent:
     case e @ ChecksOverrideEvent(_)           => e.asJson
     case e @ ProgressEvent(_)                 => e.asJson
     case e @ AtomLoaded(_, _, _)              => e.asJson
+    case e @ UserNotification(_)              => e.asJson
 
   given Decoder[ClientEvent] =
     List[Decoder[ClientEvent]](
@@ -110,5 +117,6 @@ object ClientEvent:
       Decoder[SingleActionEvent].widen,
       Decoder[ChecksOverrideEvent].widen,
       Decoder[ProgressEvent].widen,
-      Decoder[AtomLoaded].widen
+      Decoder[AtomLoaded].widen,
+      Decoder[UserNotification].widen
     ).reduceLeft(_ or _)


### PR DESCRIPTION
Notification events from the engine now make it all the way to the clients, where they are displayed in a sticky toast.