### PR TITLE
Add missing parameter in split query

### DIFF
--- a/modules/server_new/src/clue/scala/observe/common/ObsQueriesGQL.scala
+++ b/modules/server_new/src/clue/scala/observe/common/ObsQueriesGQL.scala
@@ -76,7 +76,7 @@ object ObsQueriesGQL:
           itc { ...itcFields }
         }
 
-        executionConfig(futureLimit: 100) {
+        executionConfig(observationId: $$obsId, futureLimit: 100) {
           instrument
           gmosNorth {
             static {


### PR DESCRIPTION
I had forgotten to replicate the `observationId` parameter when the query was split.