### PR TITLE
Avoid page refresh on dataset QA submit

### DIFF
--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/QaEditor.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/QaEditor.scala
@@ -47,7 +47,7 @@ object QaEditor
           <.span(ObserveStyles.QaStatusSelect)(Icons.ChevronDown),
           OverlayPanel(onHide = reset)(
             <.form(ObserveStyles.QaEditorPanel)(
-              ^.onSubmit --> submit,
+              ^.onSubmit ==> { e => e.preventDefaultCB >> submit },
               ^.onKeyDown ==> { e =>
                 e.keyCode match // Allows submitting by pressing enter after changing the status.
                   case KeyCode.Enter => submit >> panelRef.hide


### PR DESCRIPTION
Sometimes when saving the dataset QA the whole page would refresh.