### PR TITLE
Setting QA for newly created step records used to fail

### DIFF
--- a/modules/web/client/src/main/scala/observe/ui/Icons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/Icons.scala
@@ -30,8 +30,8 @@ object Icons:
   val faBars: FAIcon = js.native
 
   @js.native
-  @JSImport("@fortawesome/pro-regular-svg-icons", "faCalendarDays")
-  private val faCalendarDays: FAIcon = js.native
+  @JSImport("@fortawesome/pro-solid-svg-icons", "faCalendar")
+  private val faCalendar: FAIcon = js.native
 
   @js.native
   @JSImport("@fortawesome/pro-solid-svg-icons", "faCaretRight")
@@ -164,7 +164,7 @@ object Icons:
     faArrowUpFromLine,
     faBan,
     faBars,
-    faCalendarDays,
+    faCalendar,
     faCaretRight,
     faCheck,
     faChevronDown,
@@ -203,7 +203,7 @@ object Icons:
   inline def ArrowUpFromLine   = FontAwesomeIcon(faArrowUpFromLine)
   inline def Ban               = FontAwesomeIcon(faBan)
   inline def Bars              = FontAwesomeIcon(faBars)
-  inline def CalendarDays      = FontAwesomeIcon(faCalendarDays)
+  inline def Calendar          = FontAwesomeIcon(faCalendar)
   inline def CaretRight        = FontAwesomeIcon(faCaretRight)
   inline def Check             = FontAwesomeIcon(faCheck)
   inline def ChevronDown       = FontAwesomeIcon(faChevronDown)
@@ -241,3 +241,9 @@ object Icons:
       Pause.withSize(IconSize.SM).withClass(ObserveStyles.IconSoft),
       Ban.withSize(IconSize.LG)
     )
+
+  val DaytimeCalendar =
+    LayeredIcon()(
+      Calendar,
+      Sun.withInverse().withTransform(Transform(y = 3, size = 9))
+    ).withFixedWidth().withSize(IconSize.LG)

--- a/modules/web/client/src/main/scala/observe/ui/components/Home.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/Home.scala
@@ -70,6 +70,8 @@ object Home
 
         (clientConfigPot, rootModelData.userVault.map(_.toPot).flatten).tupled
           .renderPot: (clientConfig, _) =>
+            val loadedObsId: Option[Observation.Id] =
+              rootModelData.nighttimeObservation.map(_.obsId)
 
             val renderExploreLinkToObs
               : Reusable[Either[(Program.Id, Observation.Id), ObservationReference] => VdomNode] =
@@ -99,10 +101,15 @@ object Home
                         .map: obs =>
                           SessionQueueRow(
                             obs,
-                            SequenceState.Idle,
+                            rootModelData.executionState
+                              .get(obs.obsId)
+                              .map(_.sequenceState)
+                              .getOrElse(SequenceState.Idle),
                             props.rootModel.data.get.observer,
                             ObsClass.Nighttime,
-                            false, // obs.activeStatus === ObsActiveStatus.Active,
+                            loadedObsId.contains_(obs.obsId),
+                            // We can't easily know step numbers nor the total number of steps.
+                            // Maybe we want to show pending and total times instead?
                             none,
                             none,
                             false
@@ -118,7 +125,7 @@ object Home
                       )
                     ),
                   ConfigPanel(
-                    rootModelData.nighttimeObservation.map(_.obsId),
+                    loadedObsId,
                     props.rootModel.data.zoom(RootModelData.observer),
                     props.rootModel.data.zoom(RootModelData.operator),
                     props.rootModel.data.zoom(RootModelData.conditions)

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -36,6 +36,7 @@ import lucuma.react.primereact.MessageItem
 import lucuma.react.primereact.hooks.all.*
 import lucuma.refined.*
 import lucuma.schemas.ObservationDB
+import lucuma.ui.LucumaStyles
 import lucuma.ui.components.SolarProgress
 import lucuma.ui.components.state.IfLogged
 import lucuma.ui.sso.*
@@ -76,7 +77,6 @@ import typings.loglevel.mod.LogLevelDesc
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
-import lucuma.ui.LucumaStyles
 
 object MainApp extends ServerEventHandler:
   private val ApiBasePath: Uri.Path = path"/api/observe/"

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -76,6 +76,7 @@ import typings.loglevel.mod.LogLevelDesc
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
+import lucuma.ui.LucumaStyles
 
 object MainApp extends ServerEventHandler:
   private val ApiBasePath: Uri.Path = path"/api/observe/"
@@ -255,7 +256,8 @@ object MainApp extends ServerEventHandler:
                         MessageItem(
                           id = "configApiError",
                           content = "Error saving changes",
-                          severity = Message.Severity.Error
+                          severity = Message.Severity.Error,
+                          clazz = LucumaStyles.Toast
                         )
                       .to[IO] >>
                       LogMessage

--- a/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/queue/SessionQueue.scala
@@ -182,14 +182,14 @@ object SessionQueue
         ),
         ColDef(
           AddQueueColumnId,
-          header = _ => renderCentered(Icons.CalendarDays), // Tooltip: Add all to queue
+          header = _ => renderCentered(Icons.DaytimeCalendar), // Tooltip: Add all to queue
           cell = cell => renderCentered(addToQueueRenderer(cell.row.original)),
           size = 30.toPx,
           enableResizing = false
         ),
         ColDef(
           ClassColumnId,
-          header = _ => renderCentered(Icons.Clock),        // Tooltip: "Obs. class"
+          header = _ => renderCentered(Icons.Clock),           // Tooltip: "Obs. class"
           cell = cell => renderCentered(classIconRenderer(cell.row.original)),
           size = 26.toPx,
           enableResizing = false

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/QaEditor.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/steps/QaEditor.scala
@@ -82,7 +82,7 @@ object QaEditor
               <.div(ObserveStyles.QaEditorPanelButtons)(
                 Button(icon = Icons.XMark, severity = Button.Severity.Danger).compact("Cancel"),
                 Button(icon = Icons.Check, severity = Button.Severity.Success).compact
-                  .withMods(^.`type` := "submit")(
+                  .withMods(^.`type` := "submit")( // This way it works with "Enter" key.
                     "Save"
                   )
               )

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
@@ -43,6 +43,7 @@ import observe.ui.model.enums.ApiStatus
 import observe.ui.model.enums.OperationRequest
 import observe.ui.model.enums.SyncStatus
 import org.typelevel.log4cats.Logger
+import lucuma.ui.LucumaStyles
 
 trait ServerEventHandler:
   private def logMessage(
@@ -203,7 +204,14 @@ trait ServerEventHandler:
         val node: VdomNode = <.span(msgs.mkTagMod(<.br))
 
         toast
-          .show(MessageItem(content = node, severity = Message.Severity.Error, sticky = true))
+          .show(
+            MessageItem(
+              content = node,
+              severity = Message.Severity.Error,
+              sticky = true,
+              clazz = LucumaStyles.Toast
+            )
+          )
           .to[IO] >>
           logMessage(rootModelDataMod, ObserveLogLevel.Error, msgs.mkString("; "))
       case LogEvent(msg)                                                                  =>

--- a/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/services/ServerEventHandler.scala
@@ -22,6 +22,7 @@ import lucuma.core.model.sequence.Step
 import lucuma.react.primereact.Message
 import lucuma.react.primereact.MessageItem
 import lucuma.react.primereact.ToastRef
+import lucuma.ui.LucumaStyles
 import monocle.Lens
 import monocle.Optional
 import observe.cats.given
@@ -43,7 +44,6 @@ import observe.ui.model.enums.ApiStatus
 import observe.ui.model.enums.OperationRequest
 import observe.ui.model.enums.SyncStatus
 import org.typelevel.log4cats.Logger
-import lucuma.ui.LucumaStyles
 
 trait ServerEventHandler:
   private def logMessage(


### PR DESCRIPTION
It was using a stale callback, it was now moved to table meta.

Also: improvements in observation table, which used to show some default data instead of the correct one (status, loaded).