### PR TITLE
UI improvements after step abort

### DIFF
--- a/modules/model/shared/src/main/scala/observe/cats.scala
+++ b/modules/model/shared/src/main/scala/observe/cats.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe
+
+import _root_.cats.Endo
+import _root_.cats.Monoid
+import _root_.cats.MonoidK
+
+object cats:
+  given [A]: Monoid[Endo[A]] = MonoidK[Endo].algebra[A]

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -383,6 +383,13 @@ object MainApp extends ServerEventHandler:
               Button("Refresh page instead", onClick = Callback(dom.window.location.reload()))
             )
 
+          val nighttimeObservationSequenceState: SequenceState =
+            rootModelData.get.nighttimeObservation
+              .map(_.obsId)
+              .flatMap(rootModelData.get.executionState.get)
+              .map(_.sequenceState)
+              .getOrElse(SequenceState.Idle)
+
           // When both AppContext and UserVault are ready, proceed to render.
           (ctxPot.value, rootModelData.zoom(RootModelData.userVault).toPotView).tupled.renderPot:
             (ctx, userVault) =>
@@ -404,7 +411,10 @@ object MainApp extends ServerEventHandler:
                 )(_ =>
                   provideApiCtx(
                     ResyncingPopup,
-                    ObservationSyncer(rootModelData.zoom(RootModelData.nighttimeObservation)),
+                    ObservationSyncer(
+                      rootModelData.zoom(RootModelData.nighttimeObservation),
+                      nighttimeObservationSequenceState
+                    ),
                     router(RootModel(clientConfigPot.get, rootModelData))
                   )
                 )

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ObservationSyncer.scala
@@ -5,10 +5,13 @@ package observe.ui.components.services
 
 import cats.effect.IO
 import cats.effect.Resource
+import cats.effect.std.Queue
 import cats.syntax.all.*
 import clue.PersistentClientStatus
+import crystal.*
 import crystal.react.*
 import crystal.react.hooks.*
+import crystal.react.syntax.pot.given
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Observation
@@ -16,81 +19,73 @@ import lucuma.react.common.ReactFnProps
 import lucuma.schemas.odb.input.*
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.effect.*
+import observe.model.SequenceState
 import observe.queries.ObsQueriesGQL
 import observe.ui.DefaultErrorPolicy
 import observe.ui.model.AppContext
 import observe.ui.model.LoadedObservation
-import observe.ui.model.reusability.given
 import observe.ui.services.ODBQueryApi
 import observe.ui.services.SequenceApi
 
 // Renderless component that reloads observation summaries and sequences when observations are selected.
-case class ObservationSyncer(nighttimeObservation: View[Option[LoadedObservation]])
-    extends ReactFnProps(ObservationSyncer.component)
+case class ObservationSyncer(
+  nighttimeObservation:              View[Option[LoadedObservation]],
+  nighttimeObservationSequenceState: SequenceState
+) extends ReactFnProps(ObservationSyncer.component)
 
 object ObservationSyncer:
   private type Props = ObservationSyncer
 
   private val component =
-    ScalaFnComponent
-      .withHooks[Props]
-      .useContext(AppContext.ctx)
-      .useContext(SequenceApi.ctx)
-      .useContext(ODBQueryApi.ctx)
-      .useStreamOnMountBy: (_, ctx, _, _) =>
-        ctx.odbClient.statusStream
-      .useRef(none[Observation.Id])
-      .useEffectStreamResourceWithDepsBy((props, _, _, _, odbStatusPot, _) =>
-        // Run when observation changes or ODB status changes to Connected
-        (props.nighttimeObservation.get.map(_.obsId),
-         odbStatusPot.toOption.filter(_ === PersistentClientStatus.Connected)
-        ).tupled
-      ): (props, ctx, sequenceApi, odbQueryApi, _, subscribedObsId) =>
-        deps =>
-          import ctx.given
+    ScalaFnComponent[Props]: props =>
+      for
+        ctx             <- useContext(AppContext.ctx)
+        sequenceApi     <- useContext(SequenceApi.ctx)
+        odbQueryApi     <- useContext(ODBQueryApi.ctx)
+        subscribedObsId <- useRef(none[Observation.Id])
+        signalQueue     <- useEffectResultOnMount(Queue.unbounded[IO, Boolean])
+        _               <- useEffect: // Signal wheter sequence is stopped
+                             signalQueue.toOption
+                               .map(_.offer(!props.nighttimeObservationSequenceState.isRunning))
+                               .orEmpty
+        signal          <-            // Signals when obs stopped or ODB reconnected
+          useMemo(signalQueue.void): _ =>
+            signalQueue.map:
+              fs2.Stream
+                .fromQueueUnterminated(_, 1)
+                .changes
+                .filter(_ === true)
+                .void
+                .merge:
+                  ctx.odbClient.statusStream.changes
+                    .filter(_ === PersistentClientStatus.Connected)
+                    .void
+        _               <-
+          useEffectStreamResourceWithDeps(
+            (props.nighttimeObservation.get.map(_.obsId).toPot, signal.sequencePot).tupled.toOption
+          ): deps =>
+            import ctx.given
 
-          deps
-            .map: (obsId, _) =>
-              Option
-                .unless(subscribedObsId.value.contains(obsId))(
-                  Resource.pure(fs2.Stream.eval(subscribedObsId.setAsync(obsId.some))) >>
-                    (odbQueryApi.refreshNighttimeSequence,
-                     odbQueryApi.refreshNighttimeVisits
-                    ).parTupled.void
-                      .reRunOnResourceSignals:
-                        // Eventually, there will be another subscription notifying of sequence/visits changes
-                        ObsQueriesGQL.SingleObservationEditSubscription
-                          .subscribe[IO]:
-                            obsId.toObservationEditInput
-                )
-                .orEmpty
-            // TODO Breakpoint initialization should happen in the server, not here.
-            // Leaving the code commented here until we move it to the server.
-            // >>= ((_, configEither) =>
-            // configEither.toOption
-            //   .map: config =>
-            //     def getBreakPoints(sequence: Option[ExecutionSequence[?]]): Set[Step.Id] =
-            //       sequence
-            //         .map(s => s.nextAtom +: s.possibleFuture)
-            //         .orEmpty
-            //         .flatMap(_.steps.toList)
-            //         .collect { case s if s.breakpoint === Breakpoint.Enabled => s.id }
-            //         .toSet
-
-            //     val initialBreakpoints: Set[Step.Id] =
-            //       config match
-            //         case InstrumentExecutionConfig.GmosNorth(executionConfig) =>
-            //           getBreakPoints(executionConfig.acquisition) ++
-            //             getBreakPoints(executionConfig.science)
-            //         case InstrumentExecutionConfig.GmosSouth(executionConfig) =>
-            //           getBreakPoints(executionConfig.acquisition) ++
-            //             getBreakPoints(executionConfig.science)
-
-            //     sequenceApi.setBreakpoints(obsId, initialBreakpoints.toList, Breakpoint.Enabled)
-            // .orEmpty
-            // )
-            .getOrElse:
-              // If connection broken, or observation unselected, cleanup sequence and visits
-              Resource.pure(fs2.Stream.eval(props.nighttimeObservation.async.mod(_.map(_.reset))))
-      .render: _ =>
-        EmptyVdom
+            deps
+              .map: (obsId, signal) =>
+                Option
+                  .unless(subscribedObsId.value.contains(obsId)):
+                    Resource.pure(
+                      fs2.Stream.eval:
+                        subscribedObsId.setAsync(obsId.some)
+                    ) >>
+                      (odbQueryApi.refreshNighttimeSequence,
+                       odbQueryApi.refreshNighttimeVisits
+                      ).parTupled.void
+                        .reRunOnResourceSignals:
+                          // Eventually, there will be another subscription notifying of sequence/visits changes
+                          ObsQueriesGQL.SingleObservationEditSubscription
+                            .subscribe[IO](obsId.toObservationEditInput)
+                            .map(_.merge(signal))
+                  .orEmpty
+              .getOrElse:
+                // If connection broken, or observation unselected, cleanup sequence and visits
+                Resource.pure:
+                  fs2.Stream.eval:
+                    props.nighttimeObservation.async.mod(_.map(_.reset))
+      yield EmptyVdom

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -61,7 +61,7 @@ object Settings {
     val clue = "0.40.0"
 
     // ScalaJS libraries
-    val crystal      = "0.47.0"
+    val crystal      = "0.47.1"
     val javaTimeJS   = "2.6.0"
     val lucumaReact  = "0.76.0"
     val scalaDom     = "2.3.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -61,7 +61,7 @@ object Settings {
     val clue = "0.40.0"
 
     // ScalaJS libraries
-    val crystal      = "0.47.1"
+    val crystal      = "0.47.1-2-1e4f3d9-20241225T201622Z-SNAPSHOT"
     val javaTimeJS   = "2.6.0"
     val lucumaReact  = "0.76.0"
     val scalaDom     = "2.3.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -61,7 +61,7 @@ object Settings {
     val clue = "0.40.0"
 
     // ScalaJS libraries
-    val crystal      = "0.47.1-2-1e4f3d9-20241225T201622Z-SNAPSHOT"
+    val crystal      = "0.47.2"
     val javaTimeJS   = "2.6.0"
     val lucumaReact  = "0.76.0"
     val scalaDom     = "2.3.0"


### PR DESCRIPTION
When a step is aborted:
- Reset its progress (there was a bug where progress for the new step resumed from where the aborted one left).
- Requery visits (the aborted step's attempt(s) were not shown until the UI refreshed).