### PR TITLE
Avoid scrolling to top of table between steps, fix DhsClientDisabled

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/keywords/DhsClientDisabled.scala
+++ b/modules/server_new/src/main/scala/observe/server/keywords/DhsClientDisabled.scala
@@ -22,7 +22,7 @@ class DhsClientDisabled[F[_]: FlatMap: Clock: Logger] extends DhsClient[F] {
     for {
       _    <- overrideLogMessage[F]("DHS", "setKeywords")
       date <- Clock[F].monotonic
-                .map(d => Instant.EPOCH.plusNanos(d.toNanos))
+                .map(d => Instant.EPOCH.plusSeconds(d.toSeconds))
                 .map(LocalDateTime.ofInstant(_, java.time.ZoneOffset.UTC))
     } yield ImageFileId(
       f"S${date.format(format)}S${date.getHour() * 360 + date.getMinute() * 6 + date.getSecond() / 10}%04d"

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTableBuilder.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SequenceTableBuilder.scala
@@ -56,17 +56,19 @@ private trait SequenceTableBuilder[S: Eq, D <: DynamicConfig: Eq] extends Sequen
     virtualizerRef: UseRef[Option[HTMLTableVirtualizer]],
     table:          Table[SequenceTableRowType, TableMeta, Nothing, Nothing]
   )(rowIdCandidates: List[String]): Callback =
-    virtualizerRef.get.flatMap: refOpt =>
-      Callback( // Auto scroll to running step or next step.
-        refOpt.map:
-          _.scrollToIndex(
-            table
-              .getRowModel()
-              .rows
-              .indexWhere(row => rowIdCandidates.contains_(row.id.value)) - 1,
-            ScrollOptions
-          )
-      )
+    rowIdCandidates.some
+      .filter(_.nonEmpty)
+      .foldMap: rowIds =>
+        virtualizerRef.get.flatMap: refOpt =>
+          Callback: // Auto scroll to running step or next step.
+            refOpt.map:
+              _.scrollToIndex(
+                table
+                  .getRowModel()
+                  .rows
+                  .indexWhere(row => rowIds.contains_(row.id.value)) - 1,
+                ScrollOptions
+              )
 
   protected[sequence] val component =
     ScalaFnComponent[Props]: props =>


### PR DESCRIPTION
There's a brief moment where there's no selected row. This caused the sequence to jump to the first row.

Also: Fix DhsClientDisabled.