### PR TITLE
Avoid acquisition popup after 1st step

### DIFF
--- a/modules/engine/src/main/scala/observe/engine/Engine.scala
+++ b/modules/engine/src/main/scala/observe/engine/Engine.scala
@@ -55,9 +55,9 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
               SequenceState.Running(
                 userStop = false,
                 internalStop = false,
-                isWaitingUserPrompt = false,
-                isWaitingNextAtom = true,
-                isStarting = true
+                waitingUserPrompt = false,
+                waitingNextAtom = true,
+                starting = true
               )
             )(
               seq.rollback
@@ -150,9 +150,9 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                     SequenceState.Running(
                       userStop,
                       internalStop,
-                      isWaitingUserPrompt = true,
-                      isWaitingNextAtom = true,
-                      isStarting = false
+                      waitingUserPrompt = true,
+                      waitingNextAtom = true,
+                      starting = false
                     )
                   ) *> send(modifyState(atomLoad(this, id)))
                 // Execution completed
@@ -173,9 +173,9 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                     SequenceState.Running(
                       userStop,
                       internalStop,
-                      isWaitingUserPrompt = true,
-                      isWaitingNextAtom = true,
-                      isStarting = false
+                      waitingUserPrompt = true,
+                      waitingNextAtom = true,
+                      starting = false
                     )
                   ) *> send(modifyState(atomLoad(this, id)))
                 // Execution completed. Check breakpoint here
@@ -192,9 +192,9 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                          SequenceState.Running(
                            userStop,
                            internalStop,
-                           isWaitingUserPrompt = false,
-                           isWaitingNextAtom = true,
-                           isStarting = false
+                           waitingUserPrompt = false,
+                           waitingNextAtom = true,
+                           starting = false
                          )
                        ) *>
                          send(modifyState(atomReload(this, id)))
@@ -227,9 +227,8 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                   if (!isStarting && seq.getCurrentBreakpoint) {
                     switch(id)(SequenceState.Idle) *> send(breakpointReached(id))
                   } else
-                    switch(id)(SequenceState.Running(false, false, false, false, false)) *> send(
-                      executing(id)
-                    )
+                    switch(id)(SequenceState.Running(false, false, false, false, false)) *>
+                      send(executing(id))
               }
             }
           case _                                                                  => unit

--- a/modules/engine/src/main/scala/observe/engine/Engine.scala
+++ b/modules/engine/src/main/scala/observe/engine/Engine.scala
@@ -52,7 +52,13 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
         {
           putS(id)(
             Sequence.State.status.replace(
-              SequenceState.Running(false, false, isWaitingUserPrompt = true, isStarting = true)
+              SequenceState.Running(
+                userStop = false,
+                internalStop = false,
+                isWaitingUserPrompt = false,
+                isWaitingNextAtom = true,
+                isStarting = true
+              )
             )(
               seq.rollback
             )
@@ -133,7 +139,7 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
     getS(id).flatMap(
       _.map { seq =>
         seq.status match {
-          case SequenceState.Running(userStop, internalStop, _, _) =>
+          case SequenceState.Running(userStop, internalStop, _, _, _) =>
             if (userStop || internalStop) {
               seq.next match {
                 case None                              =>
@@ -145,6 +151,7 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                       userStop,
                       internalStop,
                       isWaitingUserPrompt = true,
+                      isWaitingNextAtom = true,
                       isStarting = false
                     )
                   ) *> send(modifyState(atomLoad(this, id)))
@@ -167,31 +174,34 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                       userStop,
                       internalStop,
                       isWaitingUserPrompt = true,
+                      isWaitingNextAtom = true,
                       isStarting = false
                     )
                   ) *> send(modifyState(atomLoad(this, id)))
                 // Execution completed. Check breakpoint here
                 case Some(qs)                          =>
-                  putS(id)(qs) *> (if (
-                                     qs.getCurrentBreakpoint && !qs.current.execution
-                                       .exists(_.uninterruptible)
-                                   ) {
-                                     switch(id)(SequenceState.Idle) *> send(breakpointReached(id))
-                                   } else if (seq.isLastAction)
-                                     // after the last action of the step, we need to reload the sequence
-                                     switch(id)(
-                                       SequenceState.Running(
-                                         userStop,
-                                         internalStop,
-                                         isWaitingUserPrompt = true,
-                                         isStarting = false
-                                       )
-                                     ) *>
-                                       send(modifyState(atomReload(this, id)))
-                                   else send(executing(id)))
+                  putS(id)(qs) *>
+                    (if (
+                       qs.getCurrentBreakpoint && !qs.current.execution
+                         .exists(_.uninterruptible)
+                     ) {
+                       switch(id)(SequenceState.Idle) *> send(breakpointReached(id))
+                     } else if (seq.isLastAction)
+                       // after the last action of the step, we need to reload the sequence
+                       switch(id)(
+                         SequenceState.Running(
+                           userStop,
+                           internalStop,
+                           isWaitingUserPrompt = false,
+                           isWaitingNextAtom = true,
+                           isStarting = false
+                         )
+                       ) *>
+                         send(modifyState(atomReload(this, id)))
+                     else send(executing(id)))
               }
             }
-          case _                                                   => unit
+          case _                                                      => unit
         }
       }.getOrElse(unit)
     )
@@ -200,7 +210,7 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
     getS(id).flatMap(
       _.map { seq =>
         seq.status match {
-          case SequenceState.Running(userStop, internalStop, true, isStarting) =>
+          case SequenceState.Running(userStop, internalStop, _, true, isStarting) =>
             if (!isStarting && (userStop || internalStop)) {
               seq match {
                 // Final State
@@ -217,12 +227,12 @@ class Engine[F[_]: MonadThrow: Logger, S, U] private (
                   if (!isStarting && seq.getCurrentBreakpoint) {
                     switch(id)(SequenceState.Idle) *> send(breakpointReached(id))
                   } else
-                    switch(id)(SequenceState.Running(false, false, false, false)) *> send(
+                    switch(id)(SequenceState.Running(false, false, false, false, false)) *> send(
                       executing(id)
                     )
               }
             }
-          case _                                                               => unit
+          case _                                                                  => unit
         }
       }.getOrElse(unit)
     )

--- a/modules/engine/src/main/scala/observe/engine/Sequence.scala
+++ b/modules/engine/src/main/scala/observe/engine/Sequence.scala
@@ -239,7 +239,9 @@ object Sequence {
       case _                                    => false
     }
 
-    def isWaitingUserPrompt[F[_]](st: State[F]): Boolean = st.status.isWaitingPrompt
+    def isWaitingUserPrompt[F[_]](st: State[F]): Boolean = st.status.isWaitingUserPrompt
+
+    def isStarting[F[_]](st: State[F]): Boolean = st.status.isStarting
 
     def userStopSet[F[_]](v: Boolean): State[F] => State[F] = status.modify {
       case r @ SequenceState.Running(_, _, _, _, _) => r.copy(userStop = v)

--- a/modules/engine/src/main/scala/observe/engine/Sequence.scala
+++ b/modules/engine/src/main/scala/observe/engine/Sequence.scala
@@ -235,20 +235,20 @@ object Sequence {
     def userStopRequested[F[_]](st: State[F]): Boolean = st.status.isUserStopRequested
 
     def anyStopRequested[F[_]](st: State[F]): Boolean = st.status match {
-      case SequenceState.Running(u, i, _, _) => u || i
-      case _                                 => false
+      case SequenceState.Running(u, i, _, _, _) => u || i
+      case _                                    => false
     }
 
     def isWaitingUserPrompt[F[_]](st: State[F]): Boolean = st.status.isWaitingPrompt
 
     def userStopSet[F[_]](v: Boolean): State[F] => State[F] = status.modify {
-      case r @ SequenceState.Running(_, _, _, _) => r.copy(userStop = v)
-      case r                                     => r
+      case r @ SequenceState.Running(_, _, _, _, _) => r.copy(userStop = v)
+      case r                                        => r
     }
 
     def internalStopSet[F[_]](v: Boolean): State[F] => State[F] = status.modify {
-      case r @ SequenceState.Running(_, _, _, _) => r.copy(internalStop = v)
-      case r                                     => r
+      case r @ SequenceState.Running(_, _, _, _, _) => r.copy(internalStop = v)
+      case r                                        => r
     }
 
     /**

--- a/modules/engine/src/test/scala/observe/engine/StepSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/StepSuite.scala
@@ -342,6 +342,7 @@ class StepSuite extends CatsEffectSuite {
                userStop = true,
                internalStop = false,
                isWaitingUserPrompt = false,
+               isWaitingNextAtom = false,
                isStarting = false
              ),
              Map.empty

--- a/modules/engine/src/test/scala/observe/engine/StepSuite.scala
+++ b/modules/engine/src/test/scala/observe/engine/StepSuite.scala
@@ -341,9 +341,9 @@ class StepSuite extends CatsEffectSuite {
              SequenceState.Running(
                userStop = true,
                internalStop = false,
-               isWaitingUserPrompt = false,
-               isWaitingNextAtom = false,
-               isStarting = false
+               waitingUserPrompt = false,
+               waitingNextAtom = false,
+               starting = false
              ),
              Map.empty
            )

--- a/modules/model/shared/src/main/scala/observe/model/ExecutionState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/ExecutionState.scala
@@ -44,7 +44,7 @@ case class ExecutionState(
     )
 
   lazy val isWaitingAcquisitionPrompt: Boolean =
-    sequenceType === SequenceType.Acquisition && sequenceState.isWaitingPrompt
+    sequenceType === SequenceType.Acquisition && sequenceState.isWaitingUserPrompt
 
 object ExecutionState:
   val sequenceState: Lens[ExecutionState, SequenceState]                                          = Focus[ExecutionState](_.sequenceState)

--- a/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
@@ -90,8 +90,11 @@ object SequenceState:
     val internalStop: Lens[SequenceState.Running, Boolean] =
       Focus[SequenceState.Running](_.internalStop)
 
-    // val isWaitingUserPrompt: Lens[SequenceState.Running, Boolean] =
-    //   Focus[SequenceState.Running](_.isWaitingUserPrompt)
+    val waitingUserPrompt: Lens[SequenceState.Running, Boolean] =
+      Focus[SequenceState.Running](_.waitingUserPrompt)
 
-    // val isStarting: Lens[SequenceState.Running, Boolean] =
-    //   Focus[SequenceState.Running](_.isStarting)
+    val waitingNextAtom: Lens[SequenceState.Running, Boolean] =
+      Focus[SequenceState.Running](_.waitingNextAtom)
+
+    val starting: Lens[SequenceState.Running, Boolean] =
+      Focus[SequenceState.Running](_.starting)

--- a/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
@@ -20,6 +20,7 @@ enum SequenceState(val name: String) derives Eq, Encoder, Decoder:
     userStop:            Boolean,
     internalStop:        Boolean,
     isWaitingUserPrompt: Boolean,
+    isWaitingNextAtom:   Boolean,
     isStarting:          Boolean
   )                        extends SequenceState("Running")
   case Completed           extends SequenceState("Completed")
@@ -28,13 +29,13 @@ enum SequenceState(val name: String) derives Eq, Encoder, Decoder:
 
   def isUserStopRequested: Boolean =
     this match
-      case SequenceState.Running(b, _, _, _) => b
-      case _                                 => false
+      case SequenceState.Running(b, _, _, _, _) => b
+      case _                                    => false
 
   def isInternalStopRequested: Boolean =
     this match
-      case SequenceState.Running(_, b, _, _) => b
-      case _                                 => false
+      case SequenceState.Running(_, b, _, _, _) => b
+      case _                                    => false
 
   def isStopRequested: Boolean =
     isUserStopRequested || isInternalStopRequested
@@ -49,15 +50,13 @@ enum SequenceState(val name: String) derives Eq, Encoder, Decoder:
 
   def isRunning: Boolean =
     this match
-      case SequenceState.Running(_, _, _, _) => true
-      case _                                 => false
+      case SequenceState.Running(_, _, _, _, _) => true
+      case _                                    => false
 
   def isWaitingPrompt: Boolean =
     this match
-      case SequenceState.Running(_, _, isWaitingUserPrompt, isStarting) =>
-        isWaitingUserPrompt && !isStarting
-      case _                                                            =>
-        false
+      case SequenceState.Running(_, _, isWaitingUserPrompt, _, _) => isWaitingUserPrompt
+      case _                                                      => false
 
   def isCompleted: Boolean =
     this === SequenceState.Completed
@@ -77,6 +76,7 @@ object SequenceState:
         userStop = false,
         internalStop = false,
         isWaitingUserPrompt = false,
+        isWaitingNextAtom = false,
         isStarting = false
       )
 

--- a/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceState.scala
@@ -17,11 +17,11 @@ import monocle.macros.GenPrism
 enum SequenceState(val name: String) derives Eq, Encoder, Decoder:
   case Idle                extends SequenceState("Idle")
   case Running(
-    userStop:            Boolean,
-    internalStop:        Boolean,
-    isWaitingUserPrompt: Boolean,
-    isWaitingNextAtom:   Boolean,
-    isStarting:          Boolean
+    userStop:          Boolean,
+    internalStop:      Boolean,
+    waitingUserPrompt: Boolean,
+    waitingNextAtom:   Boolean,
+    starting:          Boolean
   )                        extends SequenceState("Running")
   case Completed           extends SequenceState("Completed")
   case Failed(msg: String) extends SequenceState("Failed")
@@ -53,10 +53,15 @@ enum SequenceState(val name: String) derives Eq, Encoder, Decoder:
       case SequenceState.Running(_, _, _, _, _) => true
       case _                                    => false
 
-  def isWaitingPrompt: Boolean =
+  def isWaitingUserPrompt: Boolean =
     this match
-      case SequenceState.Running(_, _, isWaitingUserPrompt, _, _) => isWaitingUserPrompt
-      case _                                                      => false
+      case SequenceState.Running(_, _, waitingUserPrompt, _, _) => waitingUserPrompt
+      case _                                                    => false
+
+  def isStarting: Boolean =
+    this match
+      case SequenceState.Running(_, _, _, _, starting) => starting
+      case _                                           => false
 
   def isCompleted: Boolean =
     this === SequenceState.Completed
@@ -75,9 +80,9 @@ object SequenceState:
       SequenceState.Running(
         userStop = false,
         internalStop = false,
-        isWaitingUserPrompt = false,
-        isWaitingNextAtom = false,
-        isStarting = false
+        waitingUserPrompt = false,
+        waitingNextAtom = false,
+        starting = false
       )
 
     val userStop: Lens[SequenceState.Running, Boolean] = Focus[SequenceState.Running](_.userStop)
@@ -85,8 +90,8 @@ object SequenceState:
     val internalStop: Lens[SequenceState.Running, Boolean] =
       Focus[SequenceState.Running](_.internalStop)
 
-    val isWaitingUserPrompt: Lens[SequenceState.Running, Boolean] =
-      Focus[SequenceState.Running](_.isWaitingUserPrompt)
+    // val isWaitingUserPrompt: Lens[SequenceState.Running, Boolean] =
+    //   Focus[SequenceState.Running](_.isWaitingUserPrompt)
 
-    val isStarting: Lens[SequenceState.Running, Boolean] =
-      Focus[SequenceState.Running](_.isStarting)
+    // val isStarting: Lens[SequenceState.Running, Boolean] =
+    //   Focus[SequenceState.Running](_.isStarting)

--- a/modules/model/shared/src/main/scala/observe/model/SequenceView.scala
+++ b/modules/model/shared/src/main/scala/observe/model/SequenceView.scala
@@ -34,10 +34,10 @@ case class SequenceView(
 
   // Returns where on the sequence the execution is at
   def runningStep: Option[RunningStep] = status match
-    case SequenceState.Running(_, _, _, _) => progress
-    case SequenceState.Failed(_)           => progress
-    case SequenceState.Aborted             => progress
-    case _                                 => none
+    case SequenceState.Running(_, _, _, _, _) => progress
+    case SequenceState.Failed(_)              => progress
+    case SequenceState.Aborted                => progress
+    case _                                    => none
 
   def pausedStep = steps.find(_.isObservePaused).map(_.id).map(PausedStep(_))
 

--- a/modules/model/shared/src/main/scala/observe/model/arb/ObserveModelArbitraries.scala
+++ b/modules/model/shared/src/main/scala/observe/model/arb/ObserveModelArbitraries.scala
@@ -99,9 +99,10 @@ trait ObserveModelArbitraries {
     for {
       u <- arbitrary[Boolean]
       i <- arbitrary[Boolean]
+      w <- arbitrary[Boolean]
       a <- arbitrary[Boolean]
       s <- arbitrary[Boolean]
-    } yield SequenceState.Running(u, i, a, s)
+    } yield SequenceState.Running(u, i, w, a, s)
   }
 
   given Arbitrary[SequenceState] = Arbitrary[SequenceState] {

--- a/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
@@ -939,7 +939,9 @@ class ObserveEngineSuite extends TestCommon {
       s1             =
         EngineState
           .sequenceStateIndex[IO](seqObsId1)
-          .modify(x => Sequence.State.Final(x.toSequence, Running(false, false, true, false)))(s0)
+          .modify(x =>
+            Sequence.State.Final(x.toSequence, Running(false, false, false, true, false))
+          )(s0)
       observeEngine <- ObserveEngine.build(Site.GS, systems, defaultSettings)
       eo             = EngineObserver(observeEngine, s1)
       r             <-

--- a/modules/web/client/src/main/scala/observe/ui/components/queue/ObsListPopup.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/queue/ObsListPopup.scala
@@ -86,7 +86,7 @@ object ObsListPopup
             case (Some(Pot.Ready(_)), Some(SequenceState.Idle))                                => Icons.FileCheck
             case (Some(Pot.Ready(_)), Some(SequenceState.Completed))                           =>
               Icons.FileCheck
-            case (Some(Pot.Ready(_)), Some(SequenceState.Running(_, _, _, _)))                 =>
+            case (Some(Pot.Ready(_)), Some(SequenceState.Running(_, _, _, _, _)))              =>
               LucumaIcons.CircleNotch
             case (Some(Pot.Ready(_)), Some(SequenceState.Failed(_))) | (Some(Pot.Error(_)), _) =>
               Icons.FileCross

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SeqControlButtons.scala
@@ -38,7 +38,7 @@ case class SeqControlButtons(
   val isPauseInFlight: Boolean       = requests.pause === OperationRequest.InFlight
   val isCancelPauseInFlight: Boolean = requests.cancelPause === OperationRequest.InFlight
   val isRunning: Boolean             = sequenceState.isRunning
-  val isWaitingNextAtom: Boolean     = sequenceState.isWaitingPrompt
+  val isWaitingNextAtom: Boolean     = sequenceState.isWaitingUserPrompt
   val isRefreshing: Boolean          = props.refreshing.exists(_.get)
 
 object SeqControlButtons

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTableBuilder.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTableBuilder.scala
@@ -187,7 +187,7 @@ private trait SequenceTableBuilder[S: Eq, D <: DynamicConfig: Eq] extends Sequen
         _                        <-
           useEffectWithDeps(
             (props.executionState.sequenceState.isRunning,
-             props.executionState.sequenceState.isWaitingPrompt
+             props.executionState.sequenceState.isWaitingUserPrompt
             )
           ): _ =>
             val autoScrollCandidates: List[String] =


### PR DESCRIPTION
It turns out we do need a `waitingNextAtom` parameter, but after the latest changes we can't derive whether to show the prompt or not from it.

In this PR, I'm decoupling both concepts and introducing explicit parameters for each.