### PR TITLE
Fix DHS simulator date

### DIFF
--- a/modules/server_new/src/main/scala/observe/server/keywords/DhsClientDisabled.scala
+++ b/modules/server_new/src/main/scala/observe/server/keywords/DhsClientDisabled.scala
@@ -21,7 +21,7 @@ class DhsClientDisabled[F[_]: FlatMap: Clock: Logger] extends DhsClient[F] {
   override def createImage(p: DhsClient.ImageParameters): F[ImageFileId] =
     for {
       _    <- overrideLogMessage[F]("DHS", "setKeywords")
-      date <- Clock[F].monotonic
+      date <- Clock[F].realTime
                 .map(d => Instant.EPOCH.plusSeconds(d.toSeconds))
                 .map(LocalDateTime.ofInstant(_, java.time.ZoneOffset.UTC))
     } yield ImageFileId(

--- a/modules/server_new/src/main/scala/observe/server/keywords/DhsClientHttp.scala
+++ b/modules/server_new/src/main/scala/observe/server/keywords/DhsClientHttp.scala
@@ -248,7 +248,7 @@ private class DhsClientSim[F[_]: FlatMap: Logger](site: Site, date: LocalDate, c
 
 object DhsClientSim {
   def apply[F[_]: Sync: Logger](site: Site): F[DhsClient[F]] =
-    Clock[F].monotonic
+    Clock[F].realTime
       .map(d => Instant.EPOCH.plusSeconds(d.toSeconds))
       .map(LocalDateTime.ofInstant(_, ZoneId.systemDefault))
       .flatMap(apply(site, _))


### PR DESCRIPTION
Turns out `monotonic` is not epoch-based, it should only be used for precise measurement of elapsed time.