### PR TITLE
Limit observations to ACCEPTED, or ENGINEERING or CALIBRATION programs

### DIFF
--- a/modules/model/shared/src/main/scala/observe/model/extensions.scala
+++ b/modules/model/shared/src/main/scala/observe/model/extensions.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.model
+
+import cats.syntax.option.*
+import lucuma.core.enums.Instrument
+import lucuma.core.enums.Site
+
+object extensions:
+  extension (i: Instrument)
+    def hasOI: Boolean = i match
+      //      case Instrument.F2    => true
+      case Instrument.GmosSouth => true
+      case Instrument.GmosNorth => true
+      case _                    => false
+    //      case Instrument.Nifs  => true
+    //      case Instrument.Niri  => true
+    //      case Instrument.Gnirs => true
+    //      case Instrument.Gsaoi => false
+    //      case Instrument.Gpi   => true
+    //      case Instrument.Ghost => false
+
+    def site: Option[Site] = i match
+      // GS
+      case Instrument.GmosSouth  => Site.GS.some
+      case Instrument.Flamingos2 => Site.GS.some
+      case Instrument.Ghost      => Site.GS.some
+      case Instrument.Gpi        => Site.GS.some
+      case Instrument.Gsaoi      => Site.GS.some
+      // GN
+      case Instrument.GmosNorth  => Site.GN.some
+      case Instrument.Gnirs      => Site.GN.some
+      case Instrument.Niri       => Site.GN.some
+      case Instrument.Nifs       => Site.GN.some
+      // None
+      case _                     => none
+
+  private val SiteInstruments: Map[Site, List[Instrument]] =
+    Instrument.all
+      .filter(_.site.isDefined)
+      .groupBy(_.site.get)
+
+  extension (site: Site)
+    def instruments: List[Instrument] =
+      SiteInstruments(site)

--- a/modules/model/shared/src/main/scala/observe/model/package.scala
+++ b/modules/model/shared/src/main/scala/observe/model/package.scala
@@ -3,12 +3,10 @@
 
 package observe.model
 
-import cats.*
 import cats.syntax.all.*
 import io.circe.KeyDecoder
 import io.circe.KeyEncoder
 import lucuma.core.enums.Instrument
-import lucuma.core.enums.Site
 import lucuma.core.util.Enumerated
 import observe.model.enums.Resource
 
@@ -22,34 +20,6 @@ val UnknownTargetName = "None"
 val CalibrationQueueName: String = "Calibration Queue"
 val CalibrationQueueId: QueueId  =
   QueueId(UUID.fromString("7156fa7e-48a6-49d1-a267-dbf3bbaa7577"))
-
-extension (i: Instrument)
-  def hasOI: Boolean = i match
-//      case Instrument.F2    => true
-    case Instrument.GmosSouth => true
-    case Instrument.GmosNorth => true
-    case _                    => false
-//      case Instrument.Nifs  => true
-//      case Instrument.Niri  => true
-//      case Instrument.Gnirs => true
-//      case Instrument.Gsaoi => false
-//      case Instrument.Gpi   => true
-//      case Instrument.Ghost => false
-
-  def site: Option[Site] = i match
-    // GS
-    case Instrument.GmosSouth  => Site.GS.some
-    case Instrument.Flamingos2 => Site.GS.some
-    case Instrument.Ghost      => Site.GS.some
-    case Instrument.Gpi        => Site.GS.some
-    case Instrument.Gsaoi      => Site.GS.some
-    // GN
-    case Instrument.GmosNorth  => Site.GN.some
-    case Instrument.Gnirs      => Site.GN.some
-    case Instrument.Niri       => Site.GN.some
-    case Instrument.Nifs       => Site.GN.some
-    // None
-    case _                     => none
 
 given KeyEncoder[Resource | Instrument] = KeyEncoder.instance:
   case r: Resource   => r.tag

--- a/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
@@ -36,6 +36,7 @@ import observe.model.*
 import observe.model.Observation
 import observe.model.dhs.*
 import observe.model.enums.Resource
+import observe.model.extensions.*
 import observe.server.InstrumentSystem.*
 import observe.server.ObserveFailure.Unexpected
 import observe.server.SequenceGen.StepActionsGen
@@ -491,8 +492,8 @@ object SeqTranslate {
       NonEmptySet.of(AGUnit, (if (inst.hasOI) List(OIWFS) else List.empty)*)
 
     private def extractWavelength(s: DynamicConfig): Option[Wavelength] = s match {
-      case a:DynamicConfig.GmosNorth => a.centralWavelength
-      case b:DynamicConfig.GmosSouth => b.centralWavelength
+      case a: DynamicConfig.GmosNorth => a.centralWavelength
+      case b: DynamicConfig.GmosSouth => b.centralWavelength
     }
 
     private def getTcs[S <: StaticConfig, D <: DynamicConfig](

--- a/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
@@ -8,27 +8,18 @@ import clue.annotation.GraphQL
 import lucuma.schemas.ObservationDB
 import observe.ui.model.ObsSummary
 
+// gql: import lucuma.schemas.decoders.given
+
 object ObsQueriesGQL {
 
   @GraphQL
   trait ActiveObservationIdsQuery extends GraphQLOperation[ObservationDB] {
-    // TODO The ODB API doesn't provide a way to filter ready observations,
-    // so we filter by accepted proposals for now.
-    // Revise this when the API supports it OR we start getting obersvations from the scheduler.
     val document = s"""
-      query {
-        observations(
-          WHERE: {
-            program: {
-              OR: [
-                { proposalStatus: { EQ: ACCEPTED } }
-                { type: { IN: [ENGINEERING, CALIBRATION] } }
-              ] 
-            }
-          }
-        ) {
-          matches $ObservationSummarySubquery
-        }
+      query($$instruments: [Instrument!]!, $$semester: Semester!) {
+        observationsByWorkflowState(
+          states: [READY, ONGOING],
+          WHERE: { program: { reference: { instrument: { IN: $$instruments }, semester: { EQ: $$semester } } } }      
+        ) $ObservationSummarySubquery
       }
     """
 

--- a/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
@@ -17,7 +17,16 @@ object ObsQueriesGQL {
     // Revise this when the API supports it OR we start getting obersvations from the scheduler.
     val document = s"""
       query {
-        observations() {
+        observations(
+          WHERE: {
+            program: {
+              OR: [
+                { proposalStatus: { EQ: ACCEPTED } }
+                { type: { IN: [ENGINEERING, CALIBRATION] } }
+              ] 
+            }
+          }
+        ) {
           matches $ObservationSummarySubquery
         }
       }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -58,7 +58,7 @@ object Settings {
     val lucumaODBSchema = "0.18.3"
 
     // Clue
-    val clue = "0.43.0"
+    val clue = "0.43.1"
 
     // ScalaJS libraries
     val crystal      = "0.47.3"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
 
 // Generate code for GraphQL queries
-addSbtPlugin("edu.gemini" % "sbt-clue" % "0.43.0")
+addSbtPlugin("edu.gemini" % "sbt-clue" % "0.43.1")


### PR DESCRIPTION
A similar WHERE should be used in the query in `Observation.ts` in navigate-ui.

Note, there is also an `observationsByWorkflowState` which would allow filtering by observation workflow state in addition to the WHERE used here. But, it is only available for service users, which I think means it can't be used here?

UPDATE: Rob made `observationsByWorkflowState` available to staff users. @hugo-vrijswijk is creating a PR for navigate-ui using that query. The exact query should be discussed in that PR and I will duplicate it here.

Hugo's PR: https://github.com/gemini-hlsw/navigate-ui/pull/403