### PR TITLE
Remove unnecessary refreshes, rename property

### DIFF
--- a/modules/engine/src/main/scala/observe/engine/Engine.scala
+++ b/modules/engine/src/main/scala/observe/engine/Engine.scala
@@ -52,7 +52,7 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
         {
           putS(id)(
             Sequence.State.status.replace(
-              SequenceState.Running(false, false, waitingNextAtom = true, isStarting = true)
+              SequenceState.Running(false, false, isWaitingUserPrompt = true, isStarting = true)
             )(
               seq.rollback
             )
@@ -141,10 +141,11 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                 // Final State
                 case Some(qs: Sequence.State.Final[F]) =>
                   putS(id)(qs) *> switch(id)(
-                    SequenceState.Running(userStop,
-                                          internalStop,
-                                          waitingNextAtom = true,
-                                          isStarting = false
+                    SequenceState.Running(
+                      userStop,
+                      internalStop,
+                      isWaitingUserPrompt = true,
+                      isStarting = false
                     )
                   ) *> send(modifyState(atomLoad(this, id)))
                 // Execution completed
@@ -162,10 +163,11 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                 // Final State
                 case Some(qs: Sequence.State.Final[F]) =>
                   putS(id)(qs) *> switch(id)(
-                    SequenceState.Running(userStop,
-                                          internalStop,
-                                          waitingNextAtom = true,
-                                          isStarting = false
+                    SequenceState.Running(
+                      userStop,
+                      internalStop,
+                      isWaitingUserPrompt = true,
+                      isStarting = false
                     )
                   ) *> send(modifyState(atomLoad(this, id)))
                 // Execution completed. Check breakpoint here
@@ -178,10 +180,11 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                                    } else if (seq.isLastAction)
                                      // after the last action of the step, we need to reload the sequence
                                      switch(id)(
-                                       SequenceState.Running(userStop,
-                                                             internalStop,
-                                                             waitingNextAtom = true,
-                                                             isStarting = false
+                                       SequenceState.Running(
+                                         userStop,
+                                         internalStop,
+                                         isWaitingUserPrompt = true,
+                                         isStarting = false
                                        )
                                      ) *>
                                        send(modifyState(atomReload(this, id)))

--- a/modules/engine/src/test/scala/observe/engine/StepSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/StepSuite.scala
@@ -338,10 +338,11 @@ class StepSuite extends CatsEffectSuite {
                ),
                done = Nil
              ),
-             SequenceState.Running(userStop = true,
-                                   internalStop = false,
-                                   waitingNextAtom = false,
-                                   isStarting = false
+             SequenceState.Running(
+               userStop = true,
+               internalStop = false,
+               isWaitingUserPrompt = false,
+               isStarting = false
              ),
              Map.empty
            )

--- a/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
@@ -17,10 +17,10 @@ import monocle.macros.GenPrism
 enum SequenceState(val name: String) derives Eq, Encoder, Decoder:
   case Idle                extends SequenceState("Idle")
   case Running(
-    userStop:        Boolean,
-    internalStop:    Boolean,
-    waitingNextAtom: Boolean,
-    isStarting:      Boolean
+    userStop:            Boolean,
+    internalStop:        Boolean,
+    isWaitingUserPrompt: Boolean,
+    isStarting:          Boolean
   )                        extends SequenceState("Running")
   case Completed           extends SequenceState("Completed")
   case Failed(msg: String) extends SequenceState("Failed")
@@ -76,7 +76,7 @@ object SequenceState:
       SequenceState.Running(
         userStop = false,
         internalStop = false,
-        waitingNextAtom = false,
+        isWaitingUserPrompt = false,
         isStarting = false
       )
 
@@ -85,8 +85,8 @@ object SequenceState:
     val internalStop: Lens[SequenceState.Running, Boolean] =
       Focus[SequenceState.Running](_.internalStop)
 
-    val waitingNextAtom: Lens[SequenceState.Running, Boolean] =
-      Focus[SequenceState.Running](_.waitingNextAtom)
+    val isWaitingUserPrompt: Lens[SequenceState.Running, Boolean] =
+      Focus[SequenceState.Running](_.isWaitingUserPrompt)
 
     val isStarting: Lens[SequenceState.Running, Boolean] =
       Focus[SequenceState.Running](_.isStarting)

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTable.scala
@@ -49,7 +49,7 @@ private trait SequenceTable[S, D <: DynamicConfig](
       .flatMap(_.steps.lastOption)
       .map(s => (s.id, s.generatedId))
 
-  private lazy val activeStepId: Option[Step.Id] = // collectFirst?
+  private lazy val activeStepId: Option[Step.Id] =
     executionState.loadedSteps.find(_.isActive).map(_.id)
 
   // Obtain the id of the last recorded step only if its generated step id is the same

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTableBuilder.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTableBuilder.scala
@@ -171,17 +171,6 @@ private trait SequenceTableBuilder[S: Eq, D <: DynamicConfig: Eq] extends Sequen
               )
             )
         odbQueryApi              <- useContext(ODBQueryApi.ctx)
-        // If the list of current steps changes, reload last visit and sequence.
-        _                        <-
-          useEffectWithDeps(props.currentAtomPendingSteps.map(_.id)): _ =>
-            // TODO Maybe this should be done by ObservationSyncer. For that, we need to know there when a step
-            // has completed. Maybe we can add an ODB event in the future.
-            odbQueryApi.refreshNighttimeSequence >> odbQueryApi.refreshNighttimeVisits
-        // We also refresh the visits whenever a new step starts executing. This will pull the current recorded step.
-        // This is necessary so that the step doesn't disappear when it completes.
-        _                        <-
-          useEffectWithDeps(props.currentRecordedStepId): _ =>
-            odbQueryApi.refreshNighttimeVisits
         virtualizerRef           <- useRef(none[HTMLTableVirtualizer])
         _                        <-
           useEffectOnMount:


### PR DESCRIPTION
Remove refresh code that is no longer needed now that we have event subscriptions.

Also, renamed the ambiguously named `waitingNextAtom` property to the more specific `isWaitingUserPrompt`.