### PR TITLE
Make observe reload the current atom at the end of each step

### DIFF
--- a/modules/engine/src/main/scala/observe/engine/Event.scala
+++ b/modules/engine/src/main/scala/observe/engine/Event.scala
@@ -102,8 +102,9 @@ object Event {
     EventSystem[F, S, U](BreakpointReached(id))
   def busy[F[_], S, U](id: Observation.Id, clientId: ClientId): Event[F, S, U]         =
     EventSystem[F, S, U](Busy(id, clientId))
-  def executed[F[_], S, U](id: Observation.Id): Event[F, S, U] = EventSystem[F, S, U](Executed(id))
-  def executing[F[_], S, U](id: Observation.Id): Event[F, S, U] =
+  def executed[F[_], S, U](id: Observation.Id): Event[F, S, U]                         =
+    EventSystem[F, S, U](Executed(id))
+  def executing[F[_], S, U](id: Observation.Id): Event[F, S, U]                        =
     EventSystem[F, S, U](Executing(id))
   def finished[F[_], S, U](id: Observation.Id): Event[F, S, U] = EventSystem[F, S, U](Finished(id))
   def nullEvent[F[_], S, U]: Event[F, S, U]                                         = EventSystem[F, S, U](Null)

--- a/modules/engine/src/main/scala/observe/engine/Handle.scala
+++ b/modules/engine/src/main/scala/observe/engine/Handle.scala
@@ -14,8 +14,15 @@ import fs2.Stream
  * Type constructor where all Observe side effect are managed. Handle is a State machine inside a F,
  * which can produce Streams as output. It is combined with the input stream to run observe engine.
  *
- * Its type parameters are: A: Type of the output (usually Unit) V: Type of the events D: Type of
- * the state machine state.
+ * Its type parameters are:
+ * @tparam A:
+ *   Type of the output (usually Unit)
+ * @tparam V:
+ *   Type of the events
+ * @tparam F[_]:
+ *   Type of the effect
+ * @tparam D:
+ *   Type of the state machine state.
  */
 final case class Handle[F[_], D, V, A](run: StateT[F, D, (A, Option[Stream[F, V]])])
 

--- a/modules/engine/src/main/scala/observe/engine/Sequence.scala
+++ b/modules/engine/src/main/scala/observe/engine/Sequence.scala
@@ -155,6 +155,11 @@ object Sequence {
      */
     val next: Option[State[F]]
 
+    /**
+     * Tells if we are at the last action of the current step
+     */
+    val isLastAction: Boolean
+
     val status: SequenceState
 
     val pending: List[EngineStep[F]]
@@ -289,6 +294,9 @@ object Sequence {
         case Some(x) => Zipper(x, status, singleRuns).some
       }
 
+      override val isLastAction: Boolean =
+        zipper.focus.pending.isEmpty
+
       /**
        * Current Execution
        */
@@ -396,6 +404,8 @@ object Sequence {
       override val next: Option[State[F]] = None
 
       override val current: Execution[F] = Execution.empty
+
+      override val isLastAction: Boolean = true
 
       override val currentStep: Option[EngineStep[F]] = none
 

--- a/modules/engine/src/test/scala/observe/engine/PackageSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/PackageSuite.scala
@@ -118,6 +118,7 @@ class PackageSuite extends munit.CatsEffectSuite {
 
   private def executionEngine = Engine.build[IO, TestState, Unit](
     TestState,
+    (eng, obsId) => eng.startNewAtom(obsId),
     (eng, obsId) => eng.startNewAtom(obsId)
   )
 

--- a/modules/engine/src/test/scala/observe/engine/SequenceSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/SequenceSuite.scala
@@ -35,6 +35,7 @@ class SequenceSuite extends munit.CatsEffectSuite {
 
   private val executionEngine = Engine.build[IO, TestState, Unit](
     TestState,
+    (eng, obsId) => eng.startNewAtom(obsId),
     (eng, obsId) => eng.startNewAtom(obsId)
   )
 

--- a/modules/engine/src/test/scala/observe/engine/StepSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/StepSuite.scala
@@ -37,6 +37,7 @@ class StepSuite extends CatsEffectSuite {
 
   private val executionEngine = Engine.build[IO, TestState, Unit](
     TestState,
+    (eng, obsId) => eng.startNewAtom(obsId),
     (eng, obsId) => eng.startNewAtom(obsId)
   )
 

--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -54,6 +54,7 @@ import observe.model.enums.PendingObserveCmd.*
 import observe.model.enums.Resource
 import observe.model.enums.RunOverride
 import observe.model.events.*
+import observe.server.SequenceGen.AtomGen
 import observe.server.events.*
 import observe.server.odb.OdbProxy
 import org.typelevel.log4cats.Logger
@@ -69,8 +70,6 @@ import ClientEvent.*
 trait ObserveEngine[F[_]] {
 
   val systems: Systems[F]
-
-  def sync(seqId: Observation.Id): F[Unit]
 
   def start(
     id:          Observation.Id,
@@ -254,11 +253,6 @@ object ObserveEngine {
     @annotation.unused conditionsRef: Ref[F, Conditions]
   ) extends ObserveEngine[F] {
 
-    // private val odbLoader = new ODBSequencesLoader[F](systems.odb, translator, executeEngine)
-
-    override def sync(seqId: Observation.Id): F[Unit] = Applicative[F].unit
-    //      odbLoader.loadEvents(seqId).flatMap(_.map(executeEngine.offer).sequence.void)
-    //
     /**
      * Check if the resources to run a sequence are available
      * @return
@@ -1635,7 +1629,8 @@ object ObserveEngine {
     rc  <- Ref.of[F, Conditions](Conditions.Default)
     tr  <- createTranslator(site, systems, rc)
     eng <- Engine.build[F, EngineState[F], SeqEvent](EngineState.engineState[F],
-                                                     onAtomComplete[F](systems.odb, tr)
+                                                     onAtomComplete[F](systems.odb, tr),
+                                                     onAtomReload[F](systems.odb, tr)
            )
   } yield new ObserveEngineImpl[F](eng, systems, conf, tr, rc)
 
@@ -1858,6 +1853,30 @@ object ObserveEngine {
         )
       }
 
+  private def updateAtom[F[_]](obsId: Observation.Id, atm: AtomGen[F]) = (st: EngineState[F]) =>
+    EngineState
+      .atSequence[F](obsId)
+      .modify { seq =>
+        val sg: SequenceData[F] =
+          seq.focus(_.seqGen.nextAtom).replace(atm)
+        sg
+          .focus(_.seq)
+          .modify(s =>
+            val ns = Sequence.State.init(
+              Sequence.sequence[F](
+                obsId,
+                atm.atomId,
+                toStepList(
+                  sg.seqGen,
+                  sg.overrides,
+                  HeaderExtraData(st.conditions, st.operator, sg.observer)
+                )
+              )
+            )
+            Sequence.State.status.replace(s.status)(ns)
+          )
+      }(st)
+
   private def tryNewAtom[F[_]: Monad](
     odb:           OdbProxy[F],
     translator:    SeqTranslate[F],
@@ -1873,37 +1892,14 @@ object ObserveEngine {
               .nextAtom(x, atomType)
               ._2
               .map { atm =>
-                Event.modifyState[F, EngineState[F], SeqEvent]({
-                    (st: EngineState[F]) =>
-                      val inst: Instrument = EngineState
-                        .atSequence[F](obsId)
-                        .getOption(st)
-                        .map(_.seqGen.instrument)
-                        .getOrElse(Instrument.GmosNorth)
-                      val state            = EngineState
-                        .atSequence[F](obsId)
-                        .modify { seq =>
-                          val sg: SequenceData[F] =
-                            seq.focus(_.seqGen.nextAtom).replace(atm)
-                          sg
-                            .focus(_.seq)
-                            .modify(s =>
-                              val ns = Sequence.State.init(
-                                Sequence.sequence[F](
-                                  obsId,
-                                  atm.atomId,
-                                  toStepList(
-                                    sg.seqGen,
-                                    sg.overrides,
-                                    HeaderExtraData(st.conditions, st.operator, sg.observer)
-                                  )
-                                )
-                              )
-                              Sequence.State.status.replace(s.status)(ns)
-                            )
-                        }(st)
-
-                      (state, inst)
+                Event.modifyState[F, EngineState[F], SeqEvent]({ (st: EngineState[F]) =>
+                    val inst: Instrument = EngineState
+                      .atSequence[F](obsId)
+                      .getOption(st)
+                      .map(_.seqGen.instrument)
+                      .getOrElse(Instrument.GmosNorth)
+                    val state            = updateAtom(obsId, atm)(st)
+                    (state, inst)
                   }.toHandle.flatMap(inst =>
                     executeEngine.startNewAtom(obsId) *>
                       Handle.liftF[F, EngineState[F], Event[F, EngineState[F], SeqEvent], SeqEvent](
@@ -1929,4 +1925,59 @@ object ObserveEngine {
         }
       )
 
+  private def onAtomReload[F[_]: Monad](
+    odb:           OdbProxy[F],
+    translator:    SeqTranslate[F]
+  )(
+    executeEngine: Engine[F, EngineState[F], SeqEvent],
+    obsId:         Observation.Id
+  ): Handle[F, EngineState[F], Event[F, EngineState[F], SeqEvent], SeqEvent] =
+    Handle
+      .get[F, EngineState[F], Event[F, EngineState[F], SeqEvent]]
+      .map(EngineState.atSequence[F](obsId).getOption)
+      .flatMap {
+        _.map { seq =>
+          seq.seqGen.nextAtom.sequenceType match {
+            // We shouldn't reload acq because odb always gives more steps for acq
+            case SequenceType.Acquisition =>
+              executeEngine.startNewAtom(obsId).as(NullSeqEvent)
+            case SequenceType.Science     =>
+              tryAtomReload[F](odb, translator, executeEngine, obsId, SequenceType.Science)
+                .as(SeqEvent.NullSeqEvent)
+          }
+        }.getOrElse(
+          Handle.pure[F, EngineState[F], Event[F, EngineState[F], SeqEvent], SeqEvent](NullSeqEvent)
+        )
+      }
+
+  private def tryAtomReload[F[_]: Monad](
+    odb:           OdbProxy[F],
+    translator:    SeqTranslate[F],
+    executeEngine: Engine[F, EngineState[F], SeqEvent],
+    obsId:         Observation.Id,
+    atomType:      SequenceType
+  ): Handle[F, EngineState[F], Event[F, EngineState[F], SeqEvent], Unit] =
+    Handle
+      .fromStream[F, EngineState[F], Event[F, EngineState[F], SeqEvent]](Stream.eval {
+        odb.read(obsId).map { x =>
+          atomType match {
+            case SequenceType.Acquisition =>
+              Event.nullEvent
+            case SequenceType.Science     =>
+              // Read the next atom from the odb and replaces the current atom
+              translator
+                .nextAtom(x, atomType)
+                ._2
+                .map { atm =>
+                  Event.modifyState[F, EngineState[F], SeqEvent]({ (st: EngineState[F]) =>
+                      val state = updateAtom(obsId, atm)(st)
+                      (state, ())
+                    }.toHandle
+                      .flatMap(_ => executeEngine.startNewAtom(obsId).as(SeqEvent.NullSeqEvent))
+                  )
+                }
+                .getOrElse(Event.nullEvent)
+          }
+        }
+      })
 }

--- a/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqEvent.scala
@@ -26,7 +26,7 @@ import observe.model.enums.*
 sealed trait SeqEvent       extends Product with Serializable
 sealed trait NoUserSeqEvent extends SeqEvent
 
-object SeqEvent {
+object SeqEvent:
   case class SetOperator(name: Operator, user: Option[User])                     extends SeqEvent
   case class SetObserver(id: Observation.Id, user: Option[User], name: Observer) extends SeqEvent
   case class SetTcsEnabled(id: Observation.Id, user: Option[User], enabled: SubsystemEnabled)
@@ -89,4 +89,3 @@ object SeqEvent {
       extends SeqEvent
   case class AtomCompleted(obsId: Observation.Id, sequenceType: SequenceType, atomId: Atom.Id)
       extends SeqEvent
-}

--- a/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
@@ -214,7 +214,8 @@ object SeqTranslate {
           buildSequenceGmosN(sequence, c).pure[F]
         case Some(c @ InstrumentExecutionConfig.GmosSouth(_)) =>
           buildSequenceGmosS(sequence, c).pure[F]
-        case _                                                => ApplicativeThrow[F].raiseError(new Exception("Unknown sequence type"))
+        case _                                                =>
+          ApplicativeThrow[F].raiseError(new Exception("Unknown sequence type"))
       }
 
     private def buildNextAtom[S <: StaticConfig, D <: DynamicConfig](

--- a/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
+++ b/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
@@ -3,7 +3,7 @@
 
 package observe.server.odb
 
-import cats.Applicative
+import cats.data.NonEmptyList
 import cats.effect.Concurrent
 import cats.effect.Ref
 import cats.syntax.all.*
@@ -32,6 +32,8 @@ import lucuma.core.model.sequence.gmos
 import lucuma.core.model.sequence.gmos.DynamicConfig
 import lucuma.core.model.sequence.gmos.StaticConfig
 import lucuma.refined.*
+import monocle.Focus
+import monocle.Lens
 import monocle.syntax.all.focus
 import observe.common.ObsQueriesGQL.ObsQuery
 import observe.common.ObsQueriesGQL.ObsQuery.Data
@@ -48,16 +50,52 @@ trait TestOdbProxy[F[_]] extends OdbProxy[F] {
 object TestOdbProxy {
 
   case class State(
-    sciences: List[Atom[DynamicConfig.GmosNorth]],
-    out:      List[OdbEvent]
-  )
+    sciences:       List[Atom[DynamicConfig.GmosNorth]],
+    currentAtom:    Option[Atom.Id],
+    completedSteps: List[Step.Id],
+    currentStep:    Option[Step.Id],
+    out:            List[OdbEvent]
+  ) {
+    def completeCurrentAtom: State =
+      currentAtom.fold(this)(a =>
+        copy(currentAtom = none, currentStep = none, sciences = sciences.filter(_.id =!= a))
+      )
+
+    def startStep(generatedId: Option[Step.Id]): State =
+      State.currentStep.replace(generatedId)(this)
+
+    def completeCurrentStep: State =
+      currentStep.fold(this)(s =>
+
+        val scienceUpdated =
+          sciences
+            .map {
+              case a if currentAtom.exists(_ === a.id) =>
+                val rest = NonEmptyList.fromList(a.steps.tail)
+                rest.map(r => a.copy(steps = r))
+              case a                                   => a.some
+            }
+
+        copy(
+          currentStep = none,
+          completedSteps = (s :: completedSteps.reverse).reverse,
+          sciences = scienceUpdated.flattenOption
+        )
+      )
+  }
+
+  object State:
+    val currentStep: Lens[State, Option[Step.Id]]                  = Focus[State](_.currentStep)
+    val currentAtom: Lens[State, Option[Atom.Id]]                  = Focus[State](_.currentAtom)
+    val sciences: Lens[State, List[Atom[DynamicConfig.GmosNorth]]] = Focus[State](_.sciences)
 
   def build[F[_]: Concurrent](
-    staticCfg:   Option[StaticConfig.GmosNorth] = None,
-    acquisition: Option[Atom[DynamicConfig.GmosNorth]],
-    sciences:    List[Atom[DynamicConfig.GmosNorth]] = List.empty
+    staticCfg:          Option[StaticConfig.GmosNorth] = None,
+    acquisition:        Option[Atom[DynamicConfig.GmosNorth]],
+    sciences:           List[Atom[DynamicConfig.GmosNorth]] = List.empty,
+    updateStartObserve: State => State = identity
   ): F[TestOdbProxy[F]] = Ref
-    .of[F, State](State(sciences, List.empty))
+    .of[F, State](State(sciences, None, List.empty, None, List.empty))
     .map(rf =>
       new TestOdbProxy[F] {
         private def addEvent(ev: OdbEvent): F[Unit] =
@@ -119,17 +157,10 @@ object TestOdbProxy {
           stepCount:    NonNegShort,
           generatedId:  Option[Atom.Id]
         ): F[Unit] = (sequenceType match {
-          case SequenceType.Acquisition => Applicative[F].unit
+          case SequenceType.Acquisition =>
+            rf.update(State.currentAtom.replace(generatedId))
           case SequenceType.Science     =>
-            rf.modify(s =>
-              (s.focus(_.sciences)
-                 .modify(ss =>
-                   if (ss.isEmpty) List.empty
-                   else ss.tail
-                 ),
-               ()
-              )
-            )
+            rf.update(State.currentAtom.replace(generatedId))
         }) *> addEvent(AtomStart(obsId, instrument, sequenceType, stepCount))
 
         override def stepStartStep(
@@ -140,7 +171,8 @@ object TestOdbProxy {
           observeClass:    ObserveClass,
           generatedId:     Option[Step.Id]
         ): F[Unit] =
-          addEvent(StepStartStep(obsId, dynamicConfig, stepConfig, telescopeConfig, observeClass))
+          rf.update(_.startStep(generatedId)) *>
+            addEvent(StepStartStep(obsId, dynamicConfig, stepConfig, telescopeConfig, observeClass))
 
         override def stepStartConfigure(obsId: Observation.Id): F[Unit] = addEvent(
           StepStartConfigure(obsId)
@@ -178,13 +210,17 @@ object TestOdbProxy {
           addEvent(StepEndObserve(obsId)).as(true)
 
         override def stepEndStep(obsId: Observation.Id): F[Boolean] =
-          addEvent(StepEndStep(obsId)).as(true)
+          rf.update { a =>
+            // This is a hook to let a test caller modify the sequence at the end of a step
+            updateStartObserve(a).completeCurrentStep
+          } *> addEvent(StepEndStep(obsId))
+            .as(true)
 
         override def stepAbort(obsId: Observation.Id): F[Boolean] =
           addEvent(StepAbort(obsId)).as(true)
 
         override def atomEnd(obsId: Observation.Id): F[Boolean] =
-          addEvent(AtomEnd(obsId)).as(true)
+          rf.update(_.completeCurrentAtom) *> addEvent(AtomEnd(obsId)).as(true)
 
         override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
           addEvent(SequenceEnd(obsId)).as(true)

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/WebServerLauncher.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/WebServerLauncher.scala
@@ -29,7 +29,6 @@ import observe.server
 import observe.server.CaServiceInit
 import observe.server.ObserveEngine
 import observe.server.Systems
-import observe.server.events.TargetedClientEvent
 import observe.server.tcs.GuideConfigDb
 import observe.web.server.OcsBuildInfo
 import observe.web.server.config.*
@@ -259,7 +258,6 @@ object WebServerLauncher extends IOApp with LogInitialization {
         conf             <- Resource.eval(config[IO].flatMap(loadConfiguration[IO]))
         _                <- Resource.eval(printBanner(conf))
         cli              <- Resource.eval(mkClient(conf.observeEngine.dhsTimeout))
-        out              <- Resource.eval(Topic[IO, TargetedClientEvent])
         cs               <- Resource.eval(
                               Ref.of[IO, ClientsSetDb.ClientsSet](Map.empty).map(ClientsSetDb.apply[IO](_))
                             )

--- a/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
+++ b/modules/web/server/src/test/scala/observe/web/server/http4s/TestObserveEngine.scala
@@ -32,8 +32,6 @@ import org.typelevel.log4cats.Logger
 class TestObserveEngine[F[_]: Sync: Logger](sys: Systems[F]) extends ObserveEngine[F] {
   override val systems: Systems[F] = sys
 
-  override def sync(seqId: Id): F[Unit] = Applicative[F].unit
-
   override def start(
     id:          Id,
     user:        User,


### PR DESCRIPTION
This is a proposal of  how to solve the fact that atoms can change. Currently  the observe engine loads an atom and creates a local representation, if the atom changes that local representation needs to be updated.

This is to some extent  similar to loading the next atom thus the code has some commonality with loading the next atom.

In this PR at the end of executing a step we do a reload without emitting events (unlike loading the next atom)

Below is a video where a step is marked as failed thus forcing the odb to produce a new step. The exposure times have been reduced to make the example go faster. Note thaat we start with 3 steps but  at the end we execute 4 as the  first failed.

https://github.com/user-attachments/assets/1d267036-31fe-464b-9bfc-4c6839f8901b

Please check it and verify if this approach seems correct. Further testing is needed
