### PR TITLE
Remove unused prism

### DIFF
--- a/modules/model/shared/src/main/scala/observe/model/ModelLenses.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ModelLenses.scala
@@ -144,20 +144,6 @@ trait ModelLenses {
   def signedComponentFormat[A]: Format[String, Offset.Component[A]] =
     signedArcsecFormat.andThen(Offset.Component.angle[A].reverse)
 
-  val stringToDoubleP: Prism[String, Double] =
-    Prism((x: String) => x.parseDoubleOption)(_.show)
-
-//  def stepObserveOptional[A](
-//                              systemName: SystemName,
-//                              param: String,
-//                              prism: Prism[String, A]
-//                            ): Optional[Step, A] =
-//    Step.config
-//      .andThen( // configuration of the step
-//        configParamValueO(systemName, param)
-//      )
-//      .andThen(prism) // step type
-
   val stringToString = Iso.id[String].asPrism
 
   val stringToStepTypeP: Prism[String, StepType] =

--- a/modules/model/shared/src/test/scala/observe/model/ModelLensesSuite.scala
+++ b/modules/model/shared/src/test/scala/observe/model/ModelLensesSuite.scala
@@ -31,7 +31,6 @@ class ModelLensesSuite extends munit.DisciplineSuite with ModelLenses {
 
   checkAll("step type prism", PrismTests(stringToStepTypeP))
 
-  checkAll("step double prism", PrismTests(stringToDoubleP))
   checkAll("param guiding prism", PrismTests(stringToGuidingP))
 
   checkAll("StandardStep", PrismTests(ObserveStep.standardStepP))


### PR DESCRIPTION
This prism is unlawful and it is not in used. It was used on the seqexec to parse ocs string-based model