### PR TITLE
Explicit table sorting, attachment migration, sass syntax

### DIFF
--- a/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
@@ -14,8 +14,8 @@ import io.circe.HCursor
 import io.circe.generic.semiauto.*
 import io.circe.refined.given
 import lucuma.core.enums.Instrument
+import lucuma.core.model.Attachment
 import lucuma.core.model.ConstraintSet
-import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationReference
 import lucuma.core.model.PosAngleConstraint
@@ -37,7 +37,7 @@ case class ObsSummary(
   instrument:         Instrument,
   constraints:        ConstraintSet,
   timingWindows:      List[TimingWindow],
-  attachmentIds:      SortedSet[ObsAttachment.Id],
+  attachmentIds:      SortedSet[Attachment.Id],
   observingMode:      Option[ObservingMode],
   observationTime:    Option[Instant],
   posAngleConstraint: PosAngleConstraint,
@@ -67,7 +67,7 @@ object ObsSummary:
   val posAngleConstraint = Focus[ObsSummary](_.posAngleConstraint)
   val obsReference       = Focus[ObsSummary](_.obsReference)
 
-  private case class AttachmentIdWrapper(id: ObsAttachment.Id)
+  private case class AttachmentIdWrapper(id: Attachment.Id)
   private object AttachmentIdWrapper:
     given Decoder[AttachmentIdWrapper] = deriveDecoder
 
@@ -79,7 +79,7 @@ object ObsSummary:
       instrument         <- c.get[Option[Instrument]]("instrument")
       constraints        <- c.get[ConstraintSet]("constraintSet")
       timingWindows      <- c.get[List[TimingWindow]]("timingWindows")
-      attachmentIds      <- c.get[List[AttachmentIdWrapper]]("obsAttachments")
+      attachmentIds      <- c.get[List[AttachmentIdWrapper]]("attachments")
       observingMode      <- c.get[Option[ObservingMode]]("observingMode")
       observationTime    <- c.get[Option[Timestamp]]("observationTime")
       posAngleConstraint <- c.get[PosAngleConstraint]("posAngleConstraint")

--- a/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbObsSummary.scala
+++ b/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbObsSummary.scala
@@ -7,8 +7,8 @@ import cats.Order.given
 import eu.timepit.refined.scalacheck.string.given
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.Instrument
+import lucuma.core.model.Attachment
 import lucuma.core.model.ConstraintSet
-import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationReference
 import lucuma.core.model.PosAngleConstraint
@@ -38,7 +38,7 @@ trait ArbObsSummary:
       instrument         <- arbitrary[Instrument]
       constraints        <- arbitrary[ConstraintSet]
       timingWindows      <- arbitrary[List[TimingWindow]]
-      attachmentIds      <- arbitrary[List[ObsAttachment.Id]]
+      attachmentIds      <- arbitrary[List[Attachment.Id]]
       observingMode      <- arbitrary[Option[ObservingMode]]
       observationTime    <- arbitrary[Option[Instant]]
       posAngleConstraint <- arbitrary[PosAngleConstraint]
@@ -65,7 +65,7 @@ trait ArbObsSummary:
        Instrument,
        ConstraintSet,
        List[TimingWindow],
-       List[ObsAttachment.Id],
+       List[Attachment.Id],
        Option[ObservingMode],
        Option[Instant],
        PosAngleConstraint,

--- a/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
@@ -23,9 +23,7 @@ object ObservationSummarySubquery
           posAngleConstraint $PosAngleConstraintSubquery
           constraintSet $ConstraintSetSubquery
           timingWindows $TimingWindowSubquery
-          obsAttachments {
-            id
-          }
+          attachments { id }
           observingMode $ObservingModeSubquery
           reference {
             label

--- a/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
@@ -201,10 +201,7 @@ object SessionQueue:
       ObsRefColumnId,
       _.obsReference,
       header = "Obs. Id",
-      cell = linked(c =>
-        println(s"${c.value.map(_.label).getOrElse("---")} => ${c.value}")
-        c.value.map(_.label).getOrElse("---")
-      ),
+      cell = linked(_.value.map(_.label).getOrElse("---")),
       size = 110.toPx
     ).sortable,
     ColDef(

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
@@ -269,7 +269,6 @@ private sealed trait SequenceTableBuilder[S: Eq, D <: DynamicConfig: Eq]
         TableOptions(
           cols.map(dynTable.setInitialColWidths),
           sequence,
-          enableSorting = false,
           enableColumnResizing = true,
           enableExpanding = true,
           getRowId = (row, _, _) => getRowId(row),

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepControlButtons.scala
@@ -13,6 +13,7 @@ import lucuma.react.common.*
 import lucuma.react.fa.FontAwesomeIcon
 import lucuma.react.fa.IconSize
 import lucuma.react.primereact.*
+import lucuma.typed.primereact.components.ButtonGroup
 import observe.model.SequenceState
 import observe.model.operations.*
 import observe.model.operations.Operations.*
@@ -22,7 +23,6 @@ import observe.ui.components.DefaultTooltipOptions
 import observe.ui.model.AppContext
 import observe.ui.model.ObservationRequests
 import observe.ui.services.SequenceApi
-import lucuma.typed.primereact.components.ButtonGroup
 
 /**
  * Contains a set of control buttons like stop/abort

--- a/modules/web/client/src/main/webapp/styles/prime.scss
+++ b/modules/web/client/src/main/webapp/styles/prime.scss
@@ -4,25 +4,25 @@
 // .pl- prefix = "Prime Lucuma": Our additions to prime-react
 
 .light-theme {
-  @import "/lucuma-css/light-theme";
-
   --active-row-background: var(--orange-50);
   --disabled-row-background: var(--bluegray-50);
   --disabled-row-color: var(--bluegray-400);
   --negative-row-background: var(--red-50);
   --negative-row-color: var(--red-400);
   --muted-color: var(--gray-600);
+
+  @import "/lucuma-css/light-theme";
 }
 
 .dark-theme {
-  @import "/lucuma-css/dark-theme";
-
   --active-row-background: var(--orange-900);
   --disabled-row-background: var(--bluegray-800);
   --disabled-row-color: var(--bluegray-300);
   --negative-row-background: var(--red-900);
   --negative-row-color: var(--red-100);
   --muted-color: var(--gray-300);
+
+  @import "/lucuma-css/dark-theme";
 }
 
 @import "/lucuma-css/lucuma-ui-prime.scss";

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -52,8 +52,8 @@ object Settings {
 
     // Gemini Libraries
     val lucumaCore      = "0.110.0"
-    val lucumaUI        = "0.124.1"
-    val lucumaSchemas   = "0.108.0"
+    val lucumaUI        = "0.124.3"
+    val lucumaSchemas   = "0.109.0"
     val lucumaSSO       = "0.7.0"
     val lucumaODBSchema = "0.17.0"
 
@@ -63,7 +63,7 @@ object Settings {
     // ScalaJS libraries
     val crystal      = "0.45.3"
     val javaTimeJS   = "2.6.0"
-    val lucumaReact  = "0.73.2"
+    val lucumaReact  = "0.74.0"
     val scalaDom     = "2.3.0"
     val scalajsReact = "3.0.0-beta6"
   }


### PR DESCRIPTION
- Migrate to new table syntax where sorting is explicit.
- Migrate to new attachment model.
- Fix deprecated SASS syntax.