### PR TITLE
Use stepAbort for aborting a step

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/ObserveActions.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveActions.scala
@@ -35,7 +35,7 @@ trait ObserveActions {
     imageFileId: ImageFileId
   ): F[Result] =
     odb
-      .obsAbort(obsId, imageFileId.value)
+      .stepAbort(obsId)
       .ensure(
         ObserveFailure.Unexpected("Unable to send ObservationAborted message to ODB.")
       )(identity)

--- a/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
+++ b/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
@@ -229,9 +229,6 @@ object TestOdbProxy {
         override def sequenceEnd(obsId: Observation.Id): F[Boolean] =
           addEvent(SequenceEnd(obsId)).as(true)
 
-        override def obsAbort(obsId: Observation.Id, reason: String): F[Boolean] =
-          addEvent(ObsAbort(obsId, reason)).as(true)
-
         override def obsContinue(obsId: Observation.Id): F[Boolean] =
           addEvent(ObsContinue(obsId)).as(true)
 
@@ -277,7 +274,6 @@ object TestOdbProxy {
   case class StepAbort(obsId: Observation.Id)                                 extends OdbEvent
   case class AtomEnd(obsId: Observation.Id)                                   extends OdbEvent
   case class SequenceEnd(obsId: Observation.Id)                               extends OdbEvent
-  case class ObsAbort(obsId: Observation.Id, reason: String)                  extends OdbEvent
   case class ObsContinue(obsId: Observation.Id)                               extends OdbEvent
   case class ObsPause(obsId: Observation.Id, reason: String)                  extends OdbEvent
   case class ObsStop(obsId: Observation.Id, reason: String)                   extends OdbEvent


### PR DESCRIPTION
After aborting we cannot resume sequences. This was traced to the odb proxy which forgets the visit when doing `obsAbort`. It is unclear whats the role of `obsAbort` so it is removed and we use `steAbort` instead.

I wish we could make a test case but I couldn't figure out how to do it