### PR TITLE
Refresh visits and future sequence on dataset edit

### DIFF
--- a/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
@@ -58,4 +58,14 @@ object ObsQueriesGQL {
       }
     """
   }
+
+  @GraphQL
+  trait DatasetEditSubscription extends GraphQLOperation[ObservationDB]:
+    val document = s"""
+      subscription($$obsId: ObservationId!) {
+        datasetEdit(input: { observationId: $$obsId }) {
+          value { id }
+        }
+      }
+    """
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -53,7 +53,7 @@ object Settings {
     // Gemini Libraries
     val lucumaCore      = "0.115.2"
     val lucumaUI        = "0.130.0"
-    val lucumaSchemas   = "0.118.0"
+    val lucumaSchemas   = "0.120.0"
     val lucumaSSO       = "0.8.2"
     val lucumaODBSchema = "0.18.3"
 


### PR DESCRIPTION
This will only refresh in the UI the visits and atoms after the current one.

In order to refresh the current atom on a dataset edit, which is desirable since it can create new steps, we need to add this functionality to the server.