### PR TITLE
Better processing of updates and error handling

### DIFF
--- a/deploy/scripts/config.sh.template
+++ b/deploy/scripts/config.sh.template
@@ -12,5 +12,3 @@ DOCKERHUB_TOKEN=
 # Usually /gemsoft/var/log/gpp/observe for production and /home/software/observe/log for staging.
 LOCAL_LOG_DIR=/home/software/observe/log
 # LOCAL_LOG_DIR=/gemsoft/var/log/gpp/observe
-# Honeycomb API key
-HONEYCOMB_WRITE_KEY=

--- a/modules/server_new/src/main/scala/observe/server/engine/Handle.scala
+++ b/modules/server_new/src/main/scala/observe/server/engine/Handle.scala
@@ -57,6 +57,12 @@ object Handle {
   inline def fromEventStream[F[_]: MonadThrow, S, E](p: Stream[F, E]): Handle[F, S, E, Unit] =
     fromEventStream(_ => p)
 
+  inline def fromEvents[F[_]: MonadThrow, S, E](f: S => Seq[E]): Handle[F, S, E, Unit] =
+    fromEventStream(s => Stream.emits(f(s)))
+
+  inline def fromEvents[F[_]: MonadThrow, S, E](es: E*): Handle[F, S, E, Unit] =
+    fromEvents(_ => es)
+
   inline def fromSingleEventF[F[_]: MonadThrow, S, E](f: F[E]): Handle[F, S, E, Unit] =
     modifyStateEmitSingle(s => f.map((s, _)))
 

--- a/modules/server_new/src/main/scala/observe/server/engine/package.scala
+++ b/modules/server_new/src/main/scala/observe/server/engine/package.scala
@@ -5,6 +5,7 @@ package observe.engine
 
 import cats.Functor
 import cats.Monad
+import cats.MonadThrow
 import cats.data.NonEmptyList
 import cats.data.StateT
 import cats.effect.MonadCancelThrow
@@ -67,15 +68,23 @@ object EngineHandle {
   ): EngineHandle[F, Unit] =
     Handle.modifyStateEmitSingle(f)
 
-  inline def fromEventStream[F[_]: MonadCancelThrow](
+  inline def fromEventStream[F[_]: MonadThrow](
     f: EngineState[F] => Stream[F, Event[F]]
   ): EngineHandle[F, Unit] =
     Handle.fromEventStream(f)
 
-  inline def fromEventStream[F[_]: MonadCancelThrow](
+  inline def fromEventStream[F[_]: MonadThrow](
     p: Stream[F, Event[F]]
   ): EngineHandle[F, Unit] =
     Handle.fromEventStream(p)
+
+  inline def fromEvents[F[_]: MonadThrow](
+    f: EngineState[F] => Seq[Event[F]]
+  ): EngineHandle[F, Unit] =
+    Handle.fromEvents(f)
+
+  inline def fromEvents[F[_]: MonadThrow](es: Event[F]*): EngineHandle[F, Unit] =
+    Handle.fromEvents(es*)
 
   inline def fromSingleEventF[F[_]: MonadCancelThrow](f: F[Event[F]]): EngineHandle[F, Unit] =
     Handle.fromSingleEventF(f)
@@ -120,10 +129,13 @@ object EngineHandle {
   ): EngineHandle[F, Unit] =
     modifyState_(EngineState.sequenceStateAt(obsId).replace(s))
 
-  // For debugging
   def debug[F[_]: MonadCancelThrow: Logger](msg: String): EngineHandle[F, Unit] =
     liftF(Logger[F].debug(msg))
 
+  def logError[F[_]: MonadCancelThrow: Logger](e: Throwable)(msg: String): EngineHandle[F, Unit] =
+    liftF(Logger[F].error(e)(msg))
+
+  // For debugging
   def printSequenceState[F[_]: MonadCancelThrow: Logger](
     obsId: Observation.Id
   ): EngineHandle[F, Unit] =


### PR DESCRIPTION
If there's an error when updating the sequence, the sequence will fail and stop. But it can be restarted again. Upon restarting, the first thing observe will do is attempt to reload again.