### PR TITLE
Remove unused workflow from observation detail query

### DIFF
--- a/modules/server_new/src/clue/scala/observe/common/ObsQueriesGQL.scala
+++ b/modules/server_new/src/clue/scala/observe/common/ObsQueriesGQL.scala
@@ -25,9 +25,6 @@ object ObsQueriesGQL:
         observation(observationId: $$obsId) {
           id
           title
-          workflow {
-            state
-          }
           program {
             id
             name

--- a/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
@@ -30,7 +30,6 @@ import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.StepEstimate
 import lucuma.core.model.sequence.gmos.DynamicConfig
 import lucuma.core.model.sequence.gmos.StaticConfig
-import lucuma.core.util.CalculationState
 import lucuma.refined.*
 import observe.common.ObsQueriesGQL.ObsQuery.Data.Observation as ODBObservation
 import observe.common.ObsQueriesGQL.ObsQuery.Data.Observation.Execution
@@ -431,7 +430,6 @@ class ObserveEngineSuite extends TestCommon {
       ODBObservation(
         id = seqObsId1,
         title = "Test Observation".refined,
-        ODBObservation.Workflow(CalculationState.Ready).some,
         ODBObservation.Program(
           Program.Id(PosLong.unsafeFrom(123)),
           None,
@@ -698,7 +696,6 @@ class ObserveEngineSuite extends TestCommon {
       ODBObservation(
         id = seqObsId1,
         title = "Test Observation".refined,
-        ODBObservation.Workflow(CalculationState.Ready).some,
         ODBObservation.Program(
           Program.Id(PosLong.unsafeFrom(123)),
           None,

--- a/modules/server_new/src/test/scala/observe/server/TestCommon.scala
+++ b/modules/server_new/src/test/scala/observe/server/TestCommon.scala
@@ -53,7 +53,6 @@ import lucuma.core.model.sequence.gmos.GmosCcdMode
 import lucuma.core.model.sequence.gmos.GmosFpuMask
 import lucuma.core.model.sequence.gmos.GmosGratingConfig
 import lucuma.core.model.sequence.gmos.StaticConfig
-import lucuma.core.util.CalculationState
 import lucuma.core.util.TimeSpan
 import lucuma.refined.*
 import observe.common.ObsQueriesGQL.ObsQuery.Data.Observation as ODBObservation
@@ -314,7 +313,6 @@ object TestCommon {
     ODBObservation(
       id = id,
       title = "Test Observation".refined,
-      ODBObservation.Workflow(CalculationState.Ready).some,
       ODBObservation.Program(
         Program.Id(PosLong.unsafeFrom(123)),
         None,
@@ -456,7 +454,6 @@ object TestCommon {
       ODBObservation(
         id = id,
         title = "Test Observation".refined,
-        ODBObservation.Workflow(CalculationState.Ready).some,
         ODBObservation.Program(
           Program.Id(PosLong.unsafeFrom(123)),
           None,

--- a/modules/server_new/src/test/scala/observe/server/engine/TestUtil.scala
+++ b/modules/server_new/src/test/scala/observe/server/engine/TestUtil.scala
@@ -8,7 +8,6 @@ import cats.syntax.option.*
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.SequenceType
 import lucuma.core.model.sequence.Atom
-import lucuma.core.util.CalculationState
 import observe.common.ObsQueriesGQL.ObsQuery.Data.Observation as OdbObservation
 import observe.model.Conditions
 import observe.model.Observation
@@ -32,7 +31,6 @@ object TestUtil {
             obsData = OdbObservation(
               id = obsId,
               title = NonEmptyString.unsafeFrom("Test Observation"),
-              workflow = OdbObservation.Workflow(CalculationState.Ready).some,
               program = null,           // Not used in tests
               targetEnvironment = null, // Not used in tests
               constraintSet = null,     // Not used in tests

--- a/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
+++ b/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
@@ -30,7 +30,6 @@ import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.TelescopeConfig as CoreTelescopeConfig
 import lucuma.core.model.sequence.gmos.DynamicConfig
 import lucuma.core.model.sequence.gmos.StaticConfig
-import lucuma.core.util.CalculationState
 import lucuma.refined.*
 import monocle.Focus
 import monocle.Lens
@@ -126,7 +125,6 @@ object TestOdbProxy {
                 .Observation(
                   oid,
                   title = "Test Observation".refined,
-                  ODBObservation.Workflow(CalculationState.Ready).some,
                   Data.Observation.Program(
                     Program.Id(PosLong.unsafeFrom(1)),
                     None,


### PR DESCRIPTION
Apparently it doesn't actually care about the workflow state when it is loading the observation details.