### PR TITLE
Don't force step to running if waiting prompt, renames

### DIFF
--- a/modules/engine/src/main/scala/observe/engine/EngineStep.scala
+++ b/modules/engine/src/main/scala/observe/engine/EngineStep.scala
@@ -20,7 +20,29 @@ case class EngineStep[F[_]](
   id:         Step.Id,
   breakpoint: Breakpoint,
   executions: List[ParallelActions[F]]
-)
+):
+  /**
+   * Calculate the `Step` `Status` based on the underlying `Action`s.
+   */
+  lazy val status: StepState =
+    // Find an error in the Step
+    executions
+      .flatMap(_.toList)
+      .find(Action.errored)
+      .flatMap: x =>
+        x.state.runState match
+          case ActionState.Failed(Result.Error(msg)) => msg.some
+          case _                                     => None
+          // Return error or continue with the rest of the checks
+      .map[StepState](StepState.Failed.apply)
+      .getOrElse:
+        // All actions in this Step were completed successfully, or the Step is empty.
+        if (executions.flatMap(_.toList).exists(Action.aborted)) StepState.Aborted
+        else if (executions.flatMap(_.toList).forall(Action.completed)) StepState.Completed
+        else if (executions.flatMap(_.toList).forall(_.state.runState.isIdle))
+          StepState.Pending
+        // Not all actions are completed or pending.
+        else StepState.Running
 
 object EngineStep {
 
@@ -31,36 +53,6 @@ object EngineStep {
 
   def breakpointL[F[_]]: Lens[EngineStep[F], Boolean] =
     Focus[EngineStep[F]](_.breakpoint).andThen(isoBool)
-
-  /**
-   * Calculate the `Step` `Status` based on the underlying `Action`s.
-   */
-  private def status_[F[_]](step: EngineStep[F]): StepState =
-    // Find an error in the Step
-    step.executions
-      .flatMap(_.toList)
-      .find(Action.errored)
-      .flatMap { x =>
-        x.state.runState match {
-          case ActionState.Failed(Result.Error(msg)) => msg.some
-          case _                                     => None
-          // Return error or continue with the rest of the checks
-        }
-      }
-      .map[StepState](StepState.Failed.apply)
-      .getOrElse(
-        // All actions in this Step were completed successfully, or the Step is empty.
-        if (step.executions.flatMap(_.toList).exists(Action.aborted)) StepState.Aborted
-        else if (step.executions.flatMap(_.toList).forall(Action.completed)) StepState.Completed
-        else if (step.executions.flatMap(_.toList).forall(_.state.runState.isIdle))
-          StepState.Pending
-        // Not all actions are completed or pending.
-        else StepState.Running
-      )
-
-  extension [F[_]](s: EngineStep[F]) {
-    def status: StepState = EngineStep.status_(s)
-  }
 
   /**
    * Step Zipper. This structure is optimized for the actual `Step` execution.

--- a/modules/engine/src/main/scala/observe/engine/Sequence.scala
+++ b/modules/engine/src/main/scala/observe/engine/Sequence.scala
@@ -239,6 +239,8 @@ object Sequence {
       case _                                 => false
     }
 
+    def isWaitingUserPrompt[F[_]](st: State[F]): Boolean = st.status.isWaitingPrompt
+
     def userStopSet[F[_]](v: Boolean): State[F] => State[F] = status.modify {
       case r @ SequenceState.Running(_, _, _, _) => r.copy(userStop = v)
       case r                                     => r

--- a/modules/model/shared/src/main/scala/observe/model/ExecutionState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ExecutionState.scala
@@ -44,7 +44,7 @@ case class ExecutionState(
     )
 
   lazy val isWaitingAcquisitionPrompt: Boolean =
-    sequenceType === SequenceType.Acquisition && sequenceState.isWaitingNextAtom
+    sequenceType === SequenceType.Acquisition && sequenceState.isWaitingPrompt
 
 object ExecutionState:
   val sequenceState: Lens[ExecutionState, SequenceState]                                          = Focus[ExecutionState](_.sequenceState)

--- a/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
@@ -52,11 +52,11 @@ enum SequenceState(val name: String) derives Eq, Encoder, Decoder:
       case SequenceState.Running(_, _, _, _) => true
       case _                                 => false
 
-  def isWaitingNextAtom: Boolean =
+  def isWaitingPrompt: Boolean =
     this match
-      case SequenceState.Running(_, _, waitingNextAtom, isStarting) =>
-        waitingNextAtom && !isStarting
-      case _                                                        =>
+      case SequenceState.Running(_, _, isWaitingUserPrompt, isStarting) =>
+        isWaitingUserPrompt && !isStarting
+      case _                                                            =>
         false
 
   def isCompleted: Boolean =

--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -1706,8 +1706,10 @@ object ObserveEngine {
         // The sequence could be empty
         case Nil => Nil
         // Find first Pending ObserveStep when no ObserveStep is Running and mark it as Running
+        // When waiting user prompt, the sequence is Running, but no steps are.
         case steps
-            if Sequence.State.isRunning(st) && steps.forall(_.status =!= StepState.Running) =>
+            if (Sequence.State.isRunning(st) && !Sequence.State.isWaitingUserPrompt(st)) && steps
+              .forall(_.status =!= StepState.Running) =>
           val (xs, ys) = splitWhere(steps)(_.status === StepState.Pending)
           xs ++ ys.headOption.map(ObserveStep.status.replace(StepState.Running)).toList ++ ys.tail
         case steps

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
@@ -38,7 +38,7 @@ case class SeqControlButtons(
   val isPauseInFlight: Boolean       = requests.pause === OperationRequest.InFlight
   val isCancelPauseInFlight: Boolean = requests.cancelPause === OperationRequest.InFlight
   val isRunning: Boolean             = sequenceState.isRunning
-  val isWaitingNextAtom: Boolean     = sequenceState.isWaitingNextAtom
+  val isWaitingNextAtom: Boolean     = sequenceState.isWaitingPrompt
   val isRefreshing: Boolean          = props.refreshing.exists(_.get)
 
 object SeqControlButtons

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTableBuilder.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTableBuilder.scala
@@ -187,7 +187,7 @@ private trait SequenceTableBuilder[S: Eq, D <: DynamicConfig: Eq] extends Sequen
         _                        <-
           useEffectWithDeps(
             (props.executionState.sequenceState.isRunning,
-             props.executionState.sequenceState.isWaitingNextAtom
+             props.executionState.sequenceState.isWaitingPrompt
             )
           ): _ =>
             val autoScrollCandidates: List[String] =


### PR DESCRIPTION
When the sequence is waiting user prompt, it's state is `Running` but no step is running. The engine used to force the first step to running if the sequence is `Running`, but we don't want this if waiting user prompt.

Also: clarifying renames.