### PR TITLE
Switch breakpoints also in focused step

### DIFF
--- a/modules/engine/src/main/scala/observe/engine/Sequence.scala
+++ b/modules/engine/src/main/scala/observe/engine/Sequence.scala
@@ -316,8 +316,15 @@ object Sequence {
 
       override def setBreakpoints(stepId: List[Step.Id], v: Breakpoint): State[F] =
         self.copy(zipper =
-          zipper.copy(pending =
-            zipper.pending.map(s => if (stepId.exists(_ === s.id)) s.copy(breakpoint = v) else s)
+          zipper.copy(
+            pending = zipper.pending.map: s =>
+              if stepId.contains_(s.id)
+              then s.copy(breakpoint = v)
+              else s,
+            focus =
+              if stepId.contains_(zipper.focus.id)
+              then zipper.focus.copy(breakpoint = v)
+              else zipper.focus
           )
         )
 


### PR DESCRIPTION
Fixes https://app.shortcut.com/lucuma/story/4180/cannot-unset-a-breakpoint-once-reached