### PR TITLE
Dynamic progress bar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,6 @@ ThisBuild / scalacOptions ++= Seq(
   // ScalablyTyped macros introduce deprecated methods, this silences those warnings
   "-Wconf:msg=linkingInfo in package scala.scalajs.runtime is deprecated:s"
 )
-// ThisBuild / scalacOptions ++= Seq("-language:implicitConversions")
 ThisBuild / scalafixResolvers += coursierapi.MavenRepository.of(
   "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,12 @@ Global / onChangedBuildSource                   := ReloadOnSourceChanges
 ThisBuild / scalafixDependencies += "edu.gemini" % "lucuma-schemas_3" % LibraryVersions.lucumaUISchemas
 ThisBuild / scalaVersion                        := "3.7.3"
 ThisBuild / crossScalaVersions                  := Seq("3.7.3")
-ThisBuild / scalacOptions ++= Seq("-language:implicitConversions")
+ThisBuild / scalacOptions ++= Seq(
+  "-language:implicitConversions",
+  // ScalablyTyped macros introduce deprecated methods, this silences those warnings
+  "-Wconf:msg=linkingInfo in package scala.scalajs.runtime is deprecated:s"
+)
+// ThisBuild / scalacOptions ++= Seq("-language:implicitConversions")
 ThisBuild / scalafixResolvers += coursierapi.MavenRepository.of(
   "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 )


### PR DESCRIPTION
The progress bar maximum now adjusts if the remaining time is more than the exposure time. This happens in Flamingos2 at least, where the instrument does not distinguish between stages and reports a remaining time that includes the readout and thus exceeds the exposure time.