### PR TITLE
Exposure controls fixes

### DIFF
--- a/modules/model/shared/src/main/scala/observe/model/ObserveStage.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ObserveStage.scala
@@ -8,12 +8,12 @@ import lucuma.core.util.Enumerated
 enum ObserveStage(val tag: String) derives Enumerated:
   case Idle       extends ObserveStage("Idle")
   case Preparing  extends ObserveStage("Preparing")
-  case Acquiring  extends ObserveStage("Acquiring")
+  case Exposure   extends ObserveStage("Exposure")
   case ReadingOut extends ObserveStage("ReadingOut")
 
 object ObserveStage:
-  def fromBooleans(prep: Boolean, acq: Boolean, rdout: Boolean): ObserveStage =
+  def fromBooleans(prep: Boolean, exp: Boolean, rdout: Boolean): ObserveStage =
     if (prep) Preparing
-    else if (acq) Acquiring
+    else if (exp) Exposure
     else if (rdout) ReadingOut
     else Idle

--- a/modules/model/shared/src/main/scala/observe/model/StepProgress.scala
+++ b/modules/model/shared/src/main/scala/observe/model/StepProgress.scala
@@ -23,7 +23,7 @@ enum StepProgress(val isNs: Boolean) derives Eq:
   def remaining: TimeSpan
   def stage: ObserveStage
 
-  def isAcquiring: Boolean = stage === ObserveStage.Acquiring
+  def isExposure: Boolean = stage === ObserveStage.Exposure
 
   case Regular(
     stepId:    Step.Id,

--- a/modules/server_new/src/main/scala/observe/server/EpicsUtil.scala
+++ b/modules/server_new/src/main/scala/observe/server/EpicsUtil.scala
@@ -443,7 +443,7 @@ object EpicsUtil {
       )
       .dropWhile(_.remaining.self === TimeSpan.Zero) // drop leading zeros
       .takeThrough(x =>
-        x.remaining.self > TimeSpan.Zero || x.stage === ObserveStage.Acquiring
+        x.remaining.self > TimeSpan.Zero || x.stage === ObserveStage.Exposure
       ) // drop all tailing zeros but the first one, unless it is still acquiring
 
   // Component names read from instruments usually have a part name as suffix. For example, the

--- a/modules/server_new/src/main/scala/observe/server/ProgressUtil.scala
+++ b/modules/server_new/src/main/scala/observe/server/ProgressUtil.scala
@@ -56,7 +56,7 @@ object ProgressUtil {
         val progress  = t +| elapsed
         val remaining = total -| progress
         val clipped   = if (remaining >= TimeSpan.Zero) remaining else TimeSpan.Zero
-        ObsProgress(total, RemainingTime(clipped), ObserveStage.Acquiring).pure[F].widen[Progress]
+        ObsProgress(total, RemainingTime(clipped), ObserveStage.Exposure).pure[F].widen[Progress]
       }
       .takeThrough(_.remaining.self > TimeSpan.Zero)
 
@@ -85,5 +85,5 @@ object ProgressUtil {
           .map(v => ObsProgress(total, RemainingTime(clipped), v))
           .widen[Progress]
       }
-      .takeThrough(x => x.remaining.self > TimeSpan.Zero || x.stage === ObserveStage.Acquiring)
+      .takeThrough(x => x.remaining.self > TimeSpan.Zero || x.stage === ObserveStage.Exposure)
 }

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/ExposureControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/ExposureControlButtons.scala
@@ -28,15 +28,14 @@ import observe.ui.services.SequenceApi
  * Contains a set of control buttons like stop/abort
  */
 case class ExposureControlButtons(
-  obsId:           Observation.Id,
-  instrument:      Instrument,
-  sequenceState:   SequenceState,
-  stepId:          Step.Id,
-  isPausedInStep:  Boolean,
-  isAcquiring:     Boolean,
-  isStopRequested: Boolean,
-  isMultiLevel:    Boolean,
-  requests:        ObservationRequests
+  obsId:          Observation.Id,
+  instrument:     Instrument,
+  sequenceState:  SequenceState,
+  stepId:         Step.Id,
+  isPausedInStep: Boolean,
+  isExposure:     Boolean,
+  isMultiLevel:   Boolean,
+  requests:       ObservationRequests
 ) extends ReactFnProps(ExposureControlButtons):
   val operations: List[Operations] =
     instrument.operations(OperationLevel.Observation, isPausedInStep, isMultiLevel)
@@ -74,8 +73,7 @@ object ExposureControlButtons
                     icon = Icons.Play.withFixedWidth(),
                     tooltip = "Resume the current exposure",
                     tooltipOptions = DefaultTooltipOptions,
-                    disabled =
-                      props.requestInFlight || !props.isPausedInStep || !props.isAcquiring || props.isStopRequested,
+                    disabled = props.requestInFlight || !props.isPausedInStep,
                     onClickE = _.stopPropagationCB >> sequenceApi.resumeObs(props.obsId).runAsync
                   )
                 case PauseObservation  =>
@@ -84,8 +82,7 @@ object ExposureControlButtons
                     icon = Icons.Pause.withFixedWidth(),
                     tooltip = "Pause the current exposure",
                     tooltipOptions = DefaultTooltipOptions,
-                    disabled =
-                      props.requestInFlight || props.isPausedInStep || !props.isAcquiring || props.isStopRequested,
+                    disabled = props.requestInFlight || props.isPausedInStep || !props.isExposure,
                     onClickE = _.stopPropagationCB >> sequenceApi.pauseObs(props.obsId).runAsync
                   )
                 case StopObservation   =>
@@ -94,7 +91,7 @@ object ExposureControlButtons
                     icon = Icons.Stop.withFixedWidth().withSize(IconSize.LG),
                     tooltip = "Stop the current exposure early",
                     tooltipOptions = DefaultTooltipOptions,
-                    disabled = props.requestInFlight || !props.isAcquiring || props.isStopRequested,
+                    disabled = props.requestInFlight || !props.isExposure,
                     onClickE = _.stopPropagationCB >> sequenceApi.stop(props.obsId).runAsync
                   )
                 case AbortObservation  =>
@@ -103,7 +100,7 @@ object ExposureControlButtons
                     icon = Icons.XMark.withFixedWidth().withSize(IconSize.LG),
                     tooltip = "Abort the current exposure",
                     tooltipOptions = DefaultTooltipOptions,
-                    disabled = props.requestInFlight || !props.isAcquiring,
+                    disabled = props.requestInFlight || !props.isExposure,
                     onClickE = _.stopPropagationCB >> sequenceApi.abort(props.obsId).runAsync
                   )
                 // // N&S operations

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/ObservationProgressBar.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/ObservationProgressBar.scala
@@ -34,13 +34,11 @@ case class ObservationProgressBar(
   exposureTime:   TimeSpan,
   progress:       Option[StepProgress],
   fileId:         ImageFileId, // TODO This can be multiple ones
-  isStopping:     Boolean,
   isPausedInStep: Boolean
 ) extends ReactFnProps(ObservationProgressBar):
   val isStatic: Boolean =
     !sequenceState.isRunning ||
-      !progress.map(_.stage).contains_(ObserveStage.Acquiring) ||
-      isStopping ||
+      !progress.map(_.stage).contains_(ObserveStage.Exposure) ||
       isPausedInStep
 
   val runningProgress: Option[StepProgress] =
@@ -115,7 +113,6 @@ object ObservationProgressBar
                 renderProgressLabel(
                   props.fileId,
                   remainingShown.value.some,
-                  props.isStopping,
                   props.isPausedInStep,
                   runningProgress.stage
                 )

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepProgressCell.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/StepProgressCell.scala
@@ -21,7 +21,6 @@ import observe.model.enums.Resource
 import observe.ui.ObserveStyles
 import observe.ui.model.ObservationRequests
 import observe.ui.model.enums.ClientMode
-import observe.ui.model.enums.OperationRequest
 
 case class StepProgressCell(
   clientMode:      ClientMode,
@@ -66,9 +65,6 @@ case class StepProgressCell(
   //   else
   //     DetailRows.NoDetailRows
 
-  def isStopping: Boolean =
-    requests.stop === OperationRequest.InFlight || sequenceState.isStopRequested
-
 object StepProgressCell
     extends ReactFnComponent[StepProgressCell](props =>
       val exposureControlButtons: TagMod =
@@ -78,8 +74,7 @@ object StepProgressCell
           props.sequenceState,
           props.stepId,
           props.isPausedInStep,
-          props.progress.exists(_.isAcquiring),
-          props.sequenceState.isStopRequested,
+          props.progress.exists(_.isExposure),
           false, // props.isNs,
           props.requests
         )        // .when(props.controlButtonsActive)
@@ -166,7 +161,6 @@ object StepProgressCell
             props.exposureTime,
             props.progress,
             fileId,
-            isStopping = !props.isPausedInStep && props.isStopping,
             props.isPausedInStep
           )
         else EmptyVdom

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/package.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/package.scala
@@ -17,7 +17,6 @@ import observe.model.enums.ExecutionStepType
 def renderProgressLabel(
   fileId:            ImageFileId,
   remainingTimeSpan: Option[TimeSpan],
-  isStopping:        Boolean,
   isPausedInStep:    Boolean,
   stage:             ObserveStage
 ): String =
@@ -34,12 +33,11 @@ def renderProgressLabel(
         .filterNot(_.isEmpty)
         .mkString(" ")
 
-  val stageStr: String = (isPausedInStep, isStopping, stage) match
-    case (true, _, _)                    => "Paused"
-    case (_, true, _)                    => "Stopping - Reading out..."
-    case (_, _, ObserveStage.Preparing)  => "Preparing"
-    case (_, _, ObserveStage.ReadingOut) => "Reading out..."
-    case _                               => ""
+  val stageStr: String = (isPausedInStep, stage) match
+    case (true, _)                    => "Paused"
+    case (_, ObserveStage.Preparing)  => "Preparing"
+    case (_, ObserveStage.ReadingOut) => "Reading out..."
+    case _                            => ""
 
   // if (paused) s"$fileId - Paused$durationStr"
   // else if (stopping) s"$fileId - Stopping - Reading out..."

--- a/modules/web/server/src/main/resources/app.conf
+++ b/modules/web/server/src/main/resources/app.conf
@@ -35,7 +35,7 @@ web-server {
     external-base-url = "local.lucuma.xyz:8081"
 
     tls {
-        key-store = "modules/web/server/cacerts.jks.dev"
+        key-store = "cacerts.jks.dev"
         key-store-pwd = "passphrase"
         cert-pwd = "passphrase"
     }


### PR DESCRIPTION
Step pause/resume/stop/abort were disabled if a sequence stop was requested after the current step. This was wrong and is now fixed: the user could have requested a stop after the current step and still want to pause/resume/stop/abort the current exposure.

I've also renamed things: `ObserveStage.Acquiring` indicated that we were acquiring an image/spectroscopy, but it led to confusion regarding target acquisition. It was thus renamed to `ObserveStage.Exposure`.