### PR TITLE
Just-in-time atom recording

### DIFF
--- a/modules/model/shared/src/main/scala/observe/model/arb/ArbObsRecordedIds.scala
+++ b/modules/model/shared/src/main/scala/observe/model/arb/ArbObsRecordedIds.scala
@@ -4,6 +4,7 @@
 package observe.model.arb
 
 import lucuma.core.model.Visit
+import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Step
 import lucuma.core.util.arb.ArbGid.given
 import lucuma.core.util.arb.ArbNewType.given
@@ -31,9 +32,10 @@ trait ArbObsRecordedIds:
 
   given Arbitrary[RecordedAtom] = Arbitrary:
     for
-      atomId <- arbitrary[RecordedAtomId]
-      step   <- arbitrary[Option[RecordedStep]]
-    yield RecordedAtom(atomId, step)
+      generatedId <- arbitrary[Atom.Id]
+      atomId      <- arbitrary[RecordedAtomId]
+      step        <- arbitrary[Option[RecordedStep]]
+    yield RecordedAtom(generatedId, atomId, step)
 
   given Arbitrary[RecordedVisit] = Arbitrary:
     for
@@ -45,7 +47,9 @@ trait ArbObsRecordedIds:
     Cogen[(RecordedStepId, DatasetIdMap)].contramap(x => (x.stepId, x.datasetIds))
 
   given Cogen[RecordedAtom] =
-    Cogen[(RecordedAtomId, Option[RecordedStep])].contramap(x => (x.atomId, x.step))
+    Cogen[(Atom.Id, RecordedAtomId, Option[RecordedStep])].contramap(x =>
+      (x.generatedId, x.atomId, x.step)
+    )
 
   given Cogen[RecordedVisit] =
     Cogen[(Visit.Id, Option[RecordedAtom])].contramap(x => (x.visitId, x.atom))

--- a/modules/model/shared/src/main/scala/observe/model/odb/RecordedIds.scala
+++ b/modules/model/shared/src/main/scala/observe/model/odb/RecordedIds.scala
@@ -50,11 +50,15 @@ object RecordedStep:
   val stepId: Lens[RecordedStep, RecordedStepId]   = Focus[RecordedStep](_.stepId)
   val datasetIds: Lens[RecordedStep, DatasetIdMap] = Focus[RecordedStep](_.datasetIds)
 
-case class RecordedAtom(atomId: RecordedAtomId, step: Option[RecordedStep] = None)
-    derives Eq,
+case class RecordedAtom(
+  generatedId: Atom.Id,
+  atomId:      RecordedAtomId,
+  step:        Option[RecordedStep] = None
+) derives Eq,
       Encoder.AsObject,
       Decoder
 object RecordedAtom:
+  val generatedId: Lens[RecordedAtom, Atom.Id]       = Focus[RecordedAtom](_.generatedId)
   val atomId: Lens[RecordedAtom, RecordedAtomId]     = Focus[RecordedAtom](_.atomId)
   val step: Lens[RecordedAtom, Option[RecordedStep]] = Focus[RecordedAtom](_.step)
   val stepId: Optional[RecordedAtom, RecordedStepId] =

--- a/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
+++ b/modules/server_new/src/main/scala/observe/server/SeqTranslate.scala
@@ -119,7 +119,9 @@ object SeqTranslate {
       stepType:      StepType,
       insSpec:       InstrumentSpecifics[S, D],
       instf:         SystemOverrides => InstrumentSystem[F],
-      instHeader:    KeywordsClient[F] => Header[F]
+      instHeader:    KeywordsClient[F] => Header[F],
+      atomId:        Atom.Id,
+      sequenceType:  SequenceType
     ): StepGen[F, D] = {
 
       def buildStep(
@@ -171,7 +173,10 @@ object SeqTranslate {
                 step.stepConfig,
                 step.telescopeConfig,
                 step.observeClass,
-                step.id.some
+                step.id.some,
+                atomId,
+                insSpec.instrument,
+                sequenceType
               )
               .as(Response.Ignored)
               .toAction(ActionType.OdbEvent),
@@ -277,7 +282,9 @@ object SeqTranslate {
                       insSpec,
                       (ov: SystemOverrides) =>
                         instf(ov, step.stepConfig.stepType, stepType, step.instrumentConfig),
-                      instHeader(step.instrumentConfig)
+                      instHeader(step.instrumentConfig),
+                      atom.id,
+                      sequenceType
                     )
               .separate
 

--- a/modules/server_new/src/main/scala/observe/server/SequenceData.scala
+++ b/modules/server_new/src/main/scala/observe/server/SequenceData.scala
@@ -17,11 +17,9 @@ case class SequenceData[F[_]](
   seq:            Sequence.State[F],
   pendingObsCmd:  Option[PendingObserveCmd],
   visitStartDone: Boolean,
-  atomStartDone:  Boolean,
   cleanup:        F[Unit]
 ) {
   def withCompleteVisitStart: SequenceData[F] = this.copy(visitStartDone = true)
-  def withCompleteAtomStart: SequenceData[F]  = this.copy(atomStartDone = true)
 }
 
 object SequenceData {
@@ -39,7 +37,6 @@ object SequenceData {
     seqGen,
     seq,
     pendingObsCmd,
-    false,
     false,
     cleanup
   )

--- a/modules/server_new/src/main/scala/observe/server/odb/DummyOdbCommands.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/DummyOdbCommands.scala
@@ -32,7 +32,10 @@ class DummyOdbCommands[F[_]: Sync] extends OdbCommands[F] {
     stepConfig:      StepConfig,
     telescopeConfig: CoreTelescopeConfig,
     observeClass:    ObserveClass,
-    generatedId:     Option[Step.Id]
+    generatedId:     Option[Step.Id],
+    generatedAtomId: Atom.Id,
+    instrument:      Instrument,
+    sequenceType:    SequenceType
   ): F[Unit] = ().pure[F]
 
   override def stepStartConfigure(obsId: Observation.Id): F[Unit] = Applicative[F].unit
@@ -88,13 +91,6 @@ class DummyOdbCommands[F[_]: Sync] extends OdbCommands[F] {
 
   override def visitStart[S](obsId: Observation.Id, staticCfg: S): F[Unit] =
     Applicative[F].unit
-
-  override def atomStart(
-    obsId:        Observation.Id,
-    instrument:   Instrument,
-    sequenceType: SequenceType,
-    generatedId:  Option[Atom.Id]
-  ): F[Unit] = Applicative[F].unit
 
   override def getCurrentRecordedIds: F[ObsRecordedIds] = ObsRecordedIds.Empty.pure[F]
 }

--- a/modules/server_new/src/main/scala/observe/server/odb/DummyOdbProxy.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/DummyOdbProxy.scala
@@ -58,7 +58,10 @@ class DummyOdbProxy[F[_]: Sync] extends OdbProxy[F] {
     stepConfig:      StepConfig,
     telescopeConfig: CoreTelescopeConfig,
     observeClass:    ObserveClass,
-    generatedId:     Option[Step.Id]
+    generatedId:     Option[Step.Id],
+    generatedAtomId: Atom.Id,
+    instrument:      Instrument,
+    sequenceType:    SequenceType
   ): F[Unit] = Applicative[F].unit
 
   override def stepStartConfigure(obsId: Observation.Id): F[Unit] = Applicative[F].unit
@@ -75,13 +78,6 @@ class DummyOdbProxy[F[_]: Sync] extends OdbProxy[F] {
 
   override def visitStart[S](obsId: Observation.Id, staticCfg: S): F[Unit] =
     Applicative[F].unit
-
-  override def atomStart(
-    obsId:        Observation.Id,
-    instrument:   Instrument,
-    sequenceType: SequenceType,
-    generatedId:  Option[Atom.Id]
-  ): F[Unit] = Applicative[F].unit
 
   override def getCurrentRecordedIds: F[ObsRecordedIds] = ObsRecordedIds.Empty.pure[F]
 }

--- a/modules/server_new/src/main/scala/observe/server/odb/OdbCommands.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/OdbCommands.scala
@@ -23,19 +23,16 @@ trait OdbCommands[F[_]] private[odb] () {
   def sequenceStart(
     obsId: Observation.Id
   ): F[Unit]
-  def atomStart(
-    obsId:        Observation.Id,
-    instrument:   Instrument,
-    sequenceType: SequenceType,
-    generatedId:  Option[Atom.Id]
-  ): F[Unit]
   def stepStartStep[D](
     obsId:           Observation.Id,
     dynamicConfig:   D,
     stepConfig:      StepConfig,
     telescopeConfig: CoreTelescopeConfig,
     observeClass:    ObserveClass,
-    generatedId:     Option[Step.Id]
+    generatedId:     Option[Step.Id],
+    generatedAtomId: Atom.Id,
+    instrument:      Instrument,
+    sequenceType:    SequenceType
   ): F[Unit]
   def stepStartConfigure(obsId:  Observation.Id): F[Unit]
   def stepEndConfigure(obsId:    Observation.Id): F[Boolean]

--- a/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
+++ b/modules/server_new/src/main/scala/observe/server/odb/OdbProxy.scala
@@ -8,9 +8,7 @@ import cats.effect.Sync
 import cats.syntax.all.*
 import clue.FetchClient
 import clue.syntax.*
-import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObserveClass
-import lucuma.core.enums.SequenceType
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.TelescopeConfig

--- a/modules/server_new/src/test/scala/observe/server/engine/TestUtil.scala
+++ b/modules/server_new/src/test/scala/observe/server/engine/TestUtil.scala
@@ -47,7 +47,6 @@ object TestUtil {
           seq = seq,
           pendingObsCmd = none,
           visitStartDone = false,
-          atomStartDone = false,
           cleanup = IO.unit
         ).some,
         gmosSouth = none,

--- a/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
+++ b/modules/server_new/src/test/scala/observe/server/odb/TestOdbProxy.scala
@@ -169,27 +169,19 @@ object TestOdbProxy {
 
         override def sequenceStart(obsId: Observation.Id): F[Unit] = addEvent(SequenceStart(obsId))
 
-        override def atomStart(
-          obsId:        Observation.Id,
-          instrument:   Instrument,
-          sequenceType: SequenceType,
-          generatedId:  Option[Atom.Id]
-        ): F[Unit] = sequenceType match {
-          case SequenceType.Acquisition =>
-            rf.update(State.currentAtom.replace(generatedId))
-          case SequenceType.Science     =>
-            rf.update(State.currentAtom.replace(generatedId))
-        }
-
         override def stepStartStep[D](
           obsId:           Observation.Id,
           dynamicConfig:   D,
           stepConfig:      StepConfig,
           telescopeConfig: CoreTelescopeConfig,
           observeClass:    ObserveClass,
-          generatedId:     Option[Step.Id]
+          generatedId:     Option[Step.Id],
+          generatedAtomId: Atom.Id,
+          instrument:      Instrument,
+          sequenceType:    SequenceType
         ): F[Unit] =
-          rf.update(_.startStep(generatedId)) *>
+          rf.update(State.currentAtom.replace(generatedAtomId.some)) >>
+            rf.update(_.startStep(generatedId)) >>
             addEvent(StepStartStep(obsId, dynamicConfig, stepConfig, telescopeConfig, observeClass))
 
         override def stepStartConfigure(obsId: Observation.Id): F[Unit] = addEvent(


### PR DESCRIPTION
This PR is the observe companion the the ODB changes needed to fix the [cornucopia](https://app.shortcut.com/lucuma/story/6589/a-cornucopia-of-cloned-steps) issue.

It removes the recording of a new atom from the observe engine flow (which is a good thing, as it reduces a bit its complexity), and moves it to the ODB communication layer: if a new step is executed with a different atom id than the last one (or there was no last one), then recordAtom is invoked then, and only then.

This has the effect of keeping the same recorded atom id if steps from the last atom are regenerated due to QA during a breakpoint between atoms.