### PR TITLE
Temporary workaround for Gaia timeouts + DHS simulator fix

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/ObserveEngineImpl.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngineImpl.scala
@@ -662,7 +662,7 @@ private class ObserveEngineImpl[F[_]: Async: Logger](
     // If there is no heartbeat in 5 periods throw an error
     val noHeartbeatDetection =
       ObserveEngine.failIfNoEmitsWithin[F, Event[F]](
-        5 * heartbeatPeriod,
+        50 * heartbeatPeriod, // TODO REVERT TO 5 * heartbeatPeriod
         "Engine heartbeat not detected"
       )
     Stream

--- a/modules/server_new/src/main/scala/observe/server/keywords/DhsClientHttp.scala
+++ b/modules/server_new/src/main/scala/observe/server/keywords/DhsClientHttp.scala
@@ -249,11 +249,11 @@ private class DhsClientSim[F[_]: FlatMap: Logger](site: Site, date: LocalDate, c
 object DhsClientSim {
   def apply[F[_]: Sync: Logger](site: Site): F[DhsClient[F]] =
     Clock[F].monotonic
-      .map(d => Instant.EPOCH.plusNanos(d.toNanos))
+      .map(d => Instant.EPOCH.plusSeconds(d.toSeconds))
       .map(LocalDateTime.ofInstant(_, ZoneId.systemDefault))
       .flatMap(apply(site, _))
 
-  def apply[F[_]: Sync: Logger](site: Site, dateTime: LocalDateTime): F[DhsClient[F]] =
+  private def apply[F[_]: Sync: Logger](site: Site, dateTime: LocalDateTime): F[DhsClient[F]] =
     Ref // Initialize with ordinal of 10-second lapse in the day, between 0 and 8640
       .of[F, Int](dateTime.getHour() * 360 + dateTime.getMinute() * 6 + dateTime.getSecond() / 10)
       .map: counter =>


### PR DESCRIPTION
- Use WS client to communicate with ODB. This gets us around Heroku's 30s timeout.
- Increase engine heartbeat timeout. This seemed to be an issue, not sure why.
- Switch DHS simulator to seconds instead of nanos, we were overflowing the Long.