### PR TITLE
Don't disable inputs while API call active

### DIFF
--- a/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/ConfigPanel.scala
@@ -79,7 +79,6 @@ object ConfigPanel
                 validFormat = ModelValidators.ImageQualityValidWedge.optional
                   .nonEmpty("Must not be empty".toEitherErrorsUnsafe),
                 changeAuditor = ChangeAuditor.accept.decimal(2.refined).denyNeg,
-                disabled = configApi.isBlocked,
                 tooltipOptions = TooltipOptions.Top,
                 units = "arcsec"
               )
@@ -92,7 +91,6 @@ object ConfigPanel
                 validFormat = ModelValidators.CloudExtinctionValidWedge.optional
                   .nonEmpty("Must not be empty".toEitherErrorsUnsafe),
                 changeAuditor = ChangeAuditor.accept.decimal(2.refined).denyNeg,
-                disabled = configApi.isBlocked,
                 tooltipOptions = TooltipOptions.Top,
                 units = "mags"
               )
@@ -102,8 +100,7 @@ object ConfigPanel
                 id = "waterVapor".refined,
                 label = "WV",
                 value = wv,
-                showClear = false,
-                disabled = configApi.isBlocked
+                showClear = false
               )
             ),
             <.div(ObserveStyles.SkyBackgroundArea)(
@@ -111,8 +108,7 @@ object ConfigPanel
                 id = "skyBackground".refined,
                 label = "BG",
                 value = sb,
-                showClear = false,
-                disabled = configApi.isBlocked
+                showClear = false
               )
             )
           ),
@@ -127,8 +123,7 @@ object ConfigPanel
                 value = op,
                 validFormat = InputValidSplitEpi
                   .fromIso(OptionNonEmptyStringIso.reverse)
-                  .andThen(Operator.Value.reverse.option),
-                disabled = configApi.isBlocked
+                  .andThen(Operator.Value.reverse.option)
               )
             ),
             <.div(ObserveStyles.ObserverArea)(
@@ -145,8 +140,7 @@ object ConfigPanel
                   value = obs,
                   validFormat = InputValidSplitEpi
                     .fromIso(OptionNonEmptyStringIso.reverse)
-                    .andThen(Observer.Value.reverse.option),
-                  disabled = configApi.isBlocked
+                    .andThen(Observer.Value.reverse.option)
                 )
             )
           )

--- a/modules/web/client/src/main/scala/observe/ui/components/sequence/SubsystemOverrides.scala
+++ b/modules/web/client/src/main/scala/observe/ui/components/sequence/SubsystemOverrides.scala
@@ -40,8 +40,7 @@ object SubsystemOverrides
           CheckboxView(
             id = label,
             value = enabled.as(SubsystemEnabled.Value),
-            label = label.value,
-            disabled = configApi.isBlocked
+            label = label.value
           )
 
         <.span(ObserveStyles.ObsSummarySubsystems)(

--- a/modules/web/client/src/main/scala/observe/ui/services/ConfigApi.scala
+++ b/modules/web/client/src/main/scala/observe/ui/services/ConfigApi.scala
@@ -40,7 +40,7 @@ trait ConfigApi[F[_]: MonadThrow]:
   def setDhsEnabled(@unused obsId: Observation.Id, @unused enabled: SubsystemEnabled): F[Unit]  =
     NotAuthorized
 
-  def isBlocked: Boolean = false
+  def isBusy: Boolean = false
 
 object ConfigApi:
   // Default value is NotAuthorized implementations

--- a/modules/web/client/src/main/scala/observe/ui/services/ConfigApiImpl.scala
+++ b/modules/web/client/src/main/scala/observe/ui/services/ConfigApiImpl.scala
@@ -82,4 +82,4 @@ case class ConfigApiImpl(
       ""
     )
 
-  override def isBlocked: Boolean = apiStatus.get == ApiStatus.Busy
+  override def isBusy: Boolean = apiStatus.get == ApiStatus.Busy


### PR DESCRIPTION
This was causing issues with the focus and it's not really necessary. The latch ensures that calls are serialized, and we can introduce some other visual cue that an API call is in progress in the future.