### PR TITLE
Remove refresh button

### DIFF
--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
@@ -91,17 +91,17 @@ object SeqControlButtons
             tooltipOptions = tooltipOptions,
             onClick = sequenceApi.cancelPause(props.obsId).runAsync,
             disabled = props.isCancelPauseInFlight || props.isWaitingNextAtom
-          ).when(selectedObsIsLoaded && props.isRunning && props.isUserStopRequested),
-          Button(
-            clazz = ObserveStyles.ReloadButton |+| ObserveStyles.ObsSummaryButton,
-            loading = props.isRefreshing,
-            icon = Icons.ArrowsRotate.withFixedWidth().withSize(IconSize.LG),
-            loadingIcon = Icons.ArrowsRotate.withFixedWidth().withSize(IconSize.LG).withSpin(),
-            tooltip = "Reload sequence from ODB",
-            tooltipOptions = tooltipOptions,
-            onClick = props.refreshing.toOption.foldMap(_.set(true)) >>
-              sequenceApi.loadObservation(props.obsId, props.instrument).runAsync,
-            disabled = props.loadedObsId.exists(_.isPending) || props.isRunning
-          ).when(selectedObsIsLoaded)
+          ).when(selectedObsIsLoaded && props.isRunning && props.isUserStopRequested)
+          // Button(
+          //   clazz = ObserveStyles.ReloadButton |+| ObserveStyles.ObsSummaryButton,
+          //   loading = props.isRefreshing,
+          //   icon = Icons.ArrowsRotate.withFixedWidth().withSize(IconSize.LG),
+          //   loadingIcon = Icons.ArrowsRotate.withFixedWidth().withSize(IconSize.LG).withSpin(),
+          //   tooltip = "Reload sequence from ODB",
+          //   tooltipOptions = tooltipOptions,
+          //   onClick = props.refreshing.toOption.foldMap(_.set(true)) >>
+          //     sequenceApi.loadObservation(props.obsId, props.instrument).runAsync,
+          //   disabled = props.loadedObsId.exists(_.isPending) || props.isRunning
+          // ).when(selectedObsIsLoaded)
         )
     )


### PR DESCRIPTION
The "Refresh sequence" button was problematic as it was: since the sequence was reloaded in the server, it would produce a new visit and therefore reset a running sequence to acquisition, even if it was executing science already.

If we want to support refresh, we need an endpoint in the server that reloads the current atom without creating a new visit or resetting breakpoints.

Do we want to support this?
- If YES: I'll create a story and leave the button commented out, so that we can reuse it when we have server support.
- If NO: I'll remove the button and all the logic and styling.