### PR TITLE
Do not automatically clear last observation and fix glitch when completing sequence

### DIFF
--- a/deploy/src/main/resources/conf/app.conf
+++ b/deploy/src/main/resources/conf/app.conf
@@ -5,7 +5,7 @@
 #
 
 # If mode is DEVELOPMENT or STAGING, UI provides some extra tools
-environment = STAGING
+environment = DEVELOPMENT
 site = ${SITE}
 explore-base-url = "https://explore-dev.lucuma.xyz"
 

--- a/modules/model/shared/src/main/scala/observe/model/ObserveStep.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ObserveStep.scala
@@ -203,11 +203,6 @@ object ObserveStep:
 
     def runningOrComplete: Boolean = s.status.runningOrComplete
 
-    def isObserving: Boolean =
-      s match
-        case x: Standard      => x.observeStatus === ActionStatus.Running
-        case x: NodAndShuffle => x.nsStatus.observing === ActionStatus.Running
-
     def isObservePaused: Boolean =
       s match
         case x: Standard      => x.observeStatus === ActionStatus.Paused
@@ -217,6 +212,8 @@ object ObserveStep:
       s match
         case x: Standard      => x.configStatus.count(_._2 === ActionStatus.Running) > 0
         case x: NodAndShuffle => x.configStatus.count(_._2 === ActionStatus.Running) > 0
+
+    def isActive: Boolean = s.status.isActive
 
     def isFinished: Boolean = s.status.isFinished
 

--- a/modules/model/shared/src/main/scala/observe/model/StepState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/StepState.scala
@@ -27,6 +27,10 @@ enum StepState derives Eq, Decoder, Encoder.AsObject:
 
   lazy val isRunning: Boolean = this === StepState.Running
 
+  lazy val isPaused: Boolean = this === StepState.Paused
+
+  lazy val isActive: Boolean = isRunning || isPaused
+
   lazy val isPending: Boolean = this === StepState.Pending
 
   lazy val runningOrComplete: Boolean = this match

--- a/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
@@ -14,6 +14,7 @@ import io.circe.HCursor
 import io.circe.generic.semiauto.*
 import io.circe.refined.given
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.model.Attachment
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Observation
@@ -21,13 +22,13 @@ import lucuma.core.model.ObservationReference
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Program
 import lucuma.core.model.TimingWindow
+import lucuma.core.syntax.display.*
 import lucuma.core.util.Timestamp
 import lucuma.schemas.decoders.given
 import lucuma.schemas.model.BasicConfiguration
 import lucuma.schemas.model.ObservingMode
 import monocle.Focus
 import org.typelevel.cats.time.*
-import lucuma.core.syntax.display.*
 
 import java.time.Instant
 import scala.collection.immutable.SortedSet
@@ -44,7 +45,8 @@ case class ObsSummary(
   observingMode:      Option[ObservingMode],
   observationTime:    Option[Instant],
   posAngleConstraint: PosAngleConstraint,
-  obsReference:       Option[ObservationReference]
+  obsReference:       Option[ObservationReference],
+  workflowState:      ObservationWorkflowState
 ) derives Eq:
   lazy val configurationSummary: Option[String] = observingMode.map(_.toBasicConfiguration) match
     case Some(BasicConfiguration.GmosNorthLongSlit(grating, _, fpu, _)) =>
@@ -96,6 +98,7 @@ object ObsSummary:
           .map(_.map(_.get[Option[ObservationReference]]("label")).sequence.map(_.flatten))
           .sequence
           .flatten
+      workflowState      <- c.downField("workflow").get[ObservationWorkflowState]("state")
     yield ObsSummary(
       id,
       programId,
@@ -108,5 +111,6 @@ object ObsSummary:
       observingMode,
       observationTime.map(_.toInstant),
       posAngleConstraint,
-      obsReference
+      obsReference,
+      workflowState
     )

--- a/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
+++ b/modules/web/client-model/src/main/scala/observe/ui/model/ObsSummary.scala
@@ -27,6 +27,7 @@ import lucuma.schemas.model.BasicConfiguration
 import lucuma.schemas.model.ObservingMode
 import monocle.Focus
 import org.typelevel.cats.time.*
+import lucuma.core.syntax.display.*
 
 import java.time.Instant
 import scala.collection.immutable.SortedSet
@@ -55,6 +56,9 @@ case class ObsSummary(
 
   lazy val constraintsSummary: String =
     s"${constraints.imageQuality.label} ${constraints.cloudExtinction.label} ${constraints.skyBackground.label} ${constraints.waterVapor.label}"
+
+  lazy val refAndId: String =
+    obsReference.fold(obsId.shortName)(ref => s"${ref.label} (${obsId.shortName})")
 
 object ObsSummary:
   val obsId              = Focus[ObsSummary](_.obsId)

--- a/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbObsSummary.scala
+++ b/modules/web/client-model/src/test/scala/observe/ui/model/arb/ArbObsSummary.scala
@@ -7,6 +7,7 @@ import cats.Order.given
 import eu.timepit.refined.scalacheck.string.given
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.model.Attachment
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Observation
@@ -45,6 +46,7 @@ trait ArbObsSummary:
       observationTime    <- arbitrary[Option[Instant]]
       posAngleConstraint <- arbitrary[PosAngleConstraint]
       obsReference       <- arbitrary[Option[ObservationReference]]
+      workflowState      <- arbitrary[ObservationWorkflowState]
     yield ObsSummary(
       obsId,
       programId,
@@ -57,7 +59,8 @@ trait ArbObsSummary:
       observingMode,
       observationTime,
       posAngleConstraint,
-      obsReference
+      obsReference,
+      workflowState
     )
 
   given Cogen[ObsSummary] =
@@ -73,7 +76,8 @@ trait ArbObsSummary:
        Option[ObservingMode],
        Option[Instant],
        PosAngleConstraint,
-       Option[ObservationReference]
+       Option[ObservationReference],
+       ObservationWorkflowState
       )
     ]
       .contramap: s =>
@@ -88,7 +92,8 @@ trait ArbObsSummary:
          s.observingMode,
          s.observationTime,
          s.posAngleConstraint,
-         s.obsReference
+         s.obsReference,
+         s.workflowState
         )
 
 object ArbObsSummary extends ArbObsSummary

--- a/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObsQueriesGQL.scala
@@ -15,7 +15,7 @@ object ObsQueriesGQL {
     val document = s"""
       query($$site: Site!, $$date: Date!) {
         observationsByWorkflowState(
-          states: [READY, ONGOING],
+          states: [READY, ONGOING, COMPLETED],
           WHERE: { 
             site: { EQ: $$site },
             program: {

--- a/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
+++ b/modules/web/client/src/clue/scala/observe/queries/ObservationSummarySubquery.scala
@@ -26,8 +26,7 @@ object ObservationSummarySubquery
           timingWindows $TimingWindowSubquery
           attachments { id }
           observingMode $ObservingModeSubquery
-          reference {
-            label
-          }
+          reference { label }
+          workflow { state }
         }
       """

--- a/modules/web/client/src/main/scala/observe/ui/components/Home.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/Home.scala
@@ -9,6 +9,7 @@ import crystal.react.*
 import crystal.syntax.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationReference
 import lucuma.core.model.Program
@@ -91,17 +92,18 @@ object Home
                 SplitterPanel(clazz = ObserveStyles.TopPanel)(
                   rootModelData.readyObservations
                     .map:
-                      _.map: obs =>
-                        SessionQueueRow(
-                          obs,
-                          SequenceState.Idle,
-                          props.rootModel.data.get.observer,
-                          ObsClass.Nighttime,
-                          false, // obs.activeStatus === ObsActiveStatus.Active,
-                          none,
-                          none,
-                          false
-                        )
+                      _.filterNot(_.workflowState === ObservationWorkflowState.Completed)
+                        .map: obs =>
+                          SessionQueueRow(
+                            obs,
+                            SequenceState.Idle,
+                            props.rootModel.data.get.observer,
+                            ObsClass.Nighttime,
+                            false, // obs.activeStatus === ObsActiveStatus.Active,
+                            none,
+                            none,
+                            false
+                          )
                     .renderPot(
                       SessionQueue(
                         _,

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/ObsHeader.scala
@@ -42,7 +42,7 @@ object ObsHeader
             props.requests,
             props.observation.instrument
           ),
-          s"${props.observation.title} [${props.observation.obsId}]",
+          s"${props.observation.title} [${props.observation.refAndId}]",
           props.linkToExploreObs:
             props.observation.obsReference
               .toRight((props.observation.programId, props.observation.obsId))

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
@@ -52,6 +52,8 @@ private trait SequenceTable[S, D <: DynamicConfig](
   private lazy val activeStepId: Option[Step.Id] = // collectFirst?
     executionState.loadedSteps.find(_.isActive).map(_.id)
 
+  // Obtain the id of the last recorded step only if its generated step id is the same
+  // as the currently executing step. This will be filtered out from the visit steps.
   protected[sequence] lazy val currentRecordedStepId: Option[Step.Id] =
     lastVisitStepIds.filter((_, generatedId) => activeStepId === generatedId).map(_._1)
 

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
@@ -12,7 +12,6 @@ import lucuma.core.enums.SequenceType
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.*
 import lucuma.core.model.sequence.gmos.*
-import lucuma.react.resizeDetector.hooks.*
 import lucuma.schemas.model.Visit
 import lucuma.ui.sequence.*
 import observe.model.ExecutionState
@@ -44,8 +43,17 @@ private trait SequenceTable[S, D <: DynamicConfig](
   def onDatasetQaChange: Dataset.Id => EditableQaFields => Callback
   def datasetIdsInFlight: Set[Dataset.Id]
 
+  private lazy val lastVisitStepIds: Option[(Step.Id, Option[Step.Id])] =
+    visits.lastOption
+      .flatMap(_.atoms.lastOption)
+      .flatMap(_.steps.lastOption)
+      .map(s => (s.id, s.generatedId))
+
+  private lazy val activeStepId: Option[Step.Id] = // collectFirst?
+    executionState.loadedSteps.find(_.isActive).map(_.id)
+
   protected[sequence] lazy val currentRecordedStepId: Option[Step.Id] =
-    currentRecordedVisit.flatMap(RecordedVisit.stepId.getOption).map(_.value)
+    lastVisitStepIds.filter((_, generatedId) => activeStepId === generatedId).map(_._1)
 
   private def futureSteps(atoms: List[Atom[D]]): List[SequenceRow.FutureStep[D]] =
     SequenceRow.FutureStep.fromAtoms(atoms, _ => none) // TODO Pass signal to noise

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
@@ -151,7 +151,7 @@ trait ServerEventHandler:
       case ClientEvent.ChecksOverrideEvent(_)                                             =>
         IO.unit // TODO Update the UI
       case ClientEvent.ObserveState(sequenceExecution, conditions, operator, recordedIds) =>
-        val nighttimeLoadedObsId = sequenceExecution.headOption.map(_._1)
+        val nighttimeLoadedObsId: Option[Observation.Id] = sequenceExecution.headOption.map(_._1)
 
         rootModelDataMod(
           RootModelData.operator.replace(operator) >>>
@@ -164,7 +164,7 @@ trait ServerEventHandler:
             RootModelData.obsRequests.replace(Map.empty) >>>
             RootModelData.nighttimeObservation.modify { obs =>
               // Only set if loaded obsId changed, otherwise config is lost.
-              if (obs.map(_.obsId) =!= nighttimeLoadedObsId)
+              if (nighttimeLoadedObsId.isDefined && obs.map(_.obsId) =!= nighttimeLoadedObsId)
                 nighttimeLoadedObsId.map(LoadedObservation(_))
               else
                 obs.map(LoadedObservation.refreshing.replace(false))

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveEventRoutes.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/ObserveEventRoutes.scala
@@ -94,6 +94,7 @@ class ObserveEventRoutes[F[_]: Async: Compression](
           // .filter(filterOutNull)
           .filter(filterOutOnClientId(clientId))
           .map(_._2)
+          .changes
           .map(toFrame)
 
       val clientSocket = (ws.remoteAddr, ws.remotePort).mapN((a, p) => s"$a:$p").orEmpty


### PR DESCRIPTION
This PR implements a more robust stitching algorithm which avoids duplicated steps when wrapping up atoms/sequence.

Also, it shows completed observations in the obs list, which avoids the recently completed sequence from disappearing. We don't want to actually show completed observations in the list, but this is a temporary workaround while I find another solution.