### PR TITLE
Add basic tracing, skip empty streams

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -265,11 +265,12 @@ lazy val observe_server = project
         PPrint.value,
         Clue.value,
         ClueHttp4s,
+        ClueNatchez,
         CatsParse.value,
         ACM,
         GiapiScala
       ) ++ Coulomb.value ++ LucumaSchemas.value ++ MUnit.value ++ Http4s ++ Http4sJDKClient.value ++ PureConfig ++ Monocle.value ++
-        Circe.value,
+        Circe.value ++ Natchez,
     headerSources / excludeFilter := HiddenFileFilter || (file(
       "modules/server_new"
     ) / "src/main/scala/pureconfig/module/http4s/package.scala").getName

--- a/deploy/conf/production-gn/logback.xml
+++ b/deploy/conf/production-gn/logback.xml
@@ -47,6 +47,8 @@
     <logger name="org.asynchttpclient.netty" level="INFO">
         <appender-ref ref="ASYNC500" />
     </logger>
-
+    <logger name="io.honeycomb" level="INFO">
+        <appender-ref ref="ASYNC500" />
+    </logger>
 
 </configuration>

--- a/deploy/conf/production-gs/logback.xml
+++ b/deploy/conf/production-gs/logback.xml
@@ -47,6 +47,8 @@
     <logger name="org.asynchttpclient.netty" level="INFO">
         <appender-ref ref="ASYNC500" />
     </logger>
-
+    <logger name="io.honeycomb" level="INFO">
+        <appender-ref ref="ASYNC500" />
+    </logger>
 
 </configuration>

--- a/deploy/conf/staging-gn/logback.xml
+++ b/deploy/conf/staging-gn/logback.xml
@@ -47,6 +47,8 @@
     <logger name="org.asynchttpclient.netty" level="INFO">
         <appender-ref ref="ASYNC500" />
     </logger>
-
+    <logger name="io.honeycomb" level="INFO">
+        <appender-ref ref="ASYNC500" />
+    </logger>
 
 </configuration>

--- a/deploy/conf/staging-gs/logback.xml
+++ b/deploy/conf/staging-gs/logback.xml
@@ -47,6 +47,8 @@
     <logger name="org.asynchttpclient.netty" level="INFO">
         <appender-ref ref="ASYNC500" />
     </logger>
-
+    <logger name="io.honeycomb" level="INFO">
+        <appender-ref ref="ASYNC500" />
+    </logger>
 
 </configuration>

--- a/deploy/scripts/config.sh.template
+++ b/deploy/scripts/config.sh.template
@@ -12,3 +12,5 @@ DOCKERHUB_TOKEN=
 # Usually /gemsoft/var/log/gpp/observe for production and /home/software/observe/log for staging.
 LOCAL_LOG_DIR=/home/software/observe/log
 # LOCAL_LOG_DIR=/gemsoft/var/log/gpp/observe
+# Honeycomb API key
+HONEYCOMB_WRITE_KEY=

--- a/modules/model/jvm/src/main/scala/observe/model/config/HoneycombConfiguration.scala
+++ b/modules/model/jvm/src/main/scala/observe/model/config/HoneycombConfiguration.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package observe.model.config
+
+import cats.Eq
+import cats.derived.*
+
+final case class HoneycombConfiguration(writeKey: String) derives Eq

--- a/modules/model/jvm/src/main/scala/observe/model/config/ObserveConfiguration.scala
+++ b/modules/model/jvm/src/main/scala/observe/model/config/ObserveConfiguration.scala
@@ -30,5 +30,6 @@ case class ObserveConfiguration(
   exploreBaseUrl: Uri,
   lucumaSSO:      LucumaSSOConfiguration,
   observeEngine:  ObserveEngineConfiguration,
-  webServer:      WebServerConfiguration
+  webServer:      WebServerConfiguration,
+  honeycomb:      HoneycombConfiguration
 ) derives Eq

--- a/modules/web/server/src/main/resources/base.conf
+++ b/modules/web/server/src/main/resources/base.conf
@@ -20,7 +20,6 @@ lucuma-sso {
     service-token = ${?SSO_SERVICE_JWT}
     sso-url = "https://sso-dev.gpp.lucuma.xyz" # Development SSO Server and its public key
     public-key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGQ1w9IBEAC8Td3AlypimgzF2/isMZSD3z63sUKpd/Lc3XZHjpKwbgNHA7/3\n7ddE7VB8526Cn8DJwArL39DlKdCV5VB1VguLjnSfYD1C6GEHMmhGB5T2QiVBFVZD\n3/XvMTF/9akrwPp4Y6CxUNOWej9Bube+pvUQZ4e5gz4yCduIMwU/zODpy4BJVc1u\n86l3Xrt1FmCIgRzpD4coVrhtjAtsuXVH8eZvgMfgFY2c8whBBv8upTHxCLKfxbCN\npS9nOaZE+3ujI/+xoVw6RiOwrMR683Rs46TZGOo7IfPmpLwxtQt+XwZUHeEC5bMT\n7wG9jebPPc0Ro0wrkwf9N6J0Fnp+gdcIT2AruxtR5hjVcwckORM26RYnCJ+sirpU\nTu0kw754d7Uvwrr15cSMjvSA/qlvdmqaquOGXS+aqM/OPecAVpcUJADG4H2KAXGq\nd79OuspC/CCBoA6HJb+TBneP6UflKRVnZrdlhKc001yGiHS4X19HaJCu5Co6PNbN\nG7H2Z0+NVBHR/GIYGZ2DS/yjE0R07WhC4mCbehC01InWARNzDqmF5zcVZUi0Kmb7\nYHlJPURCG4+9qi1SBgYhVmPmPASy/vjsBVadPp5aGQFjYupv8gW3LTeq/uW+CZUw\ngbPA5SKTk0VIUxwH9qqkbod98S67fuTP9ryFRJEo5wZrWsPx7pgE7E2V8QARAQAB\ntCdMdWN1bWEgU1NPIERldiA8cm9iLm5vcnJpc0Bub2lybGFiLmVkdT6JAlcEEwEI\nAEEWIQS0yfZiKQanqInSO1pcW28wo0EWRAUCZDXD0gIbAwUJA8JnAAULCQgHAgIi\nAgYVCgkICwIEFgIDAQIeBwIXgAAKCRBcW28wo0EWRLBPEAC3T2c5BhgJ++RahDbt\nf3gPpq2nAbVJyn2VI37uFXIfNFKkYdFTQh/wlb+qprNqQrbPNnRWKebq9qzcubTd\nsADSwrM4imbBeyOEJsceyPeP6yAfaWcSpFXwtuLTVMb+eB9u985qNmu7kIC7gnak\nSjkBdbKsM3HQvr3PrsNCZsy9ysGRBdIfDc/DDwoGhCU0Bqd5ORjzsS4u7SNiRrkc\n+Dw3siX4cskwiDbCr21Bz4XJxpU86cx+idhSS7naiX6rN6KqZRhAO2FZOhL8/11u\nsQPshz45m1mvQ4367fams8N2gtpX+1RKuVY6xcSvfa7rK6aWpjGC7u0tr2hcK0G5\nNCiI6DPYllC2lyZPonycHHRaGLIQWIipJkP9cdu8ph+O/7qshEtb7nX3JlyRIxcW\nkxQnqROrVqJALogmzmF+4OP8gTjY2ph8OmaPU8ATjdql5da1iHlDT5M/0oatZ6J2\nlmYdT0LxnSMlMGFb9xOo1xeYK0/a5kR4fRET4m4g+x5N9UUPSJjfFhDa6iO89X0V\nd/EKiM3//ukkw7RcwGLWw4hnqqxPdHvLM0yTKajc79pAQR3rOEcW1SrV5PECFSxD\nHMeMka0SYzCqqtl0XWI1dlC0JXKnVfuDHOKVY523EKnEAcHqZ8oAZB//2Puj4qfO\nyMvjw3Rl9GQnMoTGYsNsunNy4Q==\n=8OhQ\n-----END PGP PUBLIC KEY BLOCK-----"
-
 }
 
 # Web server related configuration
@@ -35,6 +34,11 @@ web-server {
         key-store-pwd = "passphrase"
         cert-pwd = "passphrase"
     }
+}
+
+honeycomb {
+    # Honeycomb configuration for observability
+    write-key = ${?HONEYCOMB_WRITE_KEY}
 }
 
 # Configuration of the observe engine

--- a/modules/web/server/src/main/resources/logback.xml
+++ b/modules/web/server/src/main/resources/logback.xml
@@ -24,6 +24,9 @@
     <logger name="org.asynchttpclient.netty" level="INFO">
         <appender-ref ref="STDOUT" />
     </logger>
+    <logger name="io.honeycomb" level="INFO">
+        <appender-ref ref="STDOUT" />
+    </logger>
 
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/WebServerLauncher.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/WebServerLauncher.scala
@@ -3,6 +3,7 @@
 
 package observe.web.server.http4s
 
+import cats.data.Kleisli
 import cats.data.OptionT
 import cats.effect.*
 import cats.effect.syntax.all.*
@@ -14,10 +15,16 @@ import fs2.io.file.Files
 import fs2.io.net.Network
 import fs2.io.net.tls.TLSContext
 import fs2.io.net.tls.TLSParameters
+import lucuma.core.enums.ExecutionEnvironment
+import lucuma.core.enums.Site
 import lucuma.core.model.User
 import lucuma.sso.client.SsoClient
 import lucuma.sso.client.SsoJwtReader
 import lucuma.sso.client.util.JwtDecoder
+import natchez.EntryPoint
+import natchez.Trace
+import natchez.honeycomb.Honeycomb
+import natchez.http4s.NatchezMiddleware
 import observe.model.ClientId
 import observe.model.config.*
 import observe.model.events.*
@@ -27,6 +34,8 @@ import observe.server.Systems
 import observe.server.tcs.GuideConfigDb
 import observe.web.server.OcsBuildInfo
 import observe.web.server.config.*
+import org.http4s.HttpRoutes
+import org.http4s.Request
 import org.http4s.client.Client
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.server.EmberServerBuilder
@@ -48,6 +57,7 @@ import javax.net.ssl.TrustManagerFactory
 import scala.concurrent.duration.*
 
 object WebServerLauncher extends IOApp with LogInitialization {
+  val ServiceName: String = "observe"
 
   // Try to load configs for deployment and staging and fall back to the common one in the class path
   private def config[F[_]: Sync: Logger]: F[ConfigObjectSource] =
@@ -130,7 +140,7 @@ object WebServerLauncher extends IOApp with LogInitialization {
     )
 
   /** Resource that yields the running web server */
-  private def webServer[F[_]: Logger: Async: Files: Network: Compression](
+  private def webServer[F[_]: Async: Trace: Logger: Files: Network: Compression](
     conf:      ObserveConfiguration,
     clientsDb: ClientsSetDb[F],
     ssoClient: SsoClient[F, User],
@@ -140,36 +150,45 @@ object WebServerLauncher extends IOApp with LogInitialization {
     def router(
       wsb:    WebSocketBuilder2[F],
       events: Topic[F, (Option[ClientId], ClientEvent)]
-    ) = Router[F](
-      "/"                   -> StaticRoutes().service,
-      "/api/observe/guide"  -> GuideConfigDbRoutes(oe.systems.guideDb).service,
-      "/api/observe"        -> ObserveCommandRoutes(ssoClient, oe).service,
-      "/api/observe/ping"   -> PingRoutes(ssoClient).service,
-      "/api/observe/events" -> ObserveEventRoutes(
-        conf.site,
-        conf.environment,
-        conf.observeEngine.odbWs,
-        conf.lucumaSSO.ssoUrl,
-        conf.exploreBaseUrl,
-        clientsDb,
-        oe,
-        events,
-        wsb
-      ).service
-    )
+    ): HttpRoutes[F] =
+      Router[F](
+        "/"                   -> StaticRoutes().service,
+        "/api/observe/guide"  -> GuideConfigDbRoutes(oe.systems.guideDb).service,
+        "/api/observe"        -> ObserveCommandRoutes(ssoClient, oe).service,
+        "/api/observe/ping"   -> PingRoutes(ssoClient).service,
+        "/api/observe/events" -> ObserveEventRoutes(
+          conf.site,
+          conf.environment,
+          conf.observeEngine.odbWs,
+          conf.lucumaSSO.ssoUrl,
+          conf.exploreBaseUrl,
+          clientsDb,
+          oe,
+          events,
+          wsb
+        ).service
+      )
 
-    def builder(events: Topic[F, (Option[ClientId], ClientEvent)]) =
+    def natchez(routes: HttpRoutes[F]): HttpRoutes[F] =
+      NatchezMiddleware.server[F]:
+        Kleisli: (req: Request[F]) =>
+          OptionT:
+            Trace[F].span("http"):
+              routes.run(req).value
+
+    def builder(events: Topic[F, (Option[ClientId], ClientEvent)]): EmberServerBuilder[F] =
       EmberServerBuilder
         .default[F]
         .withHost(conf.webServer.host)
         .withPort(conf.webServer.port)
         .withHttpWebSocketApp(wsb =>
-          Http4sLogger
-            .httpRoutes(logHeaders = false, logBody = false)(router(wsb, events))
-            .orNotFound
+          natchez:
+            Http4sLogger
+              .httpRoutes(logHeaders = false, logBody = false)(router(wsb, events))
+          .orNotFound
         )
 
-    def builderWithTLS(events: Topic[F, (Option[ClientId], ClientEvent)]) =
+    def builderWithTLS(events: Topic[F, (Option[ClientId], ClientEvent)]): Resource[F, Server] =
       Resource
         .eval(
           conf.webServer.tls
@@ -253,7 +272,7 @@ object WebServerLauncher extends IOApp with LogInitialization {
   private def engineIO(
     conf:       ObserveConfiguration,
     httpClient: Client[IO]
-  )(using Logger[IO]): Resource[IO, ObserveEngine[IO]] =
+  )(using Logger[IO], Trace[IO]): Resource[IO, ObserveEngine[IO]] =
     for {
       caS  <- Resource.eval(CaServiceInit.caInit[IO](conf.observeEngine))
       sys  <- Systems.build(conf.site, httpClient, conf.observeEngine, conf.lucumaSSO, caS)
@@ -263,13 +282,28 @@ object WebServerLauncher extends IOApp with LogInitialization {
   private def publishStats[F[_]: Temporal](cs: ClientsSetDb[F]): Stream[F, Unit] =
     Stream.fixedRate[F](10.minute).flatMap(_ => Stream.eval(cs.report))
 
+  private def entryPoint[F[_]: Sync](
+    config:               HoneycombConfiguration,
+    site:                 Site,
+    executionEnvironment: ExecutionEnvironment
+  ): Resource[F, EntryPoint[F]] =
+    Honeycomb.entryPoint(ServiceName): cb =>
+      Sync[F].delay:
+        cb.setWriteKey(config.writeKey)
+        cb.setDataset(s"$ServiceName-$site-$executionEnvironment")
+        cb.build()
+
   /** Reads the configuration and launches the observe engine and web server */
   def observe: IO[ExitCode] = {
+
+    // mkTrace:       EntryPoint[F] => F[Trace[F]]
 
     val observe: Resource[IO, ExitCode] =
       for // Initialize log before the engine is setup
         given Logger[IO] <- Resource.eval(setupLogger[IO])
         conf             <- Resource.eval(config[IO].flatMap(loadConfiguration[IO]))
+        ep               <- entryPoint[IO](conf.honeycomb, conf.site, conf.environment)
+        given Trace[IO]  <- Resource.eval(Trace.ioTraceForEntryPoint(ep))
         _                <- Resource.eval(printBanner(conf))
         cli              <- mkClient[IO](conf.observeEngine.dhsTimeout)
         cs               <- Resource.eval:

--- a/modules/web/server/src/main/scala/observe/web/server/http4s/WebServerLauncher.scala
+++ b/modules/web/server/src/main/scala/observe/web/server/http4s/WebServerLauncher.scala
@@ -296,8 +296,6 @@ object WebServerLauncher extends IOApp with LogInitialization {
   /** Reads the configuration and launches the observe engine and web server */
   def observe: IO[ExitCode] = {
 
-    // mkTrace:       EntryPoint[F] => F[Trace[F]]
-
     val observe: Resource[IO, ExitCode] =
       for // Initialize log before the engine is setup
         given Logger[IO] <- Resource.eval(setupLogger[IO])

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -23,7 +23,6 @@ object Settings {
     val http4sDomVersion           = "0.2.12"
     val http4sJdkHttpClientVersion = "0.10.0"
     val http4sScalaXmlVersion      = "0.24.0"
-    val natchezVersion             = "0.3.7"
 
     val coulomb             = "0.8.0"
     val commonsHttp         = "3.1"
@@ -33,6 +32,8 @@ object Settings {
     val log4cats            = "2.7.0"
     val log4catsLogLevel    = "0.3.1"
     val logback             = "1.5.18"
+    val natchez             = "0.3.7"
+    val natchezHttp4s       = "0.6.1"
     val pureConfig          = "0.17.9"
     val monocleVersion      = "3.3.0"
     val circeVersion        = "0.14.14"
@@ -50,10 +51,10 @@ object Settings {
     val pprint        = "0.9.0"
 
     // Gemini Libraries
-    val lucumaCore      = "0.133.0"
-    val lucumaSchemas   = "0.140.0"
+    val lucumaCore      = "0.136.1"
+    val lucumaSchemas   = "0.142.0"
     val lucumaSSO       = "0.8.22"
-    val lucumaODBSchema = "0.24.1"
+    val lucumaODBSchema = "0.25.1"
 
     // Gemini UI Libraries
     val crystal     = "0.49.0"
@@ -61,7 +62,7 @@ object Settings {
     val lucumaUI    = "0.146.1"
 
     // Clue
-    val clue = "0.45.0"
+    val clue = "0.46.0"
 
     // ScalaJS libraries
     val javaTimeJS   = "2.6.0"
@@ -124,6 +125,11 @@ object Settings {
       )
     )
     val Logging          = Def.setting(Seq(JuliSlf4j) ++ Logback)
+    val Natchez          = Seq(
+      "org.tpolecat" %% "natchez-core"      % LibraryVersions.natchez,
+      "org.tpolecat" %% "natchez-honeycomb" % LibraryVersions.natchez,
+      "org.tpolecat" %% "natchez-http4s"    % LibraryVersions.natchezHttp4s
+    )
     val PureConfig       = Seq(
       "com.github.pureconfig" %% "pureconfig-core"        % LibraryVersions.pureConfig,
       "com.github.pureconfig" %% "pureconfig-cats"        % LibraryVersions.pureConfig,
@@ -262,6 +268,7 @@ object Settings {
     val ClueGenerator = "edu.gemini" %% "clue-generator" % LibraryVersions.clue
     val ClueHttp4s    = "edu.gemini" %% "clue-http4s"    % LibraryVersions.clue
     val ClueJs        = Def.setting("edu.gemini" %%% "clue-scalajs" % LibraryVersions.clue)
+    val ClueNatchez   = "edu.gemini" %% "clue-natchez"   % LibraryVersions.clue
 
   }
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -52,7 +52,7 @@ object Settings {
 
     // Gemini Libraries
     val lucumaCore      = "0.136.1"
-    val lucumaSchemas   = "0.142.0"
+    val lucumaSchemas   = "0.142.1"
     val lucumaSSO       = "0.8.22"
     val lucumaODBSchema = "0.25.1"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
 
 // Generate code for GraphQL queries
-addSbtPlugin("edu.gemini" % "sbt-clue" % "0.45.0")
+addSbtPlugin("edu.gemini" % "sbt-clue" % "0.46.0")


### PR DESCRIPTION
- Add tracing for HTTP requests to the server, as well as when the server invokes the ODB.
- Avoids processing empty event streams. A recent refactor had introduced empty streams (instead of optional). This may or may not be related to the race-based issue we are getting where the sequence finishes early. It's worth a shot and it's an optimization anyway.