### PR TITLE
Workaround for max memory in heroku+docker woes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val build = taskKey[File]("Build module for deployment")
 name := "observe"
 
 ThisBuild / dockerExposedPorts ++= Seq(9090, 9091) // Must match deployed app.conf web-server.port
-ThisBuild / dockerBaseImage := "eclipse-temurin:17-jre"
+ThisBuild / dockerBaseImage := "eclipse-temurin:21-jre"
 
 // TODO REMOVE ONCE THIS WORKS AGAIN
 ThisBuild / tlCiScalafmtCheck := false
@@ -352,7 +352,6 @@ lazy val deployedAppSettings = Seq(
   // Launch options
   Universal / javaOptions ++= Seq(
     // -J params will be added as jvm parameters
-    "-J-XX:MaxRAMPercentage=80.0",
     // Support remote JMX access
     "-J-Dcom.sun.management.jmxremote",
     "-J-Dcom.sun.management.jmxremote.authenticate=false",
@@ -361,9 +360,6 @@ lazy val deployedAppSettings = Seq(
     // Ensure the locale is correctly set
     "-J-Duser.language=en",
     "-J-Duser.country=US",
-    // Support remote debugging
-    "-J-Xdebug",
-    "-J-Xnoagent",
     "-J-XX:+HeapDumpOnOutOfMemoryError",
     // Make sure the application exits on OOM
     "-J-XX:+ExitOnOutOfMemoryError",
@@ -406,5 +402,7 @@ lazy val deploy = project
     Docker / daemonUser    := "software",
     dockerBuildOptions ++= Seq("--platform", "linux/amd64"),
     dockerUpdateLatest     := true,
-    dockerUsername         := Some("noirlab")
+    dockerUsername         := Some("noirlab"),
+    // From https://www.scala-sbt.org/sbt-native-packager/archetypes/java_app/customize.html#bash-and-bat-script-extra-defines
+    bashScriptExtraDefines ++= IO.readLines(baseDirectory.value / "_init" / "set-memory.sh")
   )

--- a/deploy/_init/set-memory.sh
+++ b/deploy/_init/set-memory.sh
@@ -1,0 +1,52 @@
+# Only set heap if not already in JAVA_OPTS
+if [[ "${JAVA_OPTS:-}" =~ -Xmx ]] || [[ "${JAVA_OPTS:-}" =~ -Xms ]] || [[ "${JAVA_OPTS:-}" =~ MaxRAMPercentage ]]; then
+  echo "Custom heap settings detected in JAVA_OPTS, not overriding."
+else
+  DEFAULT_MB=512
+  MIN_HEAP_MB=256
+  DEFAULT_HEAP_PERCENT=80
+
+  # Allow override from environment variable
+  HEAP_PERCENT=${HEROKU_JAVA_HEAP_PERCENT:-$DEFAULT_HEAP_PERCENT}
+
+  # Detect cgroup version and read memory limit
+  USE_MAX_RAM_PERCENT=false
+
+  if [[ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]]; then
+    limit_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+    echo "Detected cgroup v1: memory limit ${limit_bytes} bytes"
+  elif [[ -f /sys/fs/cgroup/memory.max ]]; then
+    val=$(cat /sys/fs/cgroup/memory.max)
+    echo "Detected cgroup v2: memory limit ${val}"
+    if [[ "$val" == "max" ]]; then
+      USE_MAX_RAM_PERCENT=true
+    else
+      limit_bytes=$val
+    fi
+  else
+    limit_bytes=$((DEFAULT_MB * 1024 * 1024))
+    echo "Cgroup memory limit not detected, using default ${DEFAULT_MB} MB"
+  fi
+
+  if [ "$USE_MAX_RAM_PERCENT" = true ]; then
+    echo "Dyno memory detected: MAX"
+
+    echo "Using -XX:MaxRAMPercentage=${HEAP_PERCENT}.0 instead of Xmx/Xms"
+    addJava "-XX:MaxRAMPercentage=${HEAP_PERCENT}.0"
+  else
+    limit_mb=$((limit_bytes / 1024 / 1024))
+    
+    echo "Dyno memory detected: ${limit_mb} MB"
+    heap_mb=$((limit_mb * HEAP_PERCENT / 100))
+
+    # Enforce minimum cap
+    if (( heap_mb < MIN_HEAP_MB )); then
+      heap_mb=$MIN_HEAP_MB
+    fi
+
+    echo "Using -Xms${heap_mb}m -Xmx${heap_mb}m"
+
+    addJava "-Xms${heap_mb}m"
+    addJava "-Xmx${heap_mb}m"
+  fi
+fi


### PR DESCRIPTION
When deploying to Heroku via Docker, the max memory is reported wrong. It reports the max host memory instead of container's. Thus, using `-XX:MaxRAMPercentage` will allocate beyond the dyno limit and cause the app to crash if it attempts to go beyond such limit.

Although Java 10+ has provisions to detect when it's running in a container and read the available memory from something called `cgroup`, there are `v1` and `v2` versions of `cgroup`. In my local Docker, the container reports the memory as `v2` and the JVM picks it up correctly.

However, in Heroku, apparently due to an outdated Docker container, it's only reported as `v1`. Although the JVM should fall back to `v1` if `v2` is not found (https://bugs.openjdk.org/browse/JDK-8230305), this just isn't happening in Heroku.

I opened up a ticket with Heroku to inquire if there's a solution for this: https://help.heroku.com/sharing/f0782264-57d3-49e0-a381-0c3913376acd

Although the bad news is that the JVM can't set its heap max size automatically, the good news is that correct size is reported somewhere. Thus, I spun a script with the aid of ChatGPT to manually do the grunt work to configure the max heap size according the dyno's limits. This seems to work well.

Unless Heroku support provides a better way of doing this or someone comes up with a better idea, I suggest we use this method throughout.