### PR TITLE
Use the site to generate filenames

### DIFF
--- a/modules/server_new/src/test/scala/observe/server/keywords/DhsClientSimSpec.scala
+++ b/modules/server_new/src/test/scala/observe/server/keywords/DhsClientSimSpec.scala
@@ -4,6 +4,7 @@
 package observe.server.keywords
 
 import cats.effect.IO
+import lucuma.core.enums.Site
 import observe.model.enums.KeywordName
 import observe.server.keywords.DhsClient.Permanent
 import org.typelevel.log4cats.Logger
@@ -11,30 +12,19 @@ import org.typelevel.log4cats.noop.NoOpLogger
 
 import java.time.LocalDateTime
 
-class DhsClientSimSpec extends munit.CatsEffectSuite {
+class DhsClientSimSpec extends munit.CatsEffectSuite:
   private given Logger[IO] = NoOpLogger.impl[IO]
 
-  test("produce data labels for today") {
-    (DhsClientSim[IO](LocalDateTime.of(2016, 4, 15, 0, 0, 0))
+  test("produce data labels for today"):
+    DhsClientSim[IO](Site.GN, LocalDateTime.of(2016, 4, 15, 0, 0, 0))
       .flatMap(_.createImage(DhsClient.ImageParameters(Permanent, Nil)))
       .map(_.value)
-      .unsafeRunSync(): String) match {
-      case "S20160415S0001" => assert(true)
-      case _                => fail("Bad id")
-    }
-  }
-  test("accept keywords") {
-    assertEquals(
-      (for {
-        client <- DhsClientSim.apply[IO]
-        id     <- client.createImage(DhsClient.ImageParameters(Permanent, Nil))
-        _      <- client.setKeywords(id,
-                                     KeywordBag(Int32Keyword(KeywordName.TELESCOP, 10)),
-                                     finalFlag = true
-                  )
-      } yield ()).unsafeRunSync(),
-      ()
-    )
-  }
+      .map(a => assertEquals("N20160415S0001", a))
 
-}
+  test("accept keywords"):
+    (for {
+      client <- DhsClientSim.apply[IO](Site.GS)
+      id     <- client.createImage(DhsClient.ImageParameters(Permanent, Nil))
+      _      <-
+        client.setKeywords(id, KeywordBag(Int32Keyword(KeywordName.TELESCOP, 10)), finalFlag = true)
+    } yield ()).assert


### PR DESCRIPTION
When simulating the file names are always set as Gemini South which is confusing when simulating at GN.

This PR uses the server site configuration to decide