### PR TITLE
Make Handle an opaque type, make it a MonadThrow, add law test

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngine.scala
@@ -4,7 +4,6 @@
 package observe.server
 
 import cats.Endo
-import cats.Monad
 import cats.MonadThrow
 import cats.Monoid
 import cats.effect.Async
@@ -395,7 +394,7 @@ object ObserveEngine {
   ): Set[Observation.Id] =
     findRunnableObservations(qid)(st).intersect(sids)
 
-  private def onAtomComplete[F[_]: Monad](
+  private def onAtomComplete[F[_]: MonadThrow](
     odb:           OdbProxy[F],
     translator:    SeqTranslate[F]
   )(
@@ -470,7 +469,7 @@ object ObserveEngine {
             )
         }(st)
 
-  def tryNewAtom[F[_]: Monad](
+  def tryNewAtom[F[_]: MonadThrow](
     odb:           OdbProxy[F],
     translator:    SeqTranslate[F],
     executeEngine: Engine[F],

--- a/modules/server_new/src/main/scala/observe/server/engine/Engine.scala
+++ b/modules/server_new/src/main/scala/observe/server/engine/Engine.scala
@@ -536,7 +536,7 @@ class Engine[F[_]: MonadThrow: Logger] private (
   )(ev: Event[F], s: EngineState[F])(using
     ci:            Concurrent[F]
   ): F[(EngineState[F], (EventResult, EngineState[F]), Stream[F, Event[F]])] =
-    run(onSystemEvent)(ev).run.run(s).map { case (si, (r, p)) =>
+    run(onSystemEvent)(ev).stateT.run(s).map { case (si, (r, p)) =>
       (si, (r, si), p)
     }
 

--- a/modules/server_new/src/main/scala/observe/server/engine/Handle.scala
+++ b/modules/server_new/src/main/scala/observe/server/engine/Handle.scala
@@ -6,6 +6,7 @@ package observe.engine
 import cats.Applicative
 import cats.Functor
 import cats.Monad
+import cats.MonadThrow
 import cats.data.StateT
 import cats.syntax.all.*
 import fs2.Stream
@@ -24,75 +25,51 @@ import fs2.Stream
  * @tparam O:
  *   Type of the output (usually Unit)
  */
-final case class Handle[F[_], S, E, O](run: StateT[F, S, (O, Stream[F, E])])
+opaque type Handle[F[_], S, E, O] = StateT[F, S, (O, Stream[F, E])]
 
 object Handle {
-  def fromEventStream[F[_]: Monad, S, E](f: S => Stream[F, E]): Handle[F, S, E, Unit] =
-    getState.flatMap: s =>
-      Handle[F, S, E, Unit]:
-        Applicative[StateT[F, S, *]].pure(((), f(s)))
+  inline def apply[F[_], S, E, O](stateT: StateT[F, S, (O, Stream[F, E])]): Handle[F, S, E, O] =
+    stateT
 
-  inline def fromEventStream[F[_]: Monad, S, E](p: Stream[F, E]): Handle[F, S, E, Unit] =
+  extension [F[_], S, E, O](self: Handle[F, S, E, O])
+    inline def stateT: StateT[F, S, (O, Stream[F, E])] = self
+
+  def modifyStateEmit[F[_]: MonadThrow, S, E](
+    f: S => F[(S, Stream[F, E])]
+  ): Handle[F, S, E, Unit] =
+    Handle[F, S, E, Unit]:
+      StateT: s0 =>
+        f(s0).map: (s1, p) =>
+          (s1, ((), p))
+
+  inline def modifyStateEmitSingle[F[_]: MonadThrow, S, E](
+    f: S => F[(S, E)]
+  ): Handle[F, S, E, Unit] =
+    modifyStateEmit(s => f(s).map((s, e) => (s, Stream(e))))
+
+  inline def fromEventStream[F[_]: MonadThrow, S, E](f: S => Stream[F, E]): Handle[F, S, E, Unit] =
+    modifyStateEmit(s => Applicative[F].pure((s, f(s))))
+
+  inline def fromEventStream[F[_]: MonadThrow, S, E](p: Stream[F, E]): Handle[F, S, E, Unit] =
     fromEventStream(_ => p)
 
-  inline def fromSingleEventF[F[_]: Monad, S, E](f: F[E]): Handle[F, S, E, Unit] =
-    fromEventStream(Stream.eval(f))
+  inline def fromSingleEventF[F[_]: MonadThrow, S, E](f: F[E]): Handle[F, S, E, Unit] =
+    modifyStateEmitSingle(s => f.map((s, _)))
 
-  inline def fromSingleEvent[F[_]: Monad, S, E](e: E): Handle[F, S, E, Unit] =
+  inline def fromSingleEvent[F[_]: MonadThrow, S, E](e: E): Handle[F, S, E, Unit] =
     fromSingleEventF(e.pure[F])
 
-  inline def liftF[F[_]: Monad, S, E, O](f: F[O]): Handle[F, S, E, O] =
+  inline def liftF[F[_]: MonadThrow, S, E, O](f: F[O]): Handle[F, S, E, O] =
     fromStateT(StateT.liftF[F, S, O](f))
 
-  inline def pure[F[_]: Monad, S, E, O](a: O): Handle[F, S, E, O] =
+  inline def pure[F[_]: MonadThrow, S, E, O](a: O): Handle[F, S, E, O] =
     Handle[F, S, E, O]:
       Applicative[StateT[F, S, *]].pure((a, Stream.empty))
-
-  given [F[_]: Monad, S, E]: Monad[Handle[F, S, E, *]] =
-    new Monad[Handle[F, S, E, *]] {
-      override def pure[O](a: O): Handle[F, S, E, O] =
-        Handle:
-          Applicative[StateT[F, S, *]].pure((a, Stream.empty))
-
-      override def flatMap[O, O1](
-        fa: Handle[F, S, E, O]
-      )(f: O => Handle[F, S, E, O1]): Handle[F, S, E, O1] =
-        Handle[F, S, E, O1]:
-          fa.run.flatMap: (a, p1) =>
-            f(a).run.map: (b, p2) =>
-              (b, p1 ++ p2)
-
-      // Kudos to @tpolecat
-      def tailRecM[O, O1](a: O)(f: O => Handle[F, S, E, Either[O, O1]]): Handle[F, S, E, O1] = {
-        // Construct a StateT that delegates to F's tailRecM
-        val st: StateT[F, S, (O1, Stream[F, E])] =
-          StateT: s =>
-            Monad[F].tailRecM[(S, O), (S, (O1, Stream[F, E]))]((s, a)): (s, a) =>
-              f(a).run
-                .run(s)
-                .map:
-                  case (sʹ, (Left(a), _))  => Left((sʹ, a))
-                  case (sʹ, (Right(b), u)) => Right((sʹ, (b, u)))
-
-        // Done
-        Handle(st)
-      }
-    }
-
-  // This class adds a method to Handle similar to flatMap, but the Streams resulting from both Handle instances
-  // are concatenated in the reverse order.
-  extension [F[_]: Monad, S, E, O](self: Handle[F, S, E, O]) {
-    def reversedStreamFlatMap[O1](f: O => Handle[F, S, E, O1]): Handle[F, S, E, O1] =
-      Handle[F, S, E, O1]:
-        self.run.flatMap: (a, p1) =>
-          f(a).run.map: (b, p2) =>
-            (b, p2 ++ p1)
-  }
 
   inline def fromStateT[F[_]: Functor, S, E, O](s: StateT[F, S, O]): Handle[F, S, E, O] =
     Handle[F, S, E, O](s.map((_, Stream.empty)))
 
-  inline def unit[F[_]: Monad, S, E]: Handle[F, S, E, Unit] =
+  inline def unit[F[_]: MonadThrow, S, E]: Handle[F, S, E, Unit] =
     Applicative[Handle[F, S, E, *]].unit
 
   inline def getState[F[_]: Applicative, S, E]: Handle[F, S, E, S] =
@@ -109,4 +86,58 @@ object Handle {
 
   inline def modifyState_[F[_]: Applicative, S, E](f: S => S): Handle[F, S, E, Unit] =
     modifyState(s => (f(s), ()))
+
+  given [F[_]: MonadThrow, S, E]: MonadThrow[Handle[F, S, E, *]] =
+    new MonadThrow[Handle[F, S, E, *]] {
+
+      override def pure[O](a: O): Handle[F, S, E, O] =
+        Handle:
+          Applicative[StateT[F, S, *]].pure((a, Stream.empty))
+
+      override def flatMap[O, O1](
+        fa: Handle[F, S, E, O]
+      )(f: O => Handle[F, S, E, O1]): Handle[F, S, E, O1] =
+        Handle[F, S, E, O1]:
+          fa.stateT.flatMap: (a, p1) =>
+            f(a).stateT.map: (b, p2) =>
+              (b, p1 ++ p2)
+
+      // Kudos to @tpolecat
+      def tailRecM[O, O1](o: O)(f: O => Handle[F, S, E, Either[O, O1]]): Handle[F, S, E, O1] = {
+        // Construct a StateT that delegates to F's tailRecM
+        val st: StateT[F, S, (O1, Stream[F, E])] =
+          StateT: s =>
+            Monad[F].tailRecM[(S, (O, Stream[F, E])), (S, (O1, Stream[F, E]))](
+              (s, (o, Stream.empty))
+            ) { case (s0, (o0, es0)) =>
+              f(o0).stateT
+                .run(s0)
+                .map:
+                  case (s1, (Left(o1), es1))  => Left((s1, (o1, es0 ++ es1)))
+                  case (s1, (Right(o1), es1)) => Right((s1, (o1, es0 ++ es1)))
+            }
+
+        // Done
+        Handle(st)
+      }
+
+      override def raiseError[A](e: Throwable): Handle[F, S, E, A] =
+        Handle.liftF(MonadThrow[F].raiseError(e))
+
+      override def handleErrorWith[A](fa: Handle[F, S, E, A])(
+        f: Throwable => Handle[F, S, E, A]
+      ): Handle[F, S, E, A] =
+        Handle:
+          fa.stateT.handleErrorWith(e => f(e).stateT)
+    }
+
+  // This class adds a method to Handle similar to flatMap, but the Streams resulting from both Handle instances
+  // are concatenated in the reverse order.
+  extension [F[_]: Monad, S, E, O](self: Handle[F, S, E, O]) {
+    def reversedStreamFlatMap[O1](f: O => Handle[F, S, E, O1]): Handle[F, S, E, O1] =
+      Handle[F, S, E, O1]:
+        self.stateT.flatMap: (a, p1) =>
+          f(a).stateT.map: (b, p2) =>
+            (b, p2 ++ p1)
+  }
 }

--- a/modules/server_new/src/test/scala/observe/server/engine/HandleSpec.scala
+++ b/modules/server_new/src/test/scala/observe/server/engine/HandleSpec.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.server.engine
+
+import cats.FlatMap
+import cats.Id
+import cats.Monad
+import cats.data.StateT
+import cats.kernel.Eq
+import cats.laws.discipline.*
+import cats.laws.discipline.arbitrary.*
+import cats.laws.discipline.eq.*
+import cats.syntax.all.*
+import cats.~>
+import fs2.Compiler
+import observe.engine.Handle
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen
+
+import scala.util.Try
+
+
+class HandleSpec extends munit.DisciplineSuite {
+  given [F[_]: Monad, S, E, O](using
+    Arbitrary[F[S => F[(S, (O, List[E]))]]]
+  ): Arbitrary[Handle[F, S, E, O]] =
+    Arbitrary:
+      arbitrary[StateT[F, S, (O, List[E])]].map: st =>
+        Handle:
+          st.map: (o, es) =>
+            (o, fs2.Stream.emits(es))
+
+  given [F[_]: FlatMap, S, A](using Cogen[S => F[(S, A)]]): Cogen[StateT[F, S, A]] =
+    Cogen[S => F[(S, A)]].contramap(_.run)
+
+  given Try ~> Id =
+    new (Try ~> Id) {
+      def apply[A](fa: Try[A]): Id[A] =
+        fa match 
+          case scala.util.Success(a) => a
+          case scala.util.Failure(e) => throw e
+    }
+
+  given [F[_]: Monad, S, E, O](using
+    Cogen[StateT[F, S, (O, List[E])]]
+  )(using fk: F ~> Id): Cogen[Handle[F, S, E, O]] =
+    Cogen[StateT[F, S, (O, List[E])]]
+      .contramap(_.stateT.map((o, es) => (o, es.translate(fk).compile.toList)))
+
+  // Adapted from https://github.com/typelevel/cats/blob/main/tests/shared/src/test/scala/cats/tests/IndexedStateTSuite.scala
+  given [F[_]: FlatMap, S: ExhaustiveCheck, E, O](using
+    Eq[F[(S, (O, List[E]))]]
+  )(using fk: F ~> Id): Eq[Handle[F, S, E, O]] =
+    Eq.by[Handle[F, S, E, O], S => F[(S, (O, List[E]))]](state =>
+      s0 =>
+        state.stateT.run(s0).map { case (s1, (o, es)) =>
+          (s1, (o, es.translate(fk).compile.toList))
+        }
+    )
+
+  given Eq[Throwable] = Eq.fromUniversalEquals
+
+  checkAll(
+    "Handle[Int].MonadErrorLaws",
+    MonadErrorTests[Handle[Try, MiniInt, Int, *], Throwable].monadError[MiniInt, Int, String]
+  )
+}

--- a/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/MainApp.scala
@@ -39,9 +39,9 @@ import lucuma.schemas.ObservationDB
 import lucuma.ui.LucumaStyles
 import lucuma.ui.components.SolarProgress
 import lucuma.ui.components.state.IfLogged
-import lucuma.ui.utils.showEnvironment
 import lucuma.ui.sso.*
 import lucuma.ui.syntax.all.*
+import lucuma.ui.utils.showEnvironment
 import observe.model.*
 import observe.model.enums.ObserveLogLevel
 import observe.model.events.ClientEvent


### PR DESCRIPTION
- `Handle` is now an `opaque type` instead of a `case class`, which avoids allocation.
- It can now handle errors in-monad since it implements `MonadThrow`.
- Added law tests.
- Fixed `tailRecM` implementation to make it lawful.