### PR TITLE
SC-4865 Fixed extraction of shutter configuration for GMOS.

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/gmos/Gmos.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/Gmos.scala
@@ -187,7 +187,7 @@ object Gmos {
   def shutterStateObserveType(obsType: StepType): ShutterState = obsType match {
     case StepType.DarkOrBias(_) | StepType.ExclusiveDarkOrBias(_) | StepType.DarkOrBiasNS(_) =>
       ShutterState.CloseShutter
-    case _                                                                                   => ShutterState.UnsetShutter
+    case _                                                                                   => ShutterState.OpenShutter
   }
 
   def calcGainSetting(r: GmosCcdMode): Double = (r.ampReadMode, r.ampGain) match {

--- a/modules/server_new/src/main/scala/observe/server/gmos/GmosController.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/GmosController.scala
@@ -93,13 +93,12 @@ object GmosController {
     sealed abstract class ShutterState(val tag: String) extends Product with Serializable
 
     object ShutterState {
-      case object UnsetShutter extends ShutterState("UnsetShutter")
       case object OpenShutter  extends ShutterState("OpenShutter")
       case object CloseShutter extends ShutterState("CloseShutter")
 
       /** @group Typeclass Instances */
       given Enumerated[ShutterState] =
-        Enumerated.from(UnsetShutter, OpenShutter, CloseShutter).withTag(_.tag)
+        Enumerated.from(OpenShutter, CloseShutter).withTag(_.tag)
     }
 
     sealed abstract class Beam(val tag: String) extends Product with Serializable

--- a/modules/server_new/src/main/scala/observe/server/gmos/GmosControllerEpics.scala
+++ b/modules/server_new/src/main/scala/observe/server/gmos/GmosControllerEpics.scala
@@ -49,7 +49,6 @@ trait GmosEncoders {
   given EncodeEpicsValue[ShutterState, String] = EncodeEpicsValue {
     case ShutterState.OpenShutter  => "OPEN"
     case ShutterState.CloseShutter => "CLOSED"
-    case _                         => ""
   }
 
   given EncodeEpicsValue[AmpCount, String] = EncodeEpicsValue {
@@ -233,12 +232,8 @@ object GmosControllerEpics extends GmosEncoders {
           useElectronicOffsetting
         )
 
-      private def setShutterState(s: GmosDCEpicsState, dc: DCConfig): Option[F[Unit]] = dc.s match {
-        case ShutterState.UnsetShutter => none
-        case sh                        =>
-          val encodedVal = encode(sh)
-          applyParam(s.shutterState, encodedVal, DC.setShutterState)
-      }
+      private def setShutterState(s: GmosDCEpicsState, dc: DCConfig): Option[F[Unit]] =
+        applyParam(s.shutterState, encode(dc.s), DC.setShutterState)
 
       private def setGainSetting(
         state: GmosDCEpicsState,


### PR DESCRIPTION
There was a bug in the code from when it was converted to the new OCS model.