### PR TITLE
Show current aborted step as idle

### DIFF
--- a/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
+++ b/modules/web/client/src/main/scala/observe/ui/ObserveStyles.scala
@@ -76,7 +76,6 @@ object ObserveStyles:
   val StepRowPossibleFuture: Css = Css("ObserveStyles-stepRowPossibleFuture")
 
   val ObservationStepProgressBar: Css = Css("ObserveStyles-observationProgressBar")
-  val AbortedProgressBar: Css         = Css("ObserveStyles-abortedProgressBar")
   val ControlButtonStrip: Css         = Css("ObserveStyles-controlButtonStrip")
   val PauseButton: Css                = Css("ObserveStyles-pauseButton")
   val CancelPauseButton: Css          = Css("ObserveStyles-cancelPauseButton")

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/ObservationProgressBar.scala
@@ -93,8 +93,8 @@ object ObservationProgressBar extends ProgressLabel:
           .orEmpty
       .render: (props, _, remainingShown, _) =>
         props.runningProgress.fold {
-          val label = if (props.isPausedInStep) "Paused" else if (props.sequenceState === SequenceState.Aborted) "Aborted" else "Preparing..."
-          val msg: String =
+          val label: String = if (props.isPausedInStep) "Paused" else "Preparing..."
+          val msg: String   =
             List(s"${props.fileId.value}", label)
               .filterNot(_.isEmpty)
               .mkString(" - ")

--- a/modules/web/client/src/main/webapp/styles/observe.scss
+++ b/modules/web/client/src/main/webapp/styles/observe.scss
@@ -734,10 +734,6 @@ body {
       }
     }
   }
-
-  &.ObserveStyles-abortedProgressBar {
-    background-color: var(--red-500);
-  }
 }
 
 .p-button-group {


### PR DESCRIPTION
Aborted steps are already shown as such in the visit record.

The current row of an aborted step should be shown as idle, without further styling.

Before:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/00a3818c-1c5f-4dc1-a0d4-db2e2a74cbd0" />

After:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/9c02d0f4-4b02-4187-b2c3-1fed4beebf95" />
