### PR TITLE
Solve early completion

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/ObserveEngineImpl.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngineImpl.scala
@@ -1480,7 +1480,7 @@ private class ObserveEngineImpl[F[_]: Async: Logger](
             ObserveEngine.onAtomReload[F](systems.odb, translator)(
               executeEngine,
               obsId,
-              OnAtomReloadAction.NoAction
+              ReloadReason.EditEvent
             )
 
   // Subscribes to obsEdit changes in the ODB.

--- a/modules/server_new/src/test/scala/observe/server/SeqTranslateSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/SeqTranslateSuite.scala
@@ -136,7 +136,7 @@ class SeqTranslateSuite extends TestCommon {
       EngineState
         .sequenceStateAt[IO](seqObsId1)
         .modify {
-          case State.Zipper(zipper, status, singleRuns, latch) =>
+          case State.Zipper(zipper, status, singleRuns) =>
             State.Zipper(
               zipper.copy(
                 focus = advanceStepUntil(
@@ -145,10 +145,9 @@ class SeqTranslateSuite extends TestCommon {
                 )
               ),
               status,
-              singleRuns,
-              latch
+              singleRuns
             )
-          case s @ State.Final(_, _)                           => s
+          case s @ State.Final(_, _)                    => s
         } >>>
       EngineState
         .sequenceStateAt[IO](seqObsId1)

--- a/modules/server_new/src/test/scala/observe/server/engine/SequenceSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/engine/SequenceSuite.scala
@@ -93,9 +93,9 @@ class SequenceSuite extends munit.CatsEffectSuite {
       s <- OptionT(qs1)
       t <- OptionT.pure(s.sequences(seqId))
       r <- OptionT.pure(t.seq match {
-             case Sequence.State.Zipper(zipper, status, _, _) =>
+             case Sequence.State.Zipper(zipper, status, _) =>
                zipper.done.length === 1 && zipper.pending.isEmpty && status === SequenceState.Idle
-             case _                                           => false
+             case _                                        => false
            })
     } yield r).value.map(_.getOrElse(fail("Sequence not found"))).assert
   }
@@ -124,9 +124,9 @@ class SequenceSuite extends munit.CatsEffectSuite {
       s <- OptionT(qs1)
       t <- OptionT.pure(s.sequences(seqId))
       r <- OptionT.pure(t.seq match {
-             case Sequence.State.Zipper(zipper, _, _, _) =>
+             case Sequence.State.Zipper(zipper, _, _) =>
                zipper.pending.nonEmpty
-             case _                                      => false
+             case _                                   => false
            })
     } yield r).value.map(_.getOrElse(fail("Sequence not found")))
 

--- a/modules/server_new/src/test/scala/observe/server/engine/StepSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/engine/StepSuite.scala
@@ -258,9 +258,9 @@ class StepSuite extends CatsEffectSuite {
 
     m.compile.last.map { l =>
       l.map(_.seq).exists {
-        case Sequence.State.Zipper(zipper, _, _, _) =>
+        case Sequence.State.Zipper(zipper, _, _) =>
           zipper.done.length === 1 // Only 1 step executed
-        case _                                      => false
+        case _                                   => false
       }
     }.assert
 
@@ -290,8 +290,7 @@ class StepSuite extends CatsEffectSuite {
             done = Nil
           ),
           SequenceState.Idle,
-          Map.empty,
-          none
+          Map.empty
         )
       )
 
@@ -308,13 +307,13 @@ class StepSuite extends CatsEffectSuite {
 
     qs1.map {
       _.map(_.seq).exists {
-        case Sequence.State.Zipper(zipper, status, _, _) =>
+        case Sequence.State.Zipper(zipper, status, _) =>
           (zipper.focus.toStep match {
             case EngineStep(_, _, List(ex1, ex2)) =>
               Execution(ex1.toList).actions.length == 2 && Execution(ex2.toList).actions.length == 1
             case _                                => false
           }) && status.isRunning
-        case _                                           => false
+        case _                                        => false
       }
     }.assert
 
@@ -347,8 +346,7 @@ class StepSuite extends CatsEffectSuite {
             IsWaitingNextAtom.No,
             IsStarting.No
           ),
-          Map.empty,
-          none
+          Map.empty
         )
       )
 
@@ -366,9 +364,9 @@ class StepSuite extends CatsEffectSuite {
     qs1
       .map(x =>
         x.flatMap(_.sequences.get(seqId)).map(_.seq).exists {
-          case Sequence.State.Zipper(_, status, _, _) =>
+          case Sequence.State.Zipper(_, status, _) =>
             status.isRunning
-          case _                                      => false
+          case _                                   => false
         }
       )
       .assert
@@ -410,13 +408,13 @@ class StepSuite extends CatsEffectSuite {
 
     qss.map { x =>
       x.flatMap(_.sequences.get(seqId)).map(_.seq).exists {
-        case Sequence.State.Zipper(zipper, status, _, _) =>
+        case Sequence.State.Zipper(zipper, status, _) =>
           zipper.focus.toStep.match {
             case EngineStep(_, _, List(ex1, ex2)) =>
               Execution(ex1.toList).actions.length == 2 && Execution(ex2.toList).actions.length == 1
             case _                                => false
           } && (status === SequenceState.Idle)
-        case _                                           => false
+        case _                                        => false
       }
     }.assert
   }
@@ -507,7 +505,7 @@ class StepSuite extends CatsEffectSuite {
 
     qs1.map { x =>
       x.flatMap(_.sequences.get(seqId)).map(_.seq).exists {
-        case Sequence.State.Zipper(zipper, status, _, _) =>
+        case Sequence.State.Zipper(zipper, status, _) =>
           (zipper.focus.toStep match {
             // Check that the sequence stopped midway
             case EngineStep(_, _, List(ex1, ex2, ex3)) =>
@@ -516,7 +514,7 @@ class StepSuite extends CatsEffectSuite {
               ).results.length == 1 && Execution(ex3.toList).actions.length == 1
             case _                                     => false
           }) && (status == SequenceState.Failed(errMsg)) // And that it ended in error
-        case _                                           => false
+        case _                                        => false
 
       }
     }.assert
@@ -585,10 +583,10 @@ class StepSuite extends CatsEffectSuite {
 
     qs1.map { x =>
       x.flatMap(_.sequences.get(seqId)).map(_.seq).exists {
-        case Sequence.State.Zipper(_, status, _, _) =>
+        case Sequence.State.Zipper(_, status, _) =>
           // And that it ended in aborted
           status === SequenceState.Aborted
-        case _                                      => false
+        case _                                   => false
       }
     }.assert
   }
@@ -619,11 +617,11 @@ class StepSuite extends CatsEffectSuite {
 
     qs1.map { x =>
       x.flatMap(_.sequences.get(seqId)).map(_.seq).exists {
-        case Sequence.State.Zipper(_, status, _, _) =>
+        case Sequence.State.Zipper(_, status, _) =>
           // Without the error we should have a value 2
           // And that it ended in error
           status === SequenceState.Failed(errMsg)
-        case _                                      => false
+        case _                                   => false
       }
     }.assert
   }
@@ -698,7 +696,7 @@ class StepSuite extends CatsEffectSuite {
     qss.map { x =>
       val a1 = x.drop(2)
       val a  = a1.headOption.flatMap(y => y.sequences.get(seqId)).map(_.seq) match {
-        case Some(Sequence.State.Zipper(zipper, status, _, _)) =>
+        case Some(Sequence.State.Zipper(zipper, status, _)) =>
           (zipper.focus.focus.execution.headOption match {
             case Some(
                   Action(_, _, Action.State(Action.ActionState.Started, v :: _), _)
@@ -706,7 +704,7 @@ class StepSuite extends CatsEffectSuite {
               v == PartialValDouble(0.5)
             case _ => false
           }) && status.isRunning
-        case _                                                 => false
+        case _                                              => false
       }
       val b  = x.lastOption.flatMap(_.sequences.get(seqId)).map(_.seq) match {
         case Some(Sequence.State.Final(seq, status)) =>

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -54,7 +54,7 @@ object Settings {
     val lucumaCore      = "0.136.1"
     val lucumaSchemas   = "0.142.1"
     val lucumaSSO       = "0.8.22"
-    val lucumaODBSchema = "0.25.1"
+    val lucumaODBSchema = "0.25.2"
 
     // Gemini UI Libraries
     val crystal     = "0.49.0"


### PR DESCRIPTION
This PR backtracks on the changes introduced yesterday.

The issue is definitely with the refresh induced by observation edits, but the use of a latch didn't solve the issue since what's actually happening is that the state became inconsistent.

This PR undoes the latching, and permits an observation edit to update the sequence only if it is not running. This seems to work, but let's test it on the servers.