### PR TITLE
derive Eq/Order instances

### DIFF
--- a/modules/model/shared/src/main/scala/observe/model/Conditions.scala
+++ b/modules/model/shared/src/main/scala/observe/model/Conditions.scala
@@ -4,7 +4,9 @@
 package observe.model
 
 import cats.Eq
+import cats.derived.*
 import cats.syntax.all.*
+import coulomb.integrations.cats.all.given
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.refined.*
@@ -22,7 +24,8 @@ case class Conditions(
   iq: Option[ImageQuality],
   sb: Option[SkyBackground],
   wv: Option[WaterVapor]
-) derives Encoder.AsObject,
+) derives Eq,
+      Encoder.AsObject,
       Decoder
 
 object Conditions:
@@ -68,6 +71,3 @@ object Conditions:
   val iq: Lens[Conditions, Option[ImageQuality]]    = Focus[Conditions](_.iq)
   val sb: Lens[Conditions, Option[SkyBackground]]   = Focus[Conditions](_.sb)
   val wv: Lens[Conditions, Option[WaterVapor]]      = Focus[Conditions](_.wv)
-
-  // TODO Replace when ImageQuality Eq is in place in core
-  given Eq[Conditions] = Eq.by(x => (x.ce, x.iq.map(_.value.value), x.sb, x.wv))

--- a/modules/server_new/src/main/scala/observe/server/ObserveEngineImpl.scala
+++ b/modules/server_new/src/main/scala/observe/server/ObserveEngineImpl.scala
@@ -6,13 +6,12 @@ package observe.server
 import cats.Applicative
 import cats.Endo
 import cats.Monoid
-import cats.Order
 import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.effect.Ref
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
-import eu.timepit.refined.cats.given
+import coulomb.integrations.cats.all.given
 import fs2.Stream
 import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.Instrument
@@ -26,6 +25,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.StepConfig as OcsStepConfig
+import lucuma.core.refined.given
 import monocle.Focus
 import monocle.Lens
 import monocle.Optional
@@ -139,9 +139,6 @@ private class ObserveEngineImpl[F[_]: Async: Logger](
     requested: CloudExtinction.Preset
   ): Boolean =
     actual.forall(_ <= requested.toCloudExtinction)
-
-  // TODO replace it when core gets updates
-  private given Order[ImageQuality] = Order.by(_.value.value)
 
   private def checkImageQuality(
     actual:    Option[ImageQuality],

--- a/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
+++ b/modules/server_new/src/test/scala/observe/server/ObserveEngineSuite.scala
@@ -9,7 +9,7 @@ import cats.effect.Async
 import cats.effect.IO
 import cats.effect.Ref
 import cats.syntax.all.*
-import eu.timepit.refined.cats.given
+import coulomb.integrations.cats.all.given
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.numeric.PosLong
 import eu.timepit.refined.types.string.NonEmptyString
@@ -30,6 +30,7 @@ import lucuma.core.model.sequence.StepEstimate
 import lucuma.core.model.sequence.gmos.DynamicConfig
 import lucuma.core.model.sequence.gmos.StaticConfig
 import lucuma.core.refined.auto.*
+import lucuma.core.refined.given
 import observe.common.ObsQueriesGQL.ObsQuery.Data.Observation as ODBObservation
 import observe.common.ObsQueriesGQL.ObsQuery.Data.Observation.Execution
 import observe.common.ObsQueriesGQL.ObsQuery.Data.Observation.TargetEnvironment
@@ -127,7 +128,7 @@ class ObserveEngineSuite extends TestCommon {
       oe <- observeEngine
       sf <- advanceN(oe, s0, oe.setImageQuality(iq, user, clientId), 2)
     } yield sf.flatMap(EngineState.conditions.andThen(Conditions.iq).get).exists { op =>
-      op == iq
+      op === iq
     }).assert
 
   }

--- a/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
@@ -3,10 +3,9 @@
 
 package observe.ui.components
 
-import cats.Eq
 import cats.syntax.all.*
+import coulomb.integrations.cats.all.given
 import crystal.react.*
-import eu.timepit.refined.cats.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.SkyBackground
@@ -15,6 +14,7 @@ import lucuma.core.model.CloudExtinction
 import lucuma.core.model.ImageQuality
 import lucuma.core.model.validation.ModelValidators
 import lucuma.core.optics.*
+import lucuma.core.refined.given
 import lucuma.core.syntax.validation.*
 import lucuma.core.validation.*
 import lucuma.react.common.*
@@ -44,8 +44,6 @@ object ConfigPanel
         configApi <- useContext(ConfigApi.ctx)
       yield
         import ctx.given
-        // TODO Remove me when in core
-        given Eq[ImageQuality] = Eq.by(_.value.value)
 
         val iq: View[Option[ImageQuality]] =
           props.conditions


### PR DESCRIPTION
Turns out you can derive the instances of ImageQuality
just need the right combination of imports
core mistake
```scala
import coulomb.integrations.cats.given
```
instead do:
```scala
import coulomb.integrations.cats.all.given
```